### PR TITLE
fix(migrations): renumber cascade-account-deps to 039 to resolve 032 head conflict

### DIFF
--- a/backend/alembic/versions/039_cascade_account_dependent_tables.py
+++ b/backend/alembic/versions/039_cascade_account_dependent_tables.py
@@ -5,15 +5,15 @@ Makes account deletion safe against the FK class of bugs (issue #110):
 - recurring_transactions.account_id -> ON DELETE CASCADE
 - goals.account_id                  -> ON DELETE SET NULL
 
-Revision ID: 032
-Revises: 031
+Revision ID: 039
+Revises: 038
 Create Date: 2026-04-23
 """
 
 from alembic import op
 
-revision = "032"
-down_revision = "031"
+revision = "039"
+down_revision = "038"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary

- PR #114 merged without rebasing over PR #115's migration chain (032→038), leaving two files both claiming `revision = "032"`
- `alembic upgrade head` fails with `Multiple head revisions are present`, blocking local dev upgrades
- Renames `032_cascade_account_dependent_tables.py` → `039_cascade_account_dependent_tables.py` and chains it after `038`
- **No schema-behavior change** — same FK modifications (CASCADE on `import_logs` + `recurring_transactions`, SET NULL on `goals`), just applied after the assets-sync migrations instead of before them

## Test plan

- [x] `alembic heads` returns a single head (`039 (head)`)
- [x] `alembic upgrade head` on a DB at revision `038` runs `038 -> 039` cleanly
- [ ] After merge, run `git pull && docker compose exec backend alembic upgrade head` locally — should go from `038` to `039` without the multiple-heads error