### PR TITLE
Fix: translate provider description

### DIFF
--- a/frontend/src/components/connector-select-dialog.tsx
+++ b/frontend/src/components/connector-select-dialog.tsx
@@ -76,7 +76,7 @@ export function ConnectorSelectDialog({ open, onClose, onSelect }: ConnectorSele
                 </div>
                 <div className="min-w-0 flex-1">
                   <p className="text-sm font-medium text-foreground">{p.display_name}</p>
-                  <p className="text-xs text-muted-foreground mt-0.5">{p.description}</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">{t(`accounts.providers.${p.name}.description`, p.description)}</p>
                   {!p.configured && (
                     <p className="text-xs text-amber-600 mt-1.5">
                       {t('accounts.connectorNotConfigured')}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -356,7 +356,12 @@
     "selectConnector": "Select Connector",
     "selectConnectorDesc": "Choose a bank connection provider",
     "connectorNotConfigured": "This connector requires configuration. Set up the required credentials to enable it.",
-    "noConnectorsAvailable": "No bank connectors available"
+    "noConnectorsAvailable": "No bank connectors available",
+    "providers": {
+      "pluggy": {
+        "description": "Open finance provider for Brazilian banks"
+      }
+    }
   },
   "connections": {
     "settings": "Connection settings",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -356,7 +356,12 @@
     "selectConnector": "Selecionar Conector",
     "selectConnectorDesc": "Escolha um provedor de conexão bancária",
     "connectorNotConfigured": "Este conector requer configuração. Configure as credenciais necessárias para habilitá-lo.",
-    "noConnectorsAvailable": "Nenhum conector bancário disponível"
+    "noConnectorsAvailable": "Nenhum conector bancário disponível",
+    "providers": {
+      "pluggy": {
+        "description": "Provedor Open Finance para bancos brasileiros"
+      }
+    }
   },
   "connections": {
     "settings": "Configurações da conexão",


### PR DESCRIPTION
## What

Added i18n support for the Pluggy provider description shown in the connector selection dialog. The description is now stored in the translation files instead of being rendered directly from the API response.

## Why

The provider description `"Open finance provider for Brazilian banks"` was hardcoded in the backend and displayed as-is in the frontend, ignoring the active language. This change ensures the string is translated when the user switches between Portuguese and English.

## How to Test

1. Open the app and go to Accounts
2. Click "Connect Bank" to open the connector selection dialog
3. Verify the Pluggy description appears in the current language
4. Switch the language (Settings → language toggle)
5. Reopen the dialog and verify the description updated accordingly

## Checklist

- [x] Translations updated (if user-facing strings changed)
