### PR TITLE
feat: raise Category Trends cap to top 11 + Other

### DIFF
--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -27,6 +27,8 @@ from app.schemas.report import (
 )
 from app.services.dashboard_service import _get_open_accounts, _account_balance_at
 
+CATEGORY_TREND_TOP_N = 11
+
 
 async def _asset_value_at(
     session: AsyncSession, user_id: uuid.UUID, cutoff: date,
@@ -655,8 +657,8 @@ async def get_income_expenses_report(
             (k, v) for (k, g), v in cat_trend_map.items() if g == group
         ]
         group_items.sort(key=lambda x: x[1]["total"], reverse=True)
-        top = group_items[:6]
-        rest = group_items[6:]
+        top = group_items[:CATEGORY_TREND_TOP_N]
+        rest = group_items[CATEGORY_TREND_TOP_N:]
 
         for cat_key, info in top:
             series = [

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -38,6 +38,8 @@ function formatCompact(value: number, currency = 'USD', locale = 'en-US') {
   }).format(value)
 }
 
+const COMPOSITION_TOP_N = 6
+
 const RANGE_OPTIONS = [
   { key: '6m', months: 6 },
   { key: '1y', months: 12 },
@@ -157,10 +159,10 @@ export default function ReportsPage() {
       items = composition.filter((c) => c.group === 'expenses')
     }
 
-    // Sort descending, take top 6, bucket the rest into "Other"
+    // Sort descending, take top N, bucket the rest into "Other"
     const sorted = [...items].sort((a, b) => b.value - a.value)
-    const top = sorted.slice(0, 6)
-    const rest = sorted.slice(6)
+    const top = sorted.slice(0, COMPOSITION_TOP_N)
+    const rest = sorted.slice(COMPOSITION_TOP_N)
     const otherValue = rest.reduce((sum, c) => sum + c.value, 0)
 
     const result = top.map((c) => ({


### PR DESCRIPTION
## What

Raise the per-group cap on the Income vs Expenses report's **Category Trends** sparklines from top 6 + Other to **top 11 + Other**.

- Backend: `backend/app/services/report_service.py` — introduce `CATEGORY_TREND_TOP_N = 11` and use it in `get_income_expenses_report`.
- Frontend: `frontend/src/pages/reports.tsx` — introduce `COMPOSITION_TOP_N = 6` so the donut's existing cap lives behind a named constant (no behavior change on the donut).

## Why

On the Reports tab, the Income vs Expenses **Category Trends** panel aggregates everything beyond the top 6 categories into a single "Other" bucket. Default (system) categories were created at onboarding and tend to accumulate the most transaction volume, so user-created categories routinely got swept into "Other" and the panel appeared to list only the defaults. The sparklines panel already paginates 6 cards per page, so 11 + Other fills exactly two pages cleanly and surfaces user-created categories as first-class entries.

The donut on the left intentionally keeps its visual top-6 + Other for readability; this PR only renames the magic number into a constant there.

## Screenshots

Page 2 of the Category Trends sparklines (same account, same date range).

**Before** — with the old top-6 cap, page 2 only contained a single "Outros" (Other) card:

<img width="1425" height="504" alt="image" src="https://github.com/user-attachments/assets/a9dc7e34-d9e7-4809-903b-57635a094f94" />

**After** — with the top-11 cap, page 2 now surfaces more categories:

<img width="1480" height="560" alt="image" src="https://github.com/user-attachments/assets/7a205b78-ceea-47c2-a094-09b401d3d9c1" />

## How to Test

1. `docker compose up --build`, then sign in at http://localhost:3000.
2. Make sure the account has default categories **plus** 4+ user-created categories with transactions in the last 12 months. If not, create a few on the Categories page and re-tag some transactions.
3. Go to **Reports → Income vs Expenses**.
4. In the **Category Trends** panel, toggle **By Expenses**: expect up to 12 cards (11 + "Other") paginated 6 per page. User-created categories that previously fell into "Other" should now have their own card.
5. Toggle **By Income**: same expectation.
6. Confirm the left **Composition** donut is unchanged — still top 6 + Other.
7. Edge case — fewer than 11 categories: no "Other" card appears; the sparkline list shows exactly the number of categories with activity (Python `list[:11]` and JS `.slice(0, 6)` on shorter arrays just return the full list, and the existing `if rest:` / `if (otherValue > 0)` guards skip the Other bucket).

## Checklist

- [x] Backend tests pass (`pytest`) — 1039 passed, 6 skipped (pre-existing PostgreSQL-only skips, unchanged).
- [x] Frontend lints clean (`npm run lint`) — 0 errors. Pre-existing warnings in `import.tsx` / `rules.tsx` are unrelated.
- [x] Frontend builds (`npm run build`).
- [ ] Translations updated (if user-facing strings changed) — N/A, no new user-facing strings (existing `reports.other` key reused).

## Notes

The integration tests that would exercise `category_trend` end-to-end (`test_income_expenses_has_category_trend`, `test_income_expenses_api_endpoint`) are already `@pytest.mark.skip`ped because the SQL uses PostgreSQL-only `to_char()` / `extract()` while the test harness runs on SQLite. The cap is trivial slicing that would require extracting a helper larger than the change itself to unit-test cleanly. Happy to add one if reviewers prefer.
