### PR TITLE
fix: category group edit

### DIFF
--- a/backend/app/services/category_group_service.py
+++ b/backend/app/services/category_group_service.py
@@ -77,7 +77,9 @@ async def get_groups(session: AsyncSession, user_id: uuid.UUID) -> list[Category
 
 async def get_group(session: AsyncSession, group_id: uuid.UUID, user_id: uuid.UUID) -> Optional[CategoryGroup]:
     result = await session.execute(
-        select(CategoryGroup).where(CategoryGroup.id == group_id, CategoryGroup.user_id == user_id)
+        select(CategoryGroup)
+        .where(CategoryGroup.id == group_id, CategoryGroup.user_id == user_id)
+        .options(selectinload(CategoryGroup.categories))
     )
     return result.scalar_one_or_none()
 
@@ -86,8 +88,7 @@ async def create_group(session: AsyncSession, user_id: uuid.UUID, data: Category
     group = CategoryGroup(user_id=user_id, **data.model_dump())
     session.add(group)
     await session.commit()
-    await session.refresh(group)
-    return group
+    return await get_group(session, group.id, user_id)
 
 
 async def update_group(
@@ -101,8 +102,7 @@ async def update_group(
         setattr(group, key, value)
 
     await session.commit()
-    await session.refresh(group)
-    return group
+    return await get_group(session, group_id, user_id)
 
 
 async def delete_group(session: AsyncSession, group_id: uuid.UUID, user_id: uuid.UUID) -> bool:

--- a/frontend/src/pages/categories.tsx
+++ b/frontend/src/pages/categories.tsx
@@ -86,6 +86,7 @@ export default function CategoriesPage() {
   const updateGroupMutation = useMutation({
     mutationFn: ({ id, ...data }: Partial<CategoryGroup> & { id: string }) => groupsApi.update(id, data),
     onSuccess: () => { invalidateAll(); setGroupDialogOpen(false); setEditingGroup(null); toast.success(t('groups.updated')) },
+    onError: () => { toast.error(t('common.error')) },
   })
   const deleteGroupMutation = useMutation({
     mutationFn: (id: string) => groupsApi.delete(id),


### PR DESCRIPTION
## What
Fixed the "Edit Category Group" flow 

## Why
The backend was failing with a 500 Internal Server Error during response serialization. This happened because SQLAlchemy attempted to lazy-load the categories relationship in an asynchronous context, which is not supported.

On the frontend, the error was being swallowed (silent failure), leaving the modal open and providing no feedback to the user, even though the database changes had already been committed.

## How to Test
Steps to verify the changes work:

1. Navigate to the Category Groups section.
2. Select an existing group and click the Edit button.
3. Modify any field and click Save.
4. Verify that the modal closes automatically and the changes are reflected in the list.
5. Check the browser's Network tab to ensure the PUT/POST request returns a 200 OK with the full categories array in the response body.


## Checklist
[x] Backend: selectinload added to get_group.
[x] Backend: Create/Update methods return fully loaded objects.
[x] Frontend: Error handling (toast) added to the mutation.
[x] Verified that async lazy loading errors are resolved.
