### PR TITLE
feat: add display_name to accounts for custom nicknames

### DIFF
--- a/backend/alembic/versions/031_account_display_name.py
+++ b/backend/alembic/versions/031_account_display_name.py
@@ -1,0 +1,22 @@
+"""add display_name to accounts
+
+Revision ID: 031
+Revises: 030
+Create Date: 2026-04-18
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "031"
+down_revision = "030"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("accounts", sa.Column("display_name", sa.String(255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("accounts", "display_name")

--- a/backend/app/models/account.py
+++ b/backend/app/models/account.py
@@ -22,6 +22,7 @@ class Account(Base):
     connection_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("bank_connections.id"), nullable=True)
     external_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     name: Mapped[str] = mapped_column(String(255))
+    display_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     type: Mapped[str] = mapped_column(String(50))  # checking, savings, credit_card
     balance: Mapped[Decimal] = mapped_column(Numeric(precision=15, scale=2), default=Decimal("0.00"))
     currency: Mapped[str] = mapped_column(String(3), default="USD")

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -29,6 +29,7 @@ class AccountCreate(BaseModel):
 
 class AccountUpdate(BaseModel):
     name: Optional[str] = None
+    display_name: Optional[str] = None
     type: Optional[str] = None
     balance: Optional[Decimal] = None
     balance_date: Optional[date] = None
@@ -45,6 +46,7 @@ class AccountRead(AccountBase):
     user_id: uuid.UUID
     connection_id: Optional[uuid.UUID] = None
     external_id: Optional[str] = None
+    display_name: Optional[str] = None
     current_balance: float = 0.0
     previous_balance: Optional[float] = None
     balance_primary: Optional[float] = None

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -98,6 +98,7 @@ def serialize_account(
         "connection_id": acc.connection_id,
         "external_id": acc.external_id,
         "name": acc.name,
+        "display_name": acc.display_name,
         "type": acc.type,
         "balance": acc.balance,
         "currency": acc.currency,
@@ -203,6 +204,7 @@ async def update_account(
     # expose those — users fill them in to unlock cycle-aware filtering.
     if account.connection_id is not None:
         editable_fields = {
+            "display_name",
             "credit_limit",
             "statement_close_day",
             "payment_due_day",
@@ -213,7 +215,9 @@ async def update_account(
         disallowed = set(update_data.keys()) - editable_fields
         if disallowed:
             raise ValueError("Cannot edit bank-connected accounts")
-        if account.type != "credit_card":
+        cc_fields = editable_fields - {"display_name"}
+        cc_update = {k: v for k, v in update_data.items() if k in cc_fields}
+        if cc_update and account.type != "credit_card":
             raise ValueError("Credit card fields can only be set on credit card accounts")
         for key, value in update_data.items():
             setattr(account, key, value)

--- a/backend/tests/test_accounts_api.py
+++ b/backend/tests/test_accounts_api.py
@@ -505,3 +505,83 @@ async def test_get_account_summary_with_dates(client: AsyncClient, auth_headers)
         headers=auth_headers,
     )
     assert resp.status_code == 200
+
+
+# --- display_name tests ---
+
+
+@pytest.mark.asyncio
+async def test_display_name_returned_in_list(client: AsyncClient, auth_headers):
+    """display_name field must be present in the accounts list response."""
+    create_resp = await client.post(
+        "/api/accounts",
+        headers=auth_headers,
+        json={"name": "Conta Teste", "type": "checking", "balance": "0"},
+    )
+    assert create_resp.status_code == 201
+    assert "display_name" in create_resp.json()
+
+
+@pytest.mark.asyncio
+async def test_set_display_name_on_manual_account(client: AsyncClient, auth_headers):
+    """Setting display_name on a manual account must be persisted and returned."""
+    create_resp = await client.post(
+        "/api/accounts",
+        headers=auth_headers,
+        json={"name": "Nubank", "type": "checking", "balance": "0"},
+    )
+    account_id = create_resp.json()["id"]
+
+    patch_resp = await client.patch(
+        f"/api/accounts/{account_id}",
+        headers=auth_headers,
+        json={"display_name": "Nu Pessoal"},
+    )
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["display_name"] == "Nu Pessoal"
+
+
+@pytest.mark.asyncio
+async def test_set_display_name_on_connected_account(
+    client: AsyncClient, auth_headers, test_account: Account
+):
+    """display_name must be editable on bank-connected accounts."""
+    response = await client.patch(
+        f"/api/accounts/{test_account.id}",
+        headers=auth_headers,
+        json={"display_name": "Minha Conta"},
+    )
+    assert response.status_code == 200
+    assert response.json()["display_name"] == "Minha Conta"
+
+
+@pytest.mark.asyncio
+async def test_clear_display_name(client: AsyncClient, auth_headers, test_account: Account):
+    """Setting display_name to null must clear it."""
+    await client.patch(
+        f"/api/accounts/{test_account.id}",
+        headers=auth_headers,
+        json={"display_name": "Apelido"},
+    )
+
+    clear_resp = await client.patch(
+        f"/api/accounts/{test_account.id}",
+        headers=auth_headers,
+        json={"display_name": None},
+    )
+    assert clear_resp.status_code == 200
+    assert clear_resp.json()["display_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_connected_account_name_still_rejected(
+    client: AsyncClient, auth_headers, test_account: Account
+):
+    """Editing 'name' on a bank-connected account must still be rejected even when display_name is allowed."""
+    response = await client.patch(
+        f"/api/accounts/{test_account.id}",
+        headers=auth_headers,
+        json={"name": "Nome Hackeado"},
+    )
+    assert response.status_code == 400
+    assert "bank-connected" in response.json()["detail"].lower()

--- a/backend/tests/test_connection_service.py
+++ b/backend/tests/test_connection_service.py
@@ -572,3 +572,51 @@ async def test_sync_connection_persists_installment_metadata(
     assert row.total_installments == 6
     assert row.installment_total_amount == Decimal("300.00")
     assert row.installment_purchase_date == date(2026, 3, 25)
+
+
+@pytest.mark.asyncio
+async def test_sync_connection_preserves_display_name(session: AsyncSession, test_user):
+    """Resyncing a connection must update the provider name but never overwrite display_name."""
+    from app.models.account import Account
+
+    conn = await _make_connection(session, test_user.id, "Preserve Bank")
+    mock_provider = AsyncMock()
+    mock_provider.refresh_credentials = AsyncMock(return_value={"token": "t"})
+    mock_provider.get_accounts = AsyncMock(return_value=[
+        AccountData(
+            external_id="preserve-acc-1", name="BANCO ORIGINAL",
+            type="checking", balance=Decimal("500"), currency="BRL",
+        ),
+    ])
+    mock_provider.get_transactions = AsyncMock(return_value=[])
+
+    with patch("app.services.connection_service.get_provider", return_value=mock_provider), \
+         patch("app.services.connection_service.detect_transfer_pairs", new_callable=AsyncMock), \
+         patch("app.services.connection_service.stamp_primary_amount", new_callable=AsyncMock), \
+         patch("app.services.connection_service.apply_rules_to_transaction", new_callable=AsyncMock):
+        await sync_connection(session, conn.id, test_user.id)
+
+    # Set a display_name after the first sync
+    account = (await session.execute(
+        select(Account).where(Account.connection_id == conn.id)
+    )).scalar_one()
+    account.display_name = "Meu Apelido"
+    await session.commit()
+
+    # Resync — provider now returns a different name
+    mock_provider.get_accounts = AsyncMock(return_value=[
+        AccountData(
+            external_id="preserve-acc-1", name="BANCO ATUALIZADO",
+            type="checking", balance=Decimal("600"), currency="BRL",
+        ),
+    ])
+
+    with patch("app.services.connection_service.get_provider", return_value=mock_provider), \
+         patch("app.services.connection_service.detect_transfer_pairs", new_callable=AsyncMock), \
+         patch("app.services.connection_service.stamp_primary_amount", new_callable=AsyncMock), \
+         patch("app.services.connection_service.apply_rules_to_transaction", new_callable=AsyncMock):
+        await sync_connection(session, conn.id, test_user.id)
+
+    await session.refresh(account)
+    assert account.name == "BANCO ATUALIZADO"
+    assert account.display_name == "Meu Apelido"

--- a/frontend/src/components/app-layout.tsx
+++ b/frontend/src/components/app-layout.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
@@ -326,7 +327,7 @@ export function AppLayout() {
                         className="flex items-center justify-between px-3 py-1.5 rounded-lg text-xs text-sidebar-muted hover:bg-sidebar-accent hover:text-sidebar-foreground transition-all"
                       >
                         <div className="truncate min-w-0">
-                          <span className="block truncate font-medium">{acc.name}</span>
+                          <span className="block truncate font-medium">{getAccountName(acc)}</span>
                           <span className="block text-[10px] text-sidebar-muted/60">
                             {t(`accounts.type${typeKey}`)}
                           </span>

--- a/frontend/src/components/link-transfer-dialog.tsx
+++ b/frontend/src/components/link-transfer-dialog.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
@@ -224,7 +225,7 @@ export function LinkTransferDialog({
                               )}
                             </div>
                             <p className="text-xs text-muted-foreground truncate">
-                              {account?.name ?? '—'} · {new Date(c.date + 'T00:00:00').toLocaleDateString(locale)}
+                              {account ? getAccountName(account) : '—'} · {new Date(c.date + 'T00:00:00').toLocaleDateString(locale)}
                             </p>
                           </div>
                           <p className={`text-sm font-bold tabular-nums ${colorClass} shrink-0`}>

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
 import { useAuth } from '@/contexts/auth-context'
@@ -614,7 +615,7 @@ function TransactionForm({
               required
             >
               {accounts.map((acc) => (
-                <option key={acc.id} value={acc.id}>{acc.name}</option>
+                <option key={acc.id} value={acc.id}>{getAccountName(acc)}</option>
               ))}
             </select>
           </div>

--- a/frontend/src/components/transactions-filter-bar.tsx
+++ b/frontend/src/components/transactions-filter-bar.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useState } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { format, startOfMonth, startOfYear, subDays } from 'date-fns'
 import {
@@ -593,7 +594,7 @@ export function TransactionsFilterBar({
                   key={`acc-${id}`}
                   icon={<Wallet size={12} />}
                   label={t('transactions.account')}
-                  value={account.name}
+                  value={getAccountName(account)}
                   onRemove={() =>
                     onAccountIdsChange(filterAccountIds.filter((x) => x !== id))
                   }

--- a/frontend/src/components/transfer-dialog.tsx
+++ b/frontend/src/components/transfer-dialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -136,7 +137,7 @@ export function TransferDialog({
                 <option value="" disabled>{t('transactions.account')}</option>
                 {accounts.map((acc) => (
                   <option key={acc.id} value={acc.id}>
-                    {acc.name} ({acc.currency})
+                    {getAccountName(acc)} ({acc.currency})
                   </option>
                 ))}
               </select>
@@ -159,7 +160,7 @@ export function TransferDialog({
                 <option value="" disabled>{t('transactions.account')}</option>
                 {availableToAccounts.map((acc) => (
                   <option key={acc.id} value={acc.id}>
-                    {acc.name} ({acc.currency})
+                    {getAccountName(acc)} ({acc.currency})
                   </option>
                 ))}
               </select>

--- a/frontend/src/lib/account-utils.ts
+++ b/frontend/src/lib/account-utils.ts
@@ -1,0 +1,3 @@
+export function getAccountName(account: { name: string; display_name?: string | null }): string {
+  return account.display_name ?? account.name
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -286,6 +286,8 @@
     "noBankConnections": "No bank connections",
     "noAccountsFound": "No accounts found",
     "accountName": "Account name",
+    "displayName": "Display name",
+    "displayNameHint": "Overrides the default provider name everywhere in the app.",
     "accountType": "Type",
     "currency": "Currency",
     "typeChecking": "Checking",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -286,6 +286,8 @@
     "noBankConnections": "Nenhuma conexão bancária",
     "noAccountsFound": "Nenhuma conta encontrada",
     "accountName": "Nome da conta",
+    "displayName": "Nome de exibição",
+    "displayNameHint": "Substitui o nome padrão do provedor em todo o sistema.",
     "accountType": "Tipo",
     "currency": "Moeda",
     "typeChecking": "Conta Corrente",

--- a/frontend/src/pages/account-detail.tsx
+++ b/frontend/src/pages/account-detail.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { useParams, Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -549,7 +550,7 @@ export default function AccountDetailPage() {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0">
             <h1 className="text-2xl sm:text-3xl font-semibold text-foreground tracking-tight truncate">
-              {account.name}
+              {getAccountName(account)}
             </h1>
             <div className="flex items-center gap-2 mt-1 flex-wrap">
               <span className="text-xs font-medium text-muted-foreground">

--- a/frontend/src/pages/accounts.tsx
+++ b/frontend/src/pages/accounts.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -227,7 +228,7 @@ export default function AccountsPage() {
                           <Icon size={14} className={cfg.color} />
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="text-sm font-medium text-foreground truncate">{acc.name}</p>
+                          <p className="text-sm font-medium text-foreground truncate">{getAccountName(acc)}</p>
                           <p className="text-xs text-muted-foreground">
                             {t(cfg.label)}
                             {dueText && <> · <span className={dueClass}>{dueText}</span></>}
@@ -384,20 +385,29 @@ export default function AccountsPage() {
                                   <Icon size={14} className={cfg.color} />
                                 </div>
                                 <div className="min-w-0 flex-1">
-                                  <p className="text-sm font-medium text-foreground truncate">{acc.name}</p>
+                                  <p className="text-sm font-medium text-foreground truncate">{getAccountName(acc)}</p>
                                   <p className="text-xs text-muted-foreground">
                                     {t(cfg.label)}
                                     {dueText && <> · <span className={dueClass}>{dueText}</span></>}
                                   </p>
                                 </div>
                               </Link>
-                              <button
-                                className="p-1.5 rounded-md text-muted-foreground hover:text-amber-600 hover:bg-amber-50 transition-colors opacity-0 group-hover:opacity-100 mr-3"
-                                onClick={(e) => { e.preventDefault(); setClosingAccountId(acc.id) }}
-                                title={t('accounts.close')}
-                              >
-                                <Archive size={13} />
-                              </button>
+                              <div className="flex items-center gap-1 mr-3 opacity-0 group-hover:opacity-100 transition-opacity">
+                                <button
+                                  className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                                  onClick={(e) => { e.preventDefault(); setEditingAccount(acc); setDialogOpen(true) }}
+                                  title={t('common.edit')}
+                                >
+                                  <Pencil size={13} />
+                                </button>
+                                <button
+                                  className="p-1.5 rounded-md text-muted-foreground hover:text-amber-600 hover:bg-amber-50 transition-colors"
+                                  onClick={(e) => { e.preventDefault(); setClosingAccountId(acc.id) }}
+                                  title={t('accounts.close')}
+                                >
+                                  <Archive size={13} />
+                                </button>
+                              </div>
                               <div className="text-right">
                                 <p className={`text-xs sm:text-sm font-semibold tabular-nums ${(acc.type === 'credit_card' ? bal > 0 : bal < 0) ? 'text-rose-500' : 'text-foreground'}`}>
                                   {mask(formatCurrency(bal, acc.currency, locale))}
@@ -447,7 +457,7 @@ export default function AccountsPage() {
                         <div className={`w-8 h-8 rounded-lg ${cfg.bg} flex items-center justify-center shrink-0`}>
                           <Icon size={14} className={cfg.color} />
                         </div>
-                        <p className="text-sm font-medium text-muted-foreground truncate">{acc.name}</p>
+                        <p className="text-sm font-medium text-muted-foreground truncate">{getAccountName(acc)}</p>
                       </div>
                       <Button
                         variant="ghost"
@@ -582,6 +592,7 @@ function AccountDialog({
   account: Account | null
   onSave: (data: {
     name?: string
+    display_name?: string | null
     type?: string
     balance?: number
     balance_date?: string
@@ -601,6 +612,7 @@ function AccountDialog({
     staleTime: Infinity,
   })
   const [name, setName] = useState(account?.name ?? '')
+  const [displayName, setDisplayName] = useState(account?.display_name ?? '')
   const [type, setType] = useState(account?.type ?? 'checking')
   const [balance, setBalance] = useState(account?.balance?.toString() ?? '0')
   const [currency, setCurrency] = useState(account?.currency ?? userCurrency)
@@ -611,6 +623,7 @@ function AccountDialog({
 
   useEffect(() => {
     setName(account?.name ?? '')
+    setDisplayName(account?.display_name ?? '')
     setType(account?.type ?? 'checking')
     setBalance(account?.balance?.toString() ?? '0')
     setCurrency(account?.currency ?? userCurrency)
@@ -637,23 +650,34 @@ function AccountDialog({
               const n = parseInt(v, 10)
               return Number.isFinite(n) && n >= 1 && n <= 31 ? n : null
             }
+            const isConnected = !!account?.connection_id
             onSave({
-              name,
-              type,
-              balance: parseFloat(balance),
-              balance_date: balanceDate,
-              currency,
-              credit_limit: isCC && creditLimit !== '' ? parseFloat(creditLimit) : null,
-              statement_close_day: isCC ? parseDay(statementCloseDay) : null,
-              payment_due_day: isCC ? parseDay(paymentDueDay) : null,
+              ...(!isConnected && { name, type, balance: parseFloat(balance), balance_date: balanceDate, currency }),
+              display_name: displayName.trim() || null,
+              ...(isCC && {
+                credit_limit: creditLimit !== '' ? parseFloat(creditLimit) : null,
+                statement_close_day: parseDay(statementCloseDay),
+                payment_due_day: parseDay(paymentDueDay),
+              }),
             })
           }}
           className="space-y-4"
         >
           <div className="space-y-2">
             <Label>{t('accounts.accountName')}</Label>
-            <Input value={name} onChange={(e) => setName(e.target.value)} required />
+            <Input value={name} onChange={(e) => setName(e.target.value)} required disabled={!!account?.connection_id} />
           </div>
+          {account?.connection_id && (
+            <div className="space-y-2">
+              <Label>{t('accounts.displayName')}</Label>
+              <Input
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder={name}
+              />
+              <p className="text-xs text-muted-foreground">{t('accounts.displayNameHint')}</p>
+            </div>
+          )}
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label>{t('accounts.accountType')}</Label>

--- a/frontend/src/pages/accounts.tsx
+++ b/frontend/src/pages/accounts.tsx
@@ -678,62 +678,66 @@ function AccountDialog({
               <p className="text-xs text-muted-foreground">{t('accounts.displayNameHint')}</p>
             </div>
           )}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label>{t('accounts.accountType')}</Label>
-              <select
-                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                value={type}
-                onChange={(e) => setType(e.target.value)}
-              >
-                <option value="checking">{t('accounts.typeChecking')}</option>
-                <option value="savings">{t('accounts.typeSavings')}</option>
-                <option value="credit_card">{t('accounts.typeCreditCard')}</option>
-                <option value="investment">{t('accounts.typeInvestment')}</option>
-                <option value="wallet">{t('accounts.typeWallet')}</option>
-              </select>
-            </div>
-            <div className="space-y-2">
-              <Label>{t('accounts.currency')}</Label>
-              <select
-                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                value={currency}
-                onChange={(e) => setCurrency(e.target.value)}
-              >
-                {(supportedCurrencies ?? [{ code: userCurrency, symbol: userCurrency, name: userCurrency, flag: '' }]).map((c) => (
-                  <option key={c.code} value={c.code}>{c.flag} {c.name}</option>
-                ))}
-              </select>
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label>
-                {type === 'credit_card'
-                  ? t('accounts.balanceCreditCard')
-                  : t('accounts.balance')}
-              </Label>
-              <Input
-                type="number"
-                step="0.01"
-                min={type === 'credit_card' ? '0' : undefined}
-                value={balance}
-                onChange={(e) => setBalance(e.target.value)}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>{t('accounts.balanceDate')}</Label>
-              <DatePickerInput
-                value={balanceDate}
-                onChange={setBalanceDate}
-                className="w-full justify-start"
-              />
-            </div>
-          </div>
-          {type === 'credit_card' && (
-            <p className="text-xs text-muted-foreground -mt-2">
-              {t('accounts.balanceCreditCardHint')}
-            </p>
+          {!account?.connection_id && (
+            <>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>{t('accounts.accountType')}</Label>
+                  <select
+                    className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                    value={type}
+                    onChange={(e) => setType(e.target.value)}
+                  >
+                    <option value="checking">{t('accounts.typeChecking')}</option>
+                    <option value="savings">{t('accounts.typeSavings')}</option>
+                    <option value="credit_card">{t('accounts.typeCreditCard')}</option>
+                    <option value="investment">{t('accounts.typeInvestment')}</option>
+                    <option value="wallet">{t('accounts.typeWallet')}</option>
+                  </select>
+                </div>
+                <div className="space-y-2">
+                  <Label>{t('accounts.currency')}</Label>
+                  <select
+                    className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                    value={currency}
+                    onChange={(e) => setCurrency(e.target.value)}
+                  >
+                    {(supportedCurrencies ?? [{ code: userCurrency, symbol: userCurrency, name: userCurrency, flag: '' }]).map((c) => (
+                      <option key={c.code} value={c.code}>{c.flag} {c.name}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>
+                    {type === 'credit_card'
+                      ? t('accounts.balanceCreditCard')
+                      : t('accounts.balance')}
+                  </Label>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    min={type === 'credit_card' ? '0' : undefined}
+                    value={balance}
+                    onChange={(e) => setBalance(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>{t('accounts.balanceDate')}</Label>
+                  <DatePickerInput
+                    value={balanceDate}
+                    onChange={setBalanceDate}
+                    className="w-full justify-start"
+                  />
+                </div>
+              </div>
+              {type === 'credit_card' && (
+                <p className="text-xs text-muted-foreground -mt-2">
+                  {t('accounts.balanceCreditCardHint')}
+                </p>
+              )}
+            </>
           )}
           {type === 'credit_card' && (
             <div className="space-y-4 rounded-lg border border-border bg-muted/30 p-4">

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
@@ -919,7 +920,7 @@ export default function DashboardPage() {
         onClose={() => { setDialogOpen(false); setEditingTx(null) }}
         transaction={editingTx}
         categories={(categoriesList ?? []).map((c: { id: string; name: string; icon: string }) => ({ id: c.id, name: c.name, icon: c.icon }))}
-        accounts={(accountsList ?? []).map((a: { id: string; name: string }) => ({ id: a.id, name: a.name }))}
+        accounts={(accountsList ?? []).map((a: { id: string; name: string; display_name?: string | null }) => ({ id: a.id, name: getAccountName(a) }))}
         onSave={(data) => {
           if (editingTx) updateMutation.mutate({ id: editingTx.id, ...data })
         }}

--- a/frontend/src/pages/goals.tsx
+++ b/frontend/src/pages/goals.tsx
@@ -1,4 +1,5 @@
 import { createElement, useState } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { goals as goalsApi, accounts as accountsApi, assets as assetsApi, currencies as currenciesApi } from '@/lib/api'
@@ -477,7 +478,7 @@ export default function GoalsPage() {
                   <option value="">{t('goals.selectAccount')}</option>
                   {accountsList?.map((acc) => (
                     <option key={acc.id} value={acc.id}>
-                      {acc.name} ({acc.currency})
+                      {getAccountName(acc)} ({acc.currency})
                     </option>
                   ))}
                 </select>

--- a/frontend/src/pages/import.tsx
+++ b/frontend/src/pages/import.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { transactions as transactionsApi, accounts as accountsApi, importLogs as importLogsApi } from '@/lib/api'
@@ -284,7 +285,7 @@ export default function ImportPage() {
               >
                 <option value="">{t('import.selectAccount')}</option>
                 {accountsList?.map((acc) => (
-                  <option key={acc.id} value={acc.id}>{acc.name} ({t(TYPE_LABELS[acc.type] || acc.type)})</option>
+                  <option key={acc.id} value={acc.id}>{getAccountName(acc)} ({t(TYPE_LABELS[acc.type] || acc.type)})</option>
                 ))}
               </select>
               {!selectedAccount && (

--- a/frontend/src/pages/recurring.tsx
+++ b/frontend/src/pages/recurring.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { categories as categoriesApi, recurring as recurringApi, accounts as accountsApi, currencies as currenciesApi } from '@/lib/api'
@@ -377,7 +378,7 @@ function RecurringForm({
           >
             {!accountId && <option value="" disabled>{t('recurring.noAccount')}</option>}
             {accounts.map((acc) => (
-              <option key={acc.id} value={acc.id}>{acc.name}</option>
+              <option key={acc.id} value={acc.id}>{getAccountName(acc)}</option>
             ))}
           </select>
         </div>

--- a/frontend/src/pages/rules.tsx
+++ b/frontend/src/pages/rules.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { categories as categoriesApi, rules as rulesApi, accounts as accountsApi, payees as payeesApi } from '@/lib/api'
@@ -532,7 +533,7 @@ function RuleDialog({
                     >
                       <option value="">{t('rules.selectAccount')}</option>
                       {accounts.map(acc => (
-                        <option key={acc.id} value={acc.id}>{acc.name}</option>
+                        <option key={acc.id} value={acc.id}>{getAccountName(acc)}</option>
                       ))}
                     </select>
                   ) : (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -80,6 +80,7 @@ export interface Account {
   connection_id: string | null
   external_id: string | null
   name: string
+  display_name: string | null
   type: string
   balance: number
   current_balance: number


### PR DESCRIPTION
Closes #77

## What

Adds a `display_name` field to accounts, allowing users to set a custom nickname for bank-connected accounts whose names are provided by the provider and cannot be changed.

## Why

Bank-connected accounts have names set by the Pluggy provider (e.g. "Nu Pagamentos S.A. - Instituição de Pagamento"), which are often long or unclear. This feature lets users define a friendly nickname that replaces the provider name everywhere in the app.

## How to Test

1. Go to **Accounts** and hover over a bank-connected account
2. Click the edit (pencil) icon that appears
3. Fill in the **Display name** field and save
4. Verify the nickname appears in the account list, sidebar, transaction dropdowns, filters, and all other places the account name is shown
5. Clear the nickname (leave blank) and save — original provider name should be restored

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
