### PR TITLE
fix: display name goals link transfer (#97)

### DIFF
--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -3,6 +3,10 @@ from datetime import date as _Date, datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Optional
 
+
+def get_account_name(account: "Account") -> str:
+    return account.display_name or account.name
+
 from sqlalchemy import case, func, select, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -3,10 +3,6 @@ from datetime import date as _Date, datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Optional
 
-
-def get_account_name(account: "Account") -> str:
-    return account.display_name or account.name
-
 from sqlalchemy import case, func, select, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,6 +11,10 @@ from app.models.bank_connection import BankConnection
 from app.models.transaction import Transaction
 from app.schemas.account import AccountCreate, AccountUpdate
 from app.services.credit_card_service import apply_effective_date, compute_available_credit, get_cycle_dates
+
+
+def get_account_name(account: Account) -> str:
+    return account.display_name or account.name
 
 
 async def get_accounts(session: AsyncSession, user_id: uuid.UUID, include_closed: bool = False) -> list[dict]:

--- a/backend/app/services/goal_service.py
+++ b/backend/app/services/goal_service.py
@@ -14,6 +14,7 @@ from app.models.user import User
 from app.schemas.goal import GoalCreate, GoalRead, GoalSummary, GoalUpdate
 from app.services.asset_service import _compute_current_value, _get_latest_value, get_total_asset_value
 from app.services.dashboard_service import _account_balance_at, _get_open_accounts
+from app.services.account_service import get_account_name
 from app.services.fx_rate_service import convert
 
 
@@ -166,7 +167,7 @@ async def _enrich_goal(
     if goal.account_id:
         account = await session.get(Account, goal.account_id)
         if account:
-            account_name = account.name
+            account_name = get_account_name(account)
     asset_name = None
     if goal.asset_id:
         asset = await session.get(Asset, goal.asset_id)

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -13,6 +13,7 @@ from app.models.transaction import Transaction
 from app.models.category import Category
 from app.models.user import User
 from app.services.admin_service import get_credit_card_accounting_mode
+from app.services.account_service import get_account_name
 from app.services.fx_rate_service import convert
 from app.schemas.report import (
     CategoryTrendItem,
@@ -271,7 +272,7 @@ async def get_net_worth_report(
         if account.type == "credit_card":
             composition.append(ReportCompositionItem(
                 key=str(account.id),
-                label=account.name,
+                label=get_account_name(account),
                 value=round(converted_val, 2),
                 color=account_type_colors.get(account.type, "#6B7280"),
                 group="liabilities",
@@ -280,7 +281,7 @@ async def get_net_worth_report(
             if bal > 0:
                 composition.append(ReportCompositionItem(
                     key=str(account.id),
-                    label=account.name,
+                    label=get_account_name(account),
                     value=round(converted_val, 2),
                     color=account_type_colors.get(account.type, "#6B7280"),
                     group="accounts",

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -745,6 +745,20 @@ async def test_net_worth_composition_includes_assets(session: AsyncSession, test
 
 
 @pytest.mark.asyncio
+async def test_net_worth_composition_uses_display_name(session: AsyncSession, test_user: User):
+    """Composition labels must use display_name when set, falling back to name."""
+    acct = await _make_manual_account(session, test_user.id, "Provider Name")
+    acct.display_name = "My Nickname"
+    await session.commit()
+    await _add_txn(session, test_user.id, acct.id, 10000, "credit", date.today())
+
+    report = await get_net_worth_report(session, test_user.id, months=1, interval="monthly")
+    comp_labels = [c.label for c in report.composition]
+    assert "My Nickname" in comp_labels
+    assert "Provider Name" not in comp_labels
+
+
+@pytest.mark.asyncio
 async def test_net_worth_weekly_interval(session: AsyncSession, test_user: User):
     acct = await _make_manual_account(session, test_user.id, "Weekly Test")
     await _add_txn(session, test_user.id, acct.id, 1000, "credit", date.today())

--- a/frontend/src/components/link-transfer-dialog.tsx
+++ b/frontend/src/components/link-transfer-dialog.tsx
@@ -164,7 +164,7 @@ export function LinkTransferDialog({
             <CounterpartCard
               label={t('transactions.linkTransferAnchor')}
               description={anchor!.description}
-              account={anchorAccount?.name ?? '—'}
+              account={anchorAccount ? getAccountName(anchorAccount) : '—'}
               date={anchor!.date}
               amount={anchorAmount}
               currency={anchor!.currency}

--- a/frontend/src/components/transactions-filter-bar.tsx
+++ b/frontend/src/components/transactions-filter-bar.tsx
@@ -220,7 +220,7 @@ export function TransactionsFilterBar({
     filterAccountIds.length > 1
       ? t('transactions.filtersBar.nSelected', { count: filterAccountIds.length })
       : filterAccountIds.length === 1
-        ? (accountById.get(filterAccountIds[0])?.name ?? '')
+        ? (getAccountName(accountById.get(filterAccountIds[0]) ?? { name: '', display_name: null }))
         : ''
 
   const categorySummary = (() => {
@@ -334,7 +334,7 @@ export function TransactionsFilterBar({
                                 toggleInArray(filterAccountIds, a.id),
                               )
                             }}
-                            label={a.name}
+                            label={getAccountName(a)}
                             sublabel={a.currency}
                           />
                         ))

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
+import { getAccountName } from '@/lib/account-utils'
 import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -559,7 +560,7 @@ export default function TransactionsPage() {
                     )}
                   </TableCell>
                   <TableCell className="hidden lg:table-cell py-2.5 text-sm text-muted-foreground">
-                    {accountsList?.find((a) => a.id === tx.account_id)?.name ?? (
+                    {getAccountName(accountsList?.find((a) => a.id === tx.account_id) ?? { name: '', display_name: null }) || (
                       <span className="text-muted-foreground">—</span>
                     )}
                   </TableCell>


### PR DESCRIPTION
## What

Use `display_name` (with fallback to `name`) when showing account names in the goals list and in the link-transfer dialog anchor card.

## Why

Both places were reading `account.name` directly, ignoring any custom `display_name` set by the user. The backend fix reuses the existing `get_account_name()` helper from `account_service`. The frontend fix reuses `getAccountName()` from `account-utils`, consistent with the rest of the same file.

## How to Test

1. Set a `display_name` on any account
2. Create a goal linked to that account — confirm the goals list shows the `display_name`
3. Create a transaction on that account and open the link-transfer dialog — confirm the anchor card shows the `display_name`

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)

Refs #97