### PR TITLE
fix: auto-detect CSV delimiter on bank statement import

### DIFF
--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -207,7 +207,12 @@ def parse_csv(
     - inflow_column/outflow_column: use split columns instead of single amount
     """
     text = content.decode('utf-8-sig')  # Handle BOM
-    reader = csv.DictReader(io.StringIO(text))
+    sample = text[:4096]
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=',;\t|')
+    except csv.Error:
+        dialect = csv.excel  # fallback to comma
+    reader = csv.DictReader(io.StringIO(text), dialect=dialect)
 
     # Normalize field names
     fieldnames = [f.lower().strip() for f in (reader.fieldnames or [])]

--- a/backend/tests/test_import_service.py
+++ b/backend/tests/test_import_service.py
@@ -145,6 +145,40 @@ class TestParseCsv:
         assert len(transactions) == 1
         assert transactions[0].date == date(2025, 12, 25)
 
+    def test_parse_csv_semicolon_delimiter(self):
+        """CSV using semicolons as delimiter should be parsed correctly."""
+        csv_content = (
+            "date;description;amount\n"
+            "15/01/2026;Grocery Store;-120.50\n"
+            "20/01/2026;Salary Payment;5000.00\n"
+        )
+        transactions = parse_csv(csv_content.encode("utf-8"))
+
+        assert len(transactions) == 2
+        assert transactions[0].description == "Grocery Store"
+        assert transactions[0].amount == Decimal("120.50")
+        assert transactions[0].type == "debit"
+        assert transactions[1].description == "Salary Payment"
+        assert transactions[1].amount == Decimal("5000.00")
+        assert transactions[1].type == "credit"
+
+    def test_parse_csv_tab_delimiter(self):
+        """CSV using tabs as delimiter should be parsed correctly."""
+        csv_content = (
+            "date\tdescription\tamount\n"
+            "2026-01-15\tGrocery Store\t-120.50\n"
+            "2026-01-20\tSalary Payment\t5000.00\n"
+        )
+        transactions = parse_csv(csv_content.encode("utf-8"))
+
+        assert len(transactions) == 2
+        assert transactions[0].description == "Grocery Store"
+        assert transactions[0].amount == Decimal("120.50")
+        assert transactions[0].type == "debit"
+        assert transactions[1].description == "Salary Payment"
+        assert transactions[1].amount == Decimal("5000.00")
+        assert transactions[1].type == "credit"
+
     def test_parse_csv_empty_file(self):
         """A CSV with only headers and no data rows should return empty list."""
         csv_content = "date,description,amount\n"


### PR DESCRIPTION
## What

Auto-detect the CSV delimiter (`,`, `;`, `\t`, `|`) when importing bank statements, instead of always assuming comma.

## Why

CSVs using semicolons (or other delimiters) caused a misleading "Could not detect CSV columns" error because the entire header row was read as a single field name.

## How to Test

1. Create a CSV with semicolon delimiter, e.g.:
date;description;amount
15/01/2026;Grocery Store;-120.50
2. Import it via the bank statement import flow.
3. Verify the transactions are parsed correctly without errors.

## Checklist

- [x] Backend tests pass (`pytest`)