### PR TITLE
sync Pluggy transactions by createdAt instead of date (#72, #80)

### DIFF
--- a/backend/app/providers/pluggy.py
+++ b/backend/app/providers/pluggy.py
@@ -210,7 +210,14 @@ class PluggyProvider(BankProvider):
                     "page": page,
                 }
                 if since:
-                    params["from"] = since.isoformat()
+                    # Filter by Pluggy ingestion time, NOT transaction date.
+                    # `from`/`to` filter on `date` (when the txn happened),
+                    # which silently drops transactions Pluggy ingests later
+                    # but backdates — e.g. credit card bill payments dated
+                    # to the bill close, or merchants that settle weeks late.
+                    # `createdAtFrom` filters on Pluggy's row creation time,
+                    # so any newly-ingested row is fetched regardless of date.
+                    params["createdAtFrom"] = since.isoformat()
 
                 resp = await client.get(
                     f"{PLUGGY_API_BASE}/transactions",

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -417,12 +417,11 @@ async def sync_connection(
             if account and account.is_closed:
                 continue
 
-            # Fetch and sync transactions.
-            # Rewind the window by 14 days on incremental syncs so we catch
-            # late-arriving transactions: bank authorizations that post a few
-            # days after the purchase date, or direct debits that Pluggy only
-            # exposes once they've been processed by the issuer. Dedup on
-            # external_id below handles any overlap cheaply.
+            # Fetch and sync transactions. The 14-day rewind is on Pluggy's
+            # `createdAt` (when their row was inserted), so it covers two
+            # cases: (1) PENDING transactions that POSTED since last sync,
+            # (2) any rows Pluggy ingested late but backdated. Dedup on
+            # external_id below handles overlap cheaply.
             since = (
                 connection.last_sync_at.date() - timedelta(days=14)
                 if connection.last_sync_at


### PR DESCRIPTION
## What

Switch Pluggy `/transactions` filter from `from` (txn date) to `createdAtFrom` (Pluggy ingestion time).

## Why

Closes #72 and #80. Pluggy backdates late-ingested rows (e.g. credit card bill payments dated to the bill close). The old `from` filter excluded them and the 14-day rewind never reached far enough, so they were silently dropped forever.

## How to Test

1. Sync a Pluggy credit card connection.
2. Compare DB transactions against Pluggy's `/transactions` API for that account.
3. No rows missing.

## Checklist

- [x] Backend tests pass (`pytest`) — 1004 passed, 6 skipped
- [ ] Frontend lints clean (`npm run lint`) — n/a, backend only
- [ ] Frontend builds (`npm run build`) — n/a, backend only
- [ ] Translations updated (if user-facing strings changed) — n/a
