### PR TITLE
Make frontend and backend ports configurable via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,14 @@
 SECRET_KEY=change-me-in-production
 
 # Bank sync — Pluggy (https://pluggy.ai)
-# 1. Create an account at https://dashboard.pluggy.ai
-# 2. Copy your Client ID and Client Secret
-# 3. Add http://localhost:3000/oauth/callback as an allowed redirect URI
+## 1. Create an account at https://dashboard.pluggy.ai
+## 2. Copy your Client ID and Client Secret
+## 3. Add http://localhost:${FRONTEND_PORT}/oauth/callback as an allowed redirect URI
 PLUGGY_CLIENT_ID=
 PLUGGY_CLIENT_SECRET=
+
+# Host ports (optional) — change these to avoid conflicts with other services
+## Default values are set in docker-compose.yml and docker-compose.prod.yml. 
+## Example:
+# FRONTEND_PORT=3132
+# BACKEND_PORT=8182

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -47,11 +47,13 @@ services:
   backend:
     <<: *backend-base
     command: sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"
+    ports:
+      - "${BACKEND_PORT:-8000}:8000"
 
   frontend:
     image: ghcr.io/securo-finance/securo-frontend:latest
     ports:
-      - "3000:80"
+      - "${FRONTEND_PORT:-3000}:80"
     environment:
       BACKEND_URL: http://backend:8000
       FRONTEND_URL: http://localhost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ x-backend-env: &backend-env
   DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/securo
   SECRET_KEY: ${SECRET_KEY:-dev-secret-change-in-production}
   DEBUG: ${DEBUG:-true}
-  FRONTEND_URL: http://localhost:3000
+  FRONTEND_URL: http://localhost:${FRONTEND_PORT:-3000}
   PLUGGY_CLIENT_ID: ${PLUGGY_CLIENT_ID:-}
   PLUGGY_CLIENT_SECRET: ${PLUGGY_CLIENT_SECRET:-}
-  PLUGGY_OAUTH_REDIRECT_URI: http://localhost:3000/oauth/callback
+  PLUGGY_OAUTH_REDIRECT_URI: http://localhost:${FRONTEND_PORT:-3000}/oauth/callback
   REDIS_URL: redis://redis:6379/0
   OPENEXCHANGERATES_APP_ID: ${OPENEXCHANGERATES_APP_ID:-}
   FX_SYNC_MODE: ${FX_SYNC_MODE:-on_demand}
@@ -53,14 +53,14 @@ services:
       sh -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port
       8000 --reload"
     ports:
-      - '8000:8000'
+      - "${BACKEND_PORT:-8000}:8000"
 
   frontend:
     build:
       context: ./frontend
       dockerfile: Dockerfile.dev
     ports:
-      - '3000:5173'
+      - "${FRONTEND_PORT:-3000}:5173"
     environment:
       BACKEND_URL: http://backend:8000
       FRONTEND_URL: http://localhost:3000


### PR DESCRIPTION
## What

Make frontend and backend host ports configurable via environment variables (FRONTEND_PORT, BACKEND_PORT) in both dev and production compose files.

## Why

The hardcoded ports (3000, 8000) can conflict with other services running locally. This allows contributors and self-hosters to remap ports without editing the compose files directly. if not set, default values are applied.

## How to Test

1. Start the stack normally — defaults still work: docker compose up --build
2. Open http://localhost:3000 (http://localhost:3000) — should load as before
3. Create a .env file with custom ports:
   FRONTEND_PORT=3132
   BACKEND_PORT=8182
4. Restart: docker compose up
5. Open http://localhost:3132 (http://localhost:3132) — should load on the new port

## Checklist

- [ ] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
