### PR TITLE
Feat/sidebar nav ux

### DIFF
--- a/frontend/src/components/app-layout.tsx
+++ b/frontend/src/components/app-layout.tsx
@@ -50,7 +50,9 @@ type NavItem =
 const navItems: NavItem[] = [
   { type: 'link', key: 'dashboard',    path: '/',             icon: LayoutDashboard },
   { type: 'link', key: 'transactions', path: '/transactions', icon: ArrowLeftRight },
+  { type: 'separator', labelKey: 'nav.groupAccounts' },
   { type: 'link', key: 'accounts',     path: '/accounts',     icon: Building2 },
+  { type: 'link', key: 'import',       path: '/import',       icon: Upload },
   { type: 'separator', labelKey: 'nav.groupAnalysis' },
   { type: 'link', key: 'reports',      path: '/reports',      icon: BarChart3 },
   { type: 'link', key: 'assets',       path: '/assets',       icon: Landmark },
@@ -59,7 +61,6 @@ const navItems: NavItem[] = [
   { type: 'link', key: 'recurring',    path: '/recurring',    icon: Repeat },
   { type: 'link', key: 'categories',   path: '/categories',   icon: Tag },
   { type: 'link', key: 'rules',        path: '/rules',        icon: SlidersHorizontal },
-  { type: 'link', key: 'import',       path: '/import',       icon: Upload },
 ]
 
 function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -15,7 +15,8 @@
     "assets": "Assets",
     "reports": "Reports",
     "groupAnalysis": "Analysis",
-    "groupSetup": "Setup"
+    "groupSetup": "Setup",
+    "groupAccounts": "Accounts"
   },
   "auth": {
     "login": "Login",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -15,7 +15,8 @@
     "assets": "Patrimônio",
     "reports": "Relatórios",
     "groupAnalysis": "Análise",
-    "groupSetup": "Configuração"
+    "groupSetup": "Configuração",
+    "groupAccounts": "Contas"
   },
   "auth": {
     "login": "Entrar",


### PR DESCRIPTION
## What
Reorganize the sidebar navigation with labeled group separators for better information hierarchy.

### New structure:

Painel
Transações
── CONTAS ──
Contas
Importar
── ANÁLISE ──
Relatórios
Patrimônio
── CONFIGURAÇÃO ──
Orçamentos
Recorrentes
Categorias
Regras

## Why
The flat list mixed daily-use items (Painel, Transações) with configuration screens (Categorias, Regras) and analysis tools (Relatórios, Patrimônio) at the same visual level. Users had to scan the entire list to find what they needed. The new grouping matches the natural mental model: I check my overview first, then manage accounts, then analyze, then configure.

Moving Importar next to Contas makes sense — importing is an account-level action. Moving Orçamentos to Configuração reflects that it's a setup/planning tool, not a daily dashboard item.

## How to Test
Open the app — sidebar should show 3 labeled group separators
Verify all links still navigate correctly
Check mobile — overlay sidebar should reflect same order
Switch language PT ↔ EN — group labels should translate

## Checklist
 Backend tests pass (pytest)
 Frontend lints clean
 Frontend builds
 Translations updated — pt-BR and en



<img width="237" height="572" alt="image" src="https://github.com/user-attachments/assets/902ccef9-b5a7-4eab-8210-468ce322c86d" />