### PR TITLE
fix: correct translations in accounts list

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -733,7 +733,9 @@
     "success": "Success",
     "searchIcon": "Search icon...",
     "noIconsFound": "No icons found",
-    "primaryCurrency": "Primary Currency"
+    "primaryCurrency": "Primary Currency",
+    "showLess":"Show less",
+    "showMore": "+{{count}} more"
   },
   "privacy": {
     "hide": "Hide values",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -735,7 +735,7 @@
     "noIconsFound": "Nenhum ícone encontrado",
     "primaryCurrency": "Moeda Principal",
     "showLess":"Mostrar menos",
-    "showMore": "+{{count}} item"
+    "showMore": "Mostrar +{{count}}"
   },
   "privacy": {
     "hide": "Ocultar valores",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -733,7 +733,9 @@
     "success": "Sucesso",
     "searchIcon": "Buscar ícone...",
     "noIconsFound": "Nenhum ícone encontrado",
-    "primaryCurrency": "Moeda Principal"
+    "primaryCurrency": "Moeda Principal",
+    "showLess":"Mostrar menos",
+    "showMore": "+{{count}} item"
   },
   "privacy": {
     "hide": "Ocultar valores",


### PR DESCRIPTION
## What

Fix #76 to show the "Show more" and "Show less" correctly translated when using Securo in Portuguese.

## Why

Change is needed to keep the interface consistent with the chosen language.

## How to Test

Steps to verify the changes work:

1. Run securo: docker compose up --build
2. Open http://localhost:3000/ and login
3. Change language to Portuguese
4. Add at least 4 accounts to see the message "Mostrar +X"
5. Click on the message to show "Mostrar menos"

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
