### PR TITLE
fix(accounts): null transactions.import_id before deleting import_logs (#110)

### DIFF
--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -415,9 +415,20 @@ async def delete_account(session: AsyncSession, account_id: uuid.UUID, user_id: 
     await cleanup_attachment_files(session, tx_ids)
 
     # Break FK references before deleting the account. In production these are
-    # also enforced at the DB level (see migration 032) — this code path makes
+    # also enforced at the DB level (see migration 039) — this code path makes
     # the behavior explicit and keeps the FK bug from #110 from regressing for
-    # any of the three dependent tables.
+    # any of the dependent tables.
+    #
+    # Order matters: transactions imported from a file reference import_logs
+    # via transactions.import_id. We must null that out *before* deleting the
+    # log rows, otherwise the log delete trips transactions_import_id_fkey.
+    # The transaction rows themselves cascade-delete via Account.transactions
+    # when session.delete(account) flushes below.
+    await session.execute(
+        Transaction.__table__.update()
+        .where(Transaction.account_id == account_id)
+        .values(import_id=None)
+    )
     await session.execute(
         ImportLog.__table__.delete().where(ImportLog.account_id == account_id)
     )

--- a/backend/tests/test_account_service.py
+++ b/backend/tests/test_account_service.py
@@ -374,6 +374,48 @@ async def test_delete_account_with_recurring_transactions(session: AsyncSession,
 
 
 @pytest.mark.asyncio
+async def test_delete_account_with_imported_transactions(session: AsyncSession, test_user):
+    """Regression (#110 v2, @ivancarlosti): deleting an account whose transactions
+    were imported from a file must succeed. The imported rows reference the
+    import_log via transactions.import_id — deleting import_logs first would
+    trip transactions_import_id_fkey until that reference is cleared."""
+    from sqlalchemy import select
+
+    account = await _make_account(session, test_user.id, "Imported Txns")
+    log = ImportLog(
+        id=uuid.uuid4(), user_id=test_user.id, account_id=account.id,
+        filename="stmt.ofx", format="ofx", transaction_count=1,
+    )
+    session.add(log)
+    await session.flush()
+
+    tx = await _add_txn(
+        session, test_user.id, account.id,
+        amount=42.0, txn_type="debit", txn_date=date.today(),
+        source="import",
+    )
+    tx.import_id = log.id
+    await session.commit()
+    log_id = log.id
+    tx_id = tx.id
+
+    result = await delete_account(session, account.id, test_user.id)
+    assert result is True
+
+    assert await get_account(session, account.id, test_user.id) is None
+
+    session.expire_all()
+    orphan_log = await session.execute(
+        select(ImportLog).where(ImportLog.id == log_id)
+    )
+    assert orphan_log.scalar_one_or_none() is None
+    orphan_tx = await session.execute(
+        select(Transaction).where(Transaction.id == tx_id)
+    )
+    assert orphan_tx.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
 async def test_delete_account_with_linked_goal(session: AsyncSession, test_user):
     """Regression (#110): deleting an account tracked by a goal must succeed;
     the goal survives with account_id nulled out (progress history is kept)."""


### PR DESCRIPTION
## Summary

- @ivancarlosti reported a second flavor of #110 after v0.9.2 shipped: accounts whose transactions were loaded from a file import still 500 on delete with \`transactions_import_id_fkey\`.
- Root cause: \`delete_account()\` was deleting \`import_logs\` before the ORM cascade from \`Account.transactions\` ran. Live transaction rows still carried \`import_id\` references to the log rows, and PG refused to delete them.
- Fix: null out \`transactions.import_id\` for this account's transactions first, then delete \`import_logs\`. Transactions themselves still cascade-delete via the existing ORM relationship.
- Adds a regression test (\`test_delete_account_with_imported_transactions\`) covering the exact scenario.
- Verified end-to-end in Chrome against a hand-constructed repro: account + import_log + 2 imported transactions + recurring + goal → delete succeeds, all dependents handled correctly, no 500.

## Test plan

- [x] Manual repro on main reproduces the \`transactions_import_id_fkey\` 500
- [x] After the fix, same repro deletes cleanly (\`delete_account\` returns True)
- [x] \`pytest tests/test_account_service.py -k delete\` — 7 passed (3 previous #110 regression tests + 4 existing + new \`test_delete_account_with_imported_transactions\`)
- [x] UI flow in Chrome: click delete, confirm dialog shows pt-BR warning copy, Excluir button deletes cleanly, no error toast
- [x] Post-delete DB state: account gone, import_log gone, 2 imported transactions gone, recurring gone, goal survives with \`account_id = NULL\`