### PR TITLE
fix: correct CABELEIREIRO rule keyword

### DIFF
--- a/backend/app/services/rule_service.py
+++ b/backend/app/services/rule_service.py
@@ -143,7 +143,7 @@ RULE_PACKS = {
             {"name": "Barbearia / Salão", "conditions_op": "or", "conditions": [
                 {"field": "description", "op": "contains", "value": "BARBEARIA"},
                 {"field": "description", "op": "contains", "value": "SALAO"},
-                {"field": "description", "op": "contains", "value": "CABELEREIRO"},
+                {"field": "description", "op": "contains", "value": "CABELEIREIRO"},
             ], "actions": [{"op": "set_category", "value": "personal_care"}], "priority": 10},
 
             {"name": "IPTU / IPVA / Imposto", "conditions_op": "or", "conditions": [


### PR DESCRIPTION
## What

Fixes a typo in the Brazil rule pack for personal care categorization:
- `CABELEREIRO` -> `CABELEIREIRO` in the "Barbearia / Salão" rule condition.

## Why

The typo reduces match accuracy for transaction descriptions containing the correct Portuguese word "cabeleireiro", which can prevent expected auto-categorization.

## How to Test

1. Start the app stack (`docker compose up --build`).
2. Ensure Brazil rule pack is available/applied.
3. Create or import a transaction with description containing `CABELEIREIRO`.
4. Verify the transaction matches "Barbearia / Salão" and is categorized as `personal_care`.

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed) — not applicable