### PR TITLE
fix: translate payee type labels in Setup > Payees

### DIFF
--- a/frontend/src/pages/payees.tsx
+++ b/frontend/src/pages/payees.tsx
@@ -41,6 +41,11 @@ export default function PayeesPage() {
   const { mask } = usePrivacyMode()
   const { user } = useAuth()
   const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const typeLabels: Record<string, string> = {
+    merchant: t('payees.typeMerchant'),
+    person: t('payees.typePerson'),
+    company: t('payees.typeCompany'),
+  }
   const queryClient = useQueryClient()
   const [search, setSearch] = useState('')
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -257,7 +262,7 @@ export default function PayeesPage() {
                     )}
                   </TableCell>
                   <TableCell className="hidden md:table-cell py-2.5">
-                    <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full capitalize">{payee.type}</span>
+                    <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full capitalize">{typeLabels[payee.type] ?? payee.type}</span>
                   </TableCell>
                   <TableCell className="py-2.5 text-right">
                     <span className="text-sm tabular-nums text-muted-foreground">{payee.transaction_count}</span>


### PR DESCRIPTION
Closes #82

## What

Fixes the `Type` column in `Setup > Payees` to display translated labels instead of literal internal values such as `Merchant`, `Person` and `Company`.

## Why

The payee type was being shown as raw values in the UI, which breaks localization and creates an inconsistent experience for users in other languages.

## How to Test

1. Open `Setup > Payees`
2. Check the `Type` column in the payees list
3. Verify the displayed values use the translated labels for the current language instead of raw values like `Merchant`, `Person`, or `Company`

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)