### PR TITLE
fix: send null instead of undefined when clearing transaction notes

### DIFF
--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -407,7 +407,7 @@ function TransactionForm({
           ? {
               category_id: categoryId || null,
               payee_id: payeeId || null,
-              notes: notes.trim() || undefined,
+              notes: notes.trim() || null,
             } as Partial<Transaction>
           : {
               description,
@@ -418,7 +418,7 @@ function TransactionForm({
               category_id: categoryId || null,
               payee_id: payeeId || null,
               account_id: accountId || undefined,
-              notes: notes.trim() || undefined,
+              notes: notes.trim() || null,
               ...fxFields,
             } as Partial<Transaction>
         const recurringData = isCreating && isRecurring


### PR DESCRIPTION
Notes field was omitted from the payload when empty, so the backend ignored the change and the old value persisted. Sending null explicitly clears the field in the database.

## What

Changed `notes.trim() || undefined` to `notes.trim() || null` in the transaction dialog, so clearing the notes field actually removes it.

## Why

The backend uses `exclude_unset=True` when applying updates — fields absent from the JSON payload are ignored. `undefined` values are omitted from JSON serialization, so the old note persisted. `null` is serialized explicitly and clears the value in the database.

## How to Test

1. Open any transaction with a note
2. Clear the notes field and save
3. Confirm the note is removed and doesn't reappear on reload

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
