### PR TITLE
feat: enhance string matching by normalizing text to handle diacritics

### DIFF
--- a/backend/app/services/rule_engine.py
+++ b/backend/app/services/rule_engine.py
@@ -1,11 +1,19 @@
 """Pure rule evaluation engine — no DB access."""
 import re
+import unicodedata
 import uuid
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from app.models.transaction import Transaction
+
+
+def _normalize(text: str) -> str:
+    """Normalize text: uppercase and remove diacritics (accents)."""
+    upper = text.upper()
+    nfkd = unicodedata.normalize("NFKD", upper)
+    return "".join(c for c in nfkd if not unicodedata.combining(c))
 
 
 def _to_decimal(val) -> Decimal:
@@ -24,8 +32,8 @@ def _match_condition(condition: dict, tx: "Transaction") -> bool:
 
     # String operators
     if op in ("contains", "not_contains", "starts_with", "ends_with", "equals", "not_equals", "regex"):
-        tx_str = str(tx_val or "").upper()
-        val_str = str(value or "").upper()
+        tx_str = _normalize(str(tx_val or ""))
+        val_str = _normalize(str(value or ""))
 
         if op == "contains":
             return val_str in tx_str
@@ -41,7 +49,9 @@ def _match_condition(condition: dict, tx: "Transaction") -> bool:
             return tx_str != val_str
         if op == "regex":
             try:
-                return bool(re.search(str(value), str(tx_val or ""), re.IGNORECASE))
+                # Normalize both sides so accents don't break matches
+                pattern = _normalize(str(value or ""))
+                return bool(re.search(pattern, tx_str, re.IGNORECASE))
             except re.error:
                 return False
 


### PR DESCRIPTION
## What
Normalize text before string matching in the rule engine: uppercase + remove diacritics (NFKD). All string operators benefit (contains, starts_with, ends_with, equals, not_equals, not_contains, regex).

## Why
Rules were case-sensitive to accents. A rule with "pao de acucar" would not match "Pão de Açúcar". Now "café", "CAFE", "Café" all match the same way.

## How to Test
Create a categorization rule with contains → "pao de acucar"
Import or create a transaction with description "Pão de Açúcar"
Run rules — transaction should be categorized correctly
Repeat with a regex pattern like "cafe|padaria" against "Café Central"
Checklist
 Backend tests pass (pytest) — 37/37