### PR TITLE
feat: add backup restore capability

### DIFF
--- a/backend/app/api/export.py
+++ b/backend/app/api/export.py
@@ -16,9 +16,10 @@ async def backup(
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ):
-    from app.services.export_service import export_user_data
+    from app.services.export_service import ExportService
 
-    buf = await export_user_data(session, user.id)
+    service = ExportService(session, user.id)
+    buf = await service.export_data()
     today = date.today().isoformat()
     return StreamingResponse(
         iter([buf.getvalue()]),
@@ -33,7 +34,7 @@ async def restore(
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ):
-    from app.services.export_service import BackupArchiveHandler, restore_user_data
+    from app.services.export_service import BackupArchiveHandler, ExportService
 
     try:
         content = await file.read()
@@ -42,7 +43,8 @@ async def restore(
         raise HTTPException(status_code=400, detail=f"Invalid backup file: {str(e)}")
 
     try:
-        await restore_user_data(session, user.id, data_map)
+        service = ExportService(session, user.id)
+        await service.restore_data(data_map)
         await session.commit()
     except Exception as e:
         await session.rollback()

--- a/backend/app/api/export.py
+++ b/backend/app/api/export.py
@@ -1,37 +1,14 @@
-import io
-import json
-import zipfile
-from datetime import date, datetime
-from decimal import Decimal
-from uuid import UUID
+from datetime import date
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
-from sqlalchemy import select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import current_active_user
 from app.core.database import get_async_session
-from app.models.account import Account
-from app.models.asset import Asset
-from app.models.asset_group import AssetGroup
-from app.models.asset_value import AssetValue
-from app.models.budget import Budget
-from app.models.category import Category
-from app.models.category_group import CategoryGroup
-from app.models.goal import Goal
-from app.models.import_log import ImportLog
-from app.models.payee import Payee, PayeeMapping
-from app.models.recurring_transaction import RecurringTransaction
-from app.models.bank_connection import BankConnection
-from app.models.rule import Rule
-from app.models.transaction import Transaction
 from app.models.user import User
 
 router = APIRouter(prefix="/api/export", tags=["export"])
-
-
-from app.core.utils import serialize_model, deserialize_row
 
 
 @router.get("/backup")
@@ -56,11 +33,11 @@ async def restore(
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ):
-    from app.services.export_service import parse_import_zip, restore_user_data
+    from app.services.export_service import BackupArchiveHandler, restore_user_data
 
     try:
         content = await file.read()
-        data_map = parse_import_zip(content)
+        data_map = BackupArchiveHandler.parse_import_zip(content)
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid backup file: {str(e)}")
 

--- a/backend/app/api/export.py
+++ b/backend/app/api/export.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import current_active_user
 from app.core.database import get_async_session
 from app.models.user import User
+from app.services.export_service import BackupArchiveHandler, ExportService
 
 router = APIRouter(prefix="/api/export", tags=["export"])
 
@@ -16,8 +17,6 @@ async def backup(
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ):
-    from app.services.export_service import ExportService
-
     service = ExportService(session, user.id)
     buf = await service.export_data()
     today = date.today().isoformat()
@@ -34,8 +33,6 @@ async def restore(
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ):
-    from app.services.export_service import BackupArchiveHandler, ExportService
-
     try:
         content = await file.read()
         data_map = BackupArchiveHandler.parse_import_zip(content)

--- a/backend/app/api/export.py
+++ b/backend/app/api/export.py
@@ -39,102 +39,9 @@ async def backup(
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ):
-    user_id = user.id
+    from app.services.export_service import export_user_data
 
-    # Query all entities for the current user
-    accounts = (
-        (await session.execute(select(Account).where(Account.user_id == user_id))).scalars().all()
-    )
-    transactions = (
-        (await session.execute(select(Transaction).where(Transaction.user_id == user_id)))
-        .scalars()
-        .all()
-    )
-    categories = (
-        (await session.execute(select(Category).where(Category.user_id == user_id))).scalars().all()
-    )
-    category_groups = (
-        (await session.execute(select(CategoryGroup).where(CategoryGroup.user_id == user_id)))
-        .scalars()
-        .all()
-    )
-    rules = (await session.execute(select(Rule).where(Rule.user_id == user_id))).scalars().all()
-    recurring_transactions = (
-        (
-            await session.execute(
-                select(RecurringTransaction).where(RecurringTransaction.user_id == user_id)
-            )
-        )
-        .scalars()
-        .all()
-    )
-    budgets = (
-        (await session.execute(select(Budget).where(Budget.user_id == user_id))).scalars().all()
-    )
-    assets = (await session.execute(select(Asset).where(Asset.user_id == user_id))).scalars().all()
-    import_logs = (
-        (await session.execute(select(ImportLog).where(ImportLog.user_id == user_id)))
-        .scalars()
-        .all()
-    )
-    asset_groups = (
-        (await session.execute(select(AssetGroup).where(AssetGroup.user_id == user_id)))
-        .scalars()
-        .all()
-    )
-    goals = (await session.execute(select(Goal).where(Goal.user_id == user_id))).scalars().all()
-    payees = (await session.execute(select(Payee).where(Payee.user_id == user_id))).scalars().all()
-    payee_mappings = (
-        (await session.execute(select(PayeeMapping).where(PayeeMapping.user_id == user_id)))
-        .scalars()
-        .all()
-    )
-
-    # AssetValue lacks user_id — filter via asset_ids
-    asset_ids = [a.id for a in assets]
-    if asset_ids:
-        asset_values = (
-            (await session.execute(select(AssetValue).where(AssetValue.asset_id.in_(asset_ids))))
-            .scalars()
-            .all()
-        )
-    else:
-        asset_values = []
-
-    entities = {
-        "accounts": accounts,
-        "transactions": transactions,
-        "categories": categories,
-        "category_groups": category_groups,
-        "rules": rules,
-        "recurring_transactions": recurring_transactions,
-        "budgets": budgets,
-        "assets": assets,
-        "asset_groups": asset_groups,
-        "goals": goals,
-        "payees": payees,
-        "payee_mappings": payee_mappings,
-        "asset_values": asset_values,
-        "import_logs": import_logs,
-    }
-
-    # Build in-memory ZIP
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        entity_counts = {}
-        for name, rows in entities.items():
-            serialized = [serialize_model(r) for r in rows]
-            entity_counts[name] = len(serialized)
-            zf.writestr(f"{name}.json", json.dumps(serialized, indent=2, ensure_ascii=False))
-
-        metadata = {
-            "export_date": datetime.utcnow().isoformat(),
-            "format_version": "1.0",
-            "entity_counts": entity_counts,
-        }
-        zf.writestr("metadata.json", json.dumps(metadata, indent=2, ensure_ascii=False))
-
-    buf.seek(0)
+    buf = await export_user_data(session, user.id)
     today = date.today().isoformat()
     return StreamingResponse(
         iter([buf.getvalue()]),
@@ -149,135 +56,20 @@ async def restore(
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ):
+    from app.services.export_service import parse_import_zip, restore_user_data
+
     try:
         content = await file.read()
-        buf = io.BytesIO(content)
-        data_map = {}
-        with zipfile.ZipFile(buf, "r") as zf:
-            for name in zf.namelist():
-                if name.endswith(".json") and name != "metadata.json":
-                    entity_name = name[:-5]
-                    data_map[entity_name] = json.loads(zf.read(name))
+        data_map = parse_import_zip(content)
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid backup file: {str(e)}")
 
-    user_id = user.id
-
     try:
-        entity_order = [
-            ("category_groups", CategoryGroup),
-            ("categories", Category),
-            ("accounts", Account),
-            ("payees", Payee),
-            ("payee_mappings", PayeeMapping),
-            ("asset_groups", AssetGroup),
-            ("assets", Asset),
-            ("asset_values", AssetValue),
-            ("transactions", Transaction),
-            ("recurring_transactions", RecurringTransaction),
-            ("rules", Rule),
-            ("budgets", Budget),
-            ("goals", Goal),
-            ("import_logs", ImportLog),
-        ]
-
-        # 1. Delete existing data (children first, reverse dependency order)
-        for key, model in reversed(entity_order):
-            if key in data_map:
-                if model == AssetValue:
-                    # Asset values are tied to assets via ids, not user_id directly
-                    asset_ids_result = (
-                        (await session.execute(select(Asset.id).where(Asset.user_id == user_id)))
-                        .scalars()
-                        .all()
-                    )
-                    if asset_ids_result:
-                        await session.execute(
-                            delete(AssetValue).where(AssetValue.asset_id.in_(asset_ids_result))
-                        )
-                elif hasattr(model, "user_id"):
-                    await session.execute(delete(model).where(model.user_id == user_id))
-
-        await session.flush()
-
-        # 2. Insert new data (parents first)
-        existing_payees = set()
-        if "payees" not in data_map:
-            existing_payees = set(
-                str(id_val)
-                for id_val in (
-                    await session.execute(select(Payee.id).where(Payee.user_id == user_id))
-                )
-                .scalars()
-                .all()
-            )
-
-        existing_asset_groups = set()
-        if "asset_groups" not in data_map:
-            existing_asset_groups = set(
-                str(id_val)
-                for id_val in (
-                    await session.execute(
-                        select(AssetGroup.id).where(AssetGroup.user_id == user_id)
-                    )
-                )
-                .scalars()
-                .all()
-            )
-
-        existing_connections = set(
-            str(id_val)
-            for id_val in (
-                await session.execute(
-                    select(BankConnection.id).where(BankConnection.user_id == user_id)
-                )
-            )
-            .scalars()
-            .all()
-        )
-
-        for key, model in entity_order:
-            if key in data_map and data_map[key]:
-                items = []
-                for row in data_map[key]:
-                    # Convert datetimes, uuids and decimals back utilizing the central util function
-                    clean_row = deserialize_row(model, row)
-
-                    # Map imported data to the currently authenticated user
-                    if "user_id" in row:
-                        clean_row["user_id"] = user_id
-                    # Clean missing foreign keys for old backups
-                    if model == Transaction and "payees" not in data_map:
-                        if (
-                            clean_row.get("payee_id")
-                            and str(clean_row["payee_id"]) not in existing_payees
-                        ):
-                            clean_row["payee_id"] = None
-
-                    if model == Asset and "asset_groups" not in data_map:
-                        if (
-                            clean_row.get("group_id")
-                            and str(clean_row["group_id"]) not in existing_asset_groups
-                        ):
-                            clean_row["group_id"] = None
-
-                    # Clean up missing connection_ids across all models
-                    if hasattr(model, "connection_id") or "connection_id" in row:
-                        if (
-                            clean_row.get("connection_id")
-                            and str(clean_row["connection_id"]) not in existing_connections
-                        ):
-                            clean_row["connection_id"] = None
-
-                    items.append(model(**clean_row))
-
-                if items:
-                    session.add_all(items)
-                    await session.flush()
-
+        await restore_user_data(session, user.id, data_map)
         await session.commit()
     except Exception as e:
         await session.rollback()
         raise HTTPException(status_code=500, detail=f"Failed to restore backup: {str(e)}")
 
     return {"status": "success"}
+

--- a/backend/app/api/export.py
+++ b/backend/app/api/export.py
@@ -5,21 +5,25 @@ from datetime import date, datetime
 from decimal import Decimal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
-from sqlalchemy import select
+from sqlalchemy import select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import current_active_user
 from app.core.database import get_async_session
 from app.models.account import Account
 from app.models.asset import Asset
+from app.models.asset_group import AssetGroup
 from app.models.asset_value import AssetValue
 from app.models.budget import Budget
 from app.models.category import Category
 from app.models.category_group import CategoryGroup
+from app.models.goal import Goal
 from app.models.import_log import ImportLog
+from app.models.payee import Payee, PayeeMapping
 from app.models.recurring_transaction import RecurringTransaction
+from app.models.bank_connection import BankConnection
 from app.models.rule import Rule
 from app.models.transaction import Transaction
 from app.models.user import User
@@ -27,19 +31,7 @@ from app.models.user import User
 router = APIRouter(prefix="/api/export", tags=["export"])
 
 
-def _serialize(obj) -> dict:
-    """Convert a SQLAlchemy model instance to a JSON-serializable dict."""
-    d = {}
-    for col in obj.__table__.columns:
-        val = getattr(obj, col.key)
-        if isinstance(val, UUID):
-            val = str(val)
-        elif isinstance(val, (datetime, date)):
-            val = val.isoformat()
-        elif isinstance(val, Decimal):
-            val = str(val)
-        d[col.key] = val
-    return d
+from app.core.utils import serialize_model, deserialize_row
 
 
 @router.get("/backup")
@@ -50,20 +42,62 @@ async def backup(
     user_id = user.id
 
     # Query all entities for the current user
-    accounts = (await session.execute(select(Account).where(Account.user_id == user_id))).scalars().all()
-    transactions = (await session.execute(select(Transaction).where(Transaction.user_id == user_id))).scalars().all()
-    categories = (await session.execute(select(Category).where(Category.user_id == user_id))).scalars().all()
-    category_groups = (await session.execute(select(CategoryGroup).where(CategoryGroup.user_id == user_id))).scalars().all()
+    accounts = (
+        (await session.execute(select(Account).where(Account.user_id == user_id))).scalars().all()
+    )
+    transactions = (
+        (await session.execute(select(Transaction).where(Transaction.user_id == user_id)))
+        .scalars()
+        .all()
+    )
+    categories = (
+        (await session.execute(select(Category).where(Category.user_id == user_id))).scalars().all()
+    )
+    category_groups = (
+        (await session.execute(select(CategoryGroup).where(CategoryGroup.user_id == user_id)))
+        .scalars()
+        .all()
+    )
     rules = (await session.execute(select(Rule).where(Rule.user_id == user_id))).scalars().all()
-    recurring_transactions = (await session.execute(select(RecurringTransaction).where(RecurringTransaction.user_id == user_id))).scalars().all()
-    budgets = (await session.execute(select(Budget).where(Budget.user_id == user_id))).scalars().all()
+    recurring_transactions = (
+        (
+            await session.execute(
+                select(RecurringTransaction).where(RecurringTransaction.user_id == user_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    budgets = (
+        (await session.execute(select(Budget).where(Budget.user_id == user_id))).scalars().all()
+    )
     assets = (await session.execute(select(Asset).where(Asset.user_id == user_id))).scalars().all()
-    import_logs = (await session.execute(select(ImportLog).where(ImportLog.user_id == user_id))).scalars().all()
+    import_logs = (
+        (await session.execute(select(ImportLog).where(ImportLog.user_id == user_id)))
+        .scalars()
+        .all()
+    )
+    asset_groups = (
+        (await session.execute(select(AssetGroup).where(AssetGroup.user_id == user_id)))
+        .scalars()
+        .all()
+    )
+    goals = (await session.execute(select(Goal).where(Goal.user_id == user_id))).scalars().all()
+    payees = (await session.execute(select(Payee).where(Payee.user_id == user_id))).scalars().all()
+    payee_mappings = (
+        (await session.execute(select(PayeeMapping).where(PayeeMapping.user_id == user_id)))
+        .scalars()
+        .all()
+    )
 
     # AssetValue lacks user_id — filter via asset_ids
     asset_ids = [a.id for a in assets]
     if asset_ids:
-        asset_values = (await session.execute(select(AssetValue).where(AssetValue.asset_id.in_(asset_ids)))).scalars().all()
+        asset_values = (
+            (await session.execute(select(AssetValue).where(AssetValue.asset_id.in_(asset_ids))))
+            .scalars()
+            .all()
+        )
     else:
         asset_values = []
 
@@ -76,6 +110,10 @@ async def backup(
         "recurring_transactions": recurring_transactions,
         "budgets": budgets,
         "assets": assets,
+        "asset_groups": asset_groups,
+        "goals": goals,
+        "payees": payees,
+        "payee_mappings": payee_mappings,
         "asset_values": asset_values,
         "import_logs": import_logs,
     }
@@ -85,7 +123,7 @@ async def backup(
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         entity_counts = {}
         for name, rows in entities.items():
-            serialized = [_serialize(r) for r in rows]
+            serialized = [serialize_model(r) for r in rows]
             entity_counts[name] = len(serialized)
             zf.writestr(f"{name}.json", json.dumps(serialized, indent=2, ensure_ascii=False))
 
@@ -103,3 +141,143 @@ async def backup(
         media_type="application/zip",
         headers={"Content-Disposition": f'attachment; filename="securo-backup-{today}.zip"'},
     )
+
+
+@router.post("/restore")
+async def restore(
+    file: UploadFile = File(...),
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+):
+    try:
+        content = await file.read()
+        buf = io.BytesIO(content)
+        data_map = {}
+        with zipfile.ZipFile(buf, "r") as zf:
+            for name in zf.namelist():
+                if name.endswith(".json") and name != "metadata.json":
+                    entity_name = name[:-5]
+                    data_map[entity_name] = json.loads(zf.read(name))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid backup file: {str(e)}")
+
+    user_id = user.id
+
+    try:
+        entity_order = [
+            ("category_groups", CategoryGroup),
+            ("categories", Category),
+            ("accounts", Account),
+            ("payees", Payee),
+            ("payee_mappings", PayeeMapping),
+            ("asset_groups", AssetGroup),
+            ("assets", Asset),
+            ("asset_values", AssetValue),
+            ("transactions", Transaction),
+            ("recurring_transactions", RecurringTransaction),
+            ("rules", Rule),
+            ("budgets", Budget),
+            ("goals", Goal),
+            ("import_logs", ImportLog),
+        ]
+
+        # 1. Delete existing data (children first, reverse dependency order)
+        for key, model in reversed(entity_order):
+            if key in data_map:
+                if model == AssetValue:
+                    # Asset values are tied to assets via ids, not user_id directly
+                    asset_ids_result = (
+                        (await session.execute(select(Asset.id).where(Asset.user_id == user_id)))
+                        .scalars()
+                        .all()
+                    )
+                    if asset_ids_result:
+                        await session.execute(
+                            delete(AssetValue).where(AssetValue.asset_id.in_(asset_ids_result))
+                        )
+                elif hasattr(model, "user_id"):
+                    await session.execute(delete(model).where(model.user_id == user_id))
+
+        await session.flush()
+
+        # 2. Insert new data (parents first)
+        existing_payees = set()
+        if "payees" not in data_map:
+            existing_payees = set(
+                str(id_val)
+                for id_val in (
+                    await session.execute(select(Payee.id).where(Payee.user_id == user_id))
+                )
+                .scalars()
+                .all()
+            )
+
+        existing_asset_groups = set()
+        if "asset_groups" not in data_map:
+            existing_asset_groups = set(
+                str(id_val)
+                for id_val in (
+                    await session.execute(
+                        select(AssetGroup.id).where(AssetGroup.user_id == user_id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        existing_connections = set(
+            str(id_val)
+            for id_val in (
+                await session.execute(
+                    select(BankConnection.id).where(BankConnection.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        for key, model in entity_order:
+            if key in data_map and data_map[key]:
+                items = []
+                for row in data_map[key]:
+                    # Convert datetimes, uuids and decimals back utilizing the central util function
+                    clean_row = deserialize_row(model, row)
+
+                    # Map imported data to the currently authenticated user
+                    if "user_id" in row:
+                        clean_row["user_id"] = user_id
+                    # Clean missing foreign keys for old backups
+                    if model == Transaction and "payees" not in data_map:
+                        if (
+                            clean_row.get("payee_id")
+                            and str(clean_row["payee_id"]) not in existing_payees
+                        ):
+                            clean_row["payee_id"] = None
+
+                    if model == Asset and "asset_groups" not in data_map:
+                        if (
+                            clean_row.get("group_id")
+                            and str(clean_row["group_id"]) not in existing_asset_groups
+                        ):
+                            clean_row["group_id"] = None
+
+                    # Clean up missing connection_ids across all models
+                    if hasattr(model, "connection_id") or "connection_id" in row:
+                        if (
+                            clean_row.get("connection_id")
+                            and str(clean_row["connection_id"]) not in existing_connections
+                        ):
+                            clean_row["connection_id"] = None
+
+                    items.append(model(**clean_row))
+
+                if items:
+                    session.add_all(items)
+                    await session.flush()
+
+        await session.commit()
+    except Exception as e:
+        await session.rollback()
+        raise HTTPException(status_code=500, detail=f"Failed to restore backup: {str(e)}")
+
+    return {"status": "success"}

--- a/backend/app/core/utils.py
+++ b/backend/app/core/utils.py
@@ -1,0 +1,49 @@
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID
+
+def serialize_model(obj) -> dict:
+    """
+    Serializes an SQLAlchemy model instance into a JSON-compatible dictionary.
+    """
+    row = {}
+    for col in obj.__table__.columns:
+        val = getattr(obj, col.key)
+        if isinstance(val, UUID):
+            val = str(val)
+        elif hasattr(val, "isoformat"):  # datetime / date
+            val = val.isoformat()
+        elif isinstance(val, Decimal):
+            val = str(val)
+        row[col.key] = val
+    return row
+
+def deserialize_row(model, row_data: dict) -> dict:
+    """
+    Given an SQLAlchemy model and a dictionary of raw JSON data,
+    filters exactly out invalid keys and converts string values 
+    to the appropriate Python types (UUID, datetime, Decimal) based 
+    on the model's schema.
+    """
+    valid_keys = {c.key for c in model.__table__.columns}
+    clean_row = {k: v for k, v in row_data.items() if k in valid_keys}
+    
+    for k, v in list(clean_row.items()):
+        if v is None:
+            continue
+            
+        col_type = getattr(model.__table__.columns, k).type
+        try:
+            ptype = col_type.python_type
+            if ptype is datetime and isinstance(v, str):
+                clean_row[k] = datetime.fromisoformat(v.replace("Z", "+00:00"))
+            elif ptype is date and isinstance(v, str):
+                clean_row[k] = date.fromisoformat(v)
+            elif ptype is Decimal and not isinstance(v, Decimal):
+                clean_row[k] = Decimal(str(v))
+            elif ptype is UUID and isinstance(v, str):
+                clean_row[k] = UUID(v)
+        except NotImplementedError:
+            pass
+            
+    return clean_row

--- a/backend/app/core/utils.py
+++ b/backend/app/core/utils.py
@@ -1,12 +1,18 @@
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Any, TypeVar
 from uuid import UUID
 
-def serialize_model(obj) -> dict:
+from sqlalchemy.orm import DeclarativeBase
+
+T = TypeVar("T", bound=DeclarativeBase)
+
+
+def serialize_model(obj: T) -> dict[str, Any]:
     """
     Serializes an SQLAlchemy model instance into a JSON-compatible dictionary.
     """
-    row = {}
+    row: dict[str, Any] = {}
     for col in obj.__table__.columns:
         val = getattr(obj, col.key)
         if isinstance(val, UUID):
@@ -18,7 +24,8 @@ def serialize_model(obj) -> dict:
         row[col.key] = val
     return row
 
-def deserialize_row(model, row_data: dict) -> dict:
+
+def deserialize_row(model: type[T], row_data: dict[str, Any]) -> dict[str, Any]:
     """
     Given an SQLAlchemy model and a dictionary of raw JSON data,
     filters exactly out invalid keys and converts string values 
@@ -27,11 +34,11 @@ def deserialize_row(model, row_data: dict) -> dict:
     """
     valid_keys = {c.key for c in model.__table__.columns}
     clean_row = {k: v for k, v in row_data.items() if k in valid_keys}
-    
+
     for k, v in list(clean_row.items()):
         if v is None:
             continue
-            
+
         col_type = getattr(model.__table__.columns, k).type
         try:
             ptype = col_type.python_type
@@ -45,5 +52,7 @@ def deserialize_row(model, row_data: dict) -> dict:
                 clean_row[k] = UUID(v)
         except NotImplementedError:
             pass
-            
+
     return clean_row
+
+

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -139,16 +139,46 @@ class ExportService:
             "connections": existing_connections,
         }
 
-    async def _insert_new_user_data(self, data_map: dict[str, list[dict[str, Any]]], existing_keys: dict[str, set[str]]):
-        context = RestoreContext(self.user_id, data_map, existing_keys)
+    def _sanitize_row(self, model: type[DeclarativeBase], row: dict[str, Any], data_map: dict[str, list[dict[str, Any]]], existing_keys: dict[str, set[str]]) -> dict[str, Any]:
+        clean_row = deserialize_row(model, row)
+        restoring_without_payees = "payees" not in data_map
+        restoring_without_asset_groups = "asset_groups" not in data_map
 
+        has_user_id = "user_id" in row
+        if has_user_id:
+            clean_row["user_id"] = self.user_id
+
+        is_transaction_model = model == Transaction
+        if is_transaction_model and restoring_without_payees:
+            payee_uuid = clean_row.get("payee_id")
+            is_unresolved_payee = payee_uuid and str(payee_uuid) not in existing_keys["payees"]
+            if is_unresolved_payee:
+                clean_row["payee_id"] = None
+
+        is_asset_model = model == Asset
+        if is_asset_model and restoring_without_asset_groups:
+            group_uuid = clean_row.get("group_id")
+            is_unresolved_group = group_uuid and str(group_uuid) not in existing_keys["asset_groups"]
+            if is_unresolved_group:
+                clean_row["group_id"] = None
+
+        has_connection_id = hasattr(model, "connection_id") or "connection_id" in row
+        if has_connection_id:
+            connection_uuid = clean_row.get("connection_id")
+            is_unresolved_connection = connection_uuid and str(connection_uuid) not in existing_keys["connections"]
+            if is_unresolved_connection:
+                clean_row["connection_id"] = None
+
+        return clean_row
+
+    async def _insert_new_user_data(self, data_map: dict[str, list[dict[str, Any]]], existing_keys: dict[str, set[str]]):
         for key, model in EXPORT_MODELS_ORDER:
             requires_insertion = key in data_map and data_map[key]
             if not requires_insertion:
                 continue
 
             for row in data_map[key]:
-                clean_row = context.sanitize_row(model, row)
+                clean_row = self._sanitize_row(model, row, data_map, existing_keys)
                 await self.session.merge(model(**clean_row))
 
             await self.session.flush()
@@ -156,3 +186,4 @@ class ExportService:
     async def restore_data(self, data_map: dict[str, list[dict[str, Any]]]):
         existing_keys = await self._get_existing_foreign_keys(data_map)
         await self._insert_new_user_data(data_map, existing_keys)
+

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -2,10 +2,12 @@ import io
 import json
 import zipfile
 from datetime import datetime
+from typing import Any
 from uuid import UUID
 
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import DeclarativeBase
 
 from app.core.utils import deserialize_row, serialize_model
 from app.models.account import Account
@@ -23,13 +25,10 @@ from app.models.recurring_transaction import RecurringTransaction
 from app.models.rule import Rule
 from app.models.transaction import Transaction
 
-EXPORT_FORMAT_VERSION = "1.0"
-JSON_EXT = ".json"
-
 # Order is crucial: children must be deleted before parents,
 # and parents must be inserted before children.
 # This list is in INSERT order (parents first).
-EXPORT_MODELS_ORDER = [
+EXPORT_MODELS_ORDER: list[tuple[str, type[DeclarativeBase]]] = [
     ("category_groups", CategoryGroup),
     ("categories", Category),
     ("accounts", Account),
@@ -47,9 +46,49 @@ EXPORT_MODELS_ORDER = [
 ]
 
 
+class BackupArchiveHandler:
+    """Manages the packaging and unpacking of Backup ZIP archives."""
+
+    EXPORT_FORMAT_VERSION = "1.0"
+    JSON_EXT = ".json"
+
+    @classmethod
+    def create_zip_archive(cls, entities: dict[str, list[DeclarativeBase]]) -> io.BytesIO:
+        """Packages entities into a single compressed ZIP archive with a metadata index."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            entity_counts: dict[str, int] = {}
+            for name, rows in entities.items():
+                serialized = [serialize_model(r) for r in rows]
+                entity_counts[name] = len(serialized)
+                zf.writestr(f"{name}{cls.JSON_EXT}", json.dumps(serialized, indent=2, ensure_ascii=False))
+
+            metadata = {
+                "export_date": datetime.utcnow().isoformat(),
+                "format_version": cls.EXPORT_FORMAT_VERSION,
+                "entity_counts": entity_counts,
+            }
+            zf.writestr(f"metadata{cls.JSON_EXT}", json.dumps(metadata, indent=2, ensure_ascii=False))
+
+        buf.seek(0)
+        return buf
+
+    @classmethod
+    def parse_import_zip(cls, content: bytes) -> dict[str, list[dict[str, Any]]]:
+        """Reads a zip archive payload and evaluates strictly valid json entities."""
+        buf = io.BytesIO(content)
+        data_map: dict[str, list[dict[str, Any]]] = {}
+        with zipfile.ZipFile(buf, "r") as zf:
+            for name in zf.namelist():
+                if name.endswith(cls.JSON_EXT) and name != f"metadata{cls.JSON_EXT}":
+                    entity_name = name[: -len(cls.JSON_EXT)]
+                    data_map[entity_name] = json.loads(zf.read(name))
+        return data_map
+
+
 async def export_user_data(session: AsyncSession, user_id: UUID) -> io.BytesIO:
     """Extracts all user-related data from the database into structured zip bytes."""
-    entities = {}
+    entities: dict[str, list[DeclarativeBase]] = {}
 
     for key, model in EXPORT_MODELS_ORDER:
         if model == AssetValue:
@@ -69,57 +108,24 @@ async def export_user_data(session: AsyncSession, user_id: UUID) -> io.BytesIO:
                 .all()
             )
 
-    return _create_zip_archive(entities)
+    return BackupArchiveHandler.create_zip_archive(entities)
 
 
-def _create_zip_archive(entities: dict) -> io.BytesIO:
-    """Packages entities into a single compressed ZIP archive with a metadata index."""
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        entity_counts = {}
-        for name, rows in entities.items():
-            serialized = [serialize_model(r) for r in rows]
-            entity_counts[name] = len(serialized)
-            zf.writestr(f"{name}{JSON_EXT}", json.dumps(serialized, indent=2, ensure_ascii=False))
-
-        metadata = {
-            "export_date": datetime.utcnow().isoformat(),
-            "format_version": EXPORT_FORMAT_VERSION,
-            "entity_counts": entity_counts,
-        }
-        zf.writestr(f"metadata{JSON_EXT}", json.dumps(metadata, indent=2, ensure_ascii=False))
-
-    buf.seek(0)
-    return buf
-
-
-def parse_import_zip(content: bytes) -> dict:
-    """Reads a zip archive payload and evaluates strictly valid json entities."""
-    buf = io.BytesIO(content)
-    data_map = {}
-    with zipfile.ZipFile(buf, "r") as zf:
-        for name in zf.namelist():
-            if name.endswith(JSON_EXT) and name != f"metadata{JSON_EXT}":
-                entity_name = name[: -len(JSON_EXT)]
-                data_map[entity_name] = json.loads(zf.read(name))
-    return data_map
-
-
-async def _get_existing_foreign_keys(session: AsyncSession, user_id: UUID, data_map: dict) -> dict:
-    existing_payees = set()
+async def _get_existing_foreign_keys(session: AsyncSession, user_id: UUID, data_map: dict[str, list[dict[str, Any]]]) -> dict[str, set[str]]:
+    existing_payees: set[str] = set()
     is_missing_payees = "payees" not in data_map
     if is_missing_payees:
         payee_ids = await session.execute(select(Payee.id).where(Payee.user_id == user_id))
         existing_payees = {str(pid) for pid in payee_ids.scalars().all()}
 
-    existing_asset_groups = set()
+    existing_asset_groups: set[str] = set()
     is_missing_asset_groups = "asset_groups" not in data_map
     if is_missing_asset_groups:
         group_ids = await session.execute(select(AssetGroup.id).where(AssetGroup.user_id == user_id))
         existing_asset_groups = {str(gid) for gid in group_ids.scalars().all()}
 
     connection_ids = await session.execute(select(BankConnection.id).where(BankConnection.user_id == user_id))
-    existing_connections = {str(cid) for cid in connection_ids.scalars().all()}
+    existing_connections: set[str] = {str(cid) for cid in connection_ids.scalars().all()}
 
     return {
         "payees": existing_payees,
@@ -129,7 +135,7 @@ async def _get_existing_foreign_keys(session: AsyncSession, user_id: UUID, data_
 
 
 class RestoreContext:
-    def __init__(self, user_id: UUID, data_map: dict, existing_keys: dict):
+    def __init__(self, user_id: UUID, data_map: dict[str, list[dict[str, Any]]], existing_keys: dict[str, set[str]]):
         self.user_id = user_id
         self.data_map = data_map
         self.existing_keys = existing_keys
@@ -137,7 +143,7 @@ class RestoreContext:
         self.restoring_without_payees = "payees" not in data_map
         self.restoring_without_asset_groups = "asset_groups" not in data_map
 
-    def sanitize_row(self, model, row: dict) -> dict:
+    def sanitize_row(self, model: type[DeclarativeBase], row: dict[str, Any]) -> dict[str, Any]:
         clean_row = deserialize_row(model, row)
 
         has_user_id = "user_id" in row
@@ -168,7 +174,7 @@ class RestoreContext:
         return clean_row
 
 
-async def _insert_new_user_data(session: AsyncSession, user_id: UUID, data_map: dict, existing_keys: dict):
+async def _insert_new_user_data(session: AsyncSession, user_id: UUID, data_map: dict[str, list[dict[str, Any]]], existing_keys: dict[str, set[str]]):
     context = RestoreContext(user_id, data_map, existing_keys)
 
     for key, model in EXPORT_MODELS_ORDER:
@@ -183,6 +189,6 @@ async def _insert_new_user_data(session: AsyncSession, user_id: UUID, data_map: 
         await session.flush()
 
 
-async def restore_user_data(session: AsyncSession, user_id: UUID, data_map: dict):
+async def restore_user_data(session: AsyncSession, user_id: UUID, data_map: dict[str, list[dict[str, Any]]]):
     existing_keys = await _get_existing_foreign_keys(session, user_id, data_map)
     await _insert_new_user_data(session, user_id, data_map, existing_keys)

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -61,7 +61,7 @@ class BackupArchiveHandler:
                 serialized = []
                 for r in rows:
                     d = serialize_model(r)
-                    # Remove connection_id de Account, Asset e AssetGroup
+                    # Remove connection_id from Account, Asset and AssetGroup
                     if name in {"accounts", "assets", "asset_groups"}:
                         d.pop("connection_id", None)
                     serialized.append(d)
@@ -135,7 +135,6 @@ class ExportService:
     async def _get_existing_foreign_keys(
         self, data_map: dict[str, list[dict[str, Any]]]
     ) -> dict[str, set[str]]:
-        # Busca todos os IDs válidos do usuário para cada FK relevante
         async def get_ids(model):
             ids = await self.session.execute(select(model.id).where(model.user_id == self.user_id))
             return {str(i) for i in ids.scalars().all()}

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -1,0 +1,188 @@
+import io
+import json
+import zipfile
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.utils import deserialize_row, serialize_model
+from app.models.account import Account
+from app.models.asset import Asset
+from app.models.asset_group import AssetGroup
+from app.models.asset_value import AssetValue
+from app.models.bank_connection import BankConnection
+from app.models.budget import Budget
+from app.models.category import Category
+from app.models.category_group import CategoryGroup
+from app.models.goal import Goal
+from app.models.import_log import ImportLog
+from app.models.payee import Payee, PayeeMapping
+from app.models.recurring_transaction import RecurringTransaction
+from app.models.rule import Rule
+from app.models.transaction import Transaction
+
+EXPORT_FORMAT_VERSION = "1.0"
+JSON_EXT = ".json"
+
+# Order is crucial: children must be deleted before parents,
+# and parents must be inserted before children.
+# This list is in INSERT order (parents first).
+EXPORT_MODELS_ORDER = [
+    ("category_groups", CategoryGroup),
+    ("categories", Category),
+    ("accounts", Account),
+    ("payees", Payee),
+    ("payee_mappings", PayeeMapping),
+    ("asset_groups", AssetGroup),
+    ("assets", Asset),
+    ("asset_values", AssetValue),
+    ("transactions", Transaction),
+    ("recurring_transactions", RecurringTransaction),
+    ("rules", Rule),
+    ("budgets", Budget),
+    ("goals", Goal),
+    ("import_logs", ImportLog),
+]
+
+
+async def export_user_data(session: AsyncSession, user_id: UUID) -> io.BytesIO:
+    """Extracts all user-related data from the database into structured zip bytes."""
+    entities = {}
+
+    for key, model in EXPORT_MODELS_ORDER:
+        if model == AssetValue:
+            asset_ids = [a.id for a in entities.get("assets", [])]
+            if asset_ids:
+                entities[key] = (
+                    (await session.execute(select(AssetValue).where(AssetValue.asset_id.in_(asset_ids))))
+                    .scalars()
+                    .all()
+                )
+            else:
+                entities[key] = []
+        else:
+            entities[key] = (
+                (await session.execute(select(model).where(model.user_id == user_id)))
+                .scalars()
+                .all()
+            )
+
+    return _create_zip_archive(entities)
+
+
+def _create_zip_archive(entities: dict) -> io.BytesIO:
+    """Packages entities into a single compressed ZIP archive with a metadata index."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        entity_counts = {}
+        for name, rows in entities.items():
+            serialized = [serialize_model(r) for r in rows]
+            entity_counts[name] = len(serialized)
+            zf.writestr(f"{name}{JSON_EXT}", json.dumps(serialized, indent=2, ensure_ascii=False))
+
+        metadata = {
+            "export_date": datetime.utcnow().isoformat(),
+            "format_version": EXPORT_FORMAT_VERSION,
+            "entity_counts": entity_counts,
+        }
+        zf.writestr(f"metadata{JSON_EXT}", json.dumps(metadata, indent=2, ensure_ascii=False))
+
+    buf.seek(0)
+    return buf
+
+
+def parse_import_zip(content: bytes) -> dict:
+    """Reads a zip archive payload and evaluates strictly valid json entities."""
+    buf = io.BytesIO(content)
+    data_map = {}
+    with zipfile.ZipFile(buf, "r") as zf:
+        for name in zf.namelist():
+            if name.endswith(JSON_EXT) and name != f"metadata{JSON_EXT}":
+                entity_name = name[: -len(JSON_EXT)]
+                data_map[entity_name] = json.loads(zf.read(name))
+    return data_map
+
+
+async def _get_existing_foreign_keys(session: AsyncSession, user_id: UUID, data_map: dict) -> dict:
+    existing_payees = set()
+    is_missing_payees = "payees" not in data_map
+    if is_missing_payees:
+        payee_ids = await session.execute(select(Payee.id).where(Payee.user_id == user_id))
+        existing_payees = {str(pid) for pid in payee_ids.scalars().all()}
+
+    existing_asset_groups = set()
+    is_missing_asset_groups = "asset_groups" not in data_map
+    if is_missing_asset_groups:
+        group_ids = await session.execute(select(AssetGroup.id).where(AssetGroup.user_id == user_id))
+        existing_asset_groups = {str(gid) for gid in group_ids.scalars().all()}
+
+    connection_ids = await session.execute(select(BankConnection.id).where(BankConnection.user_id == user_id))
+    existing_connections = {str(cid) for cid in connection_ids.scalars().all()}
+
+    return {
+        "payees": existing_payees,
+        "asset_groups": existing_asset_groups,
+        "connections": existing_connections,
+    }
+
+
+class RestoreContext:
+    def __init__(self, user_id: UUID, data_map: dict, existing_keys: dict):
+        self.user_id = user_id
+        self.data_map = data_map
+        self.existing_keys = existing_keys
+        
+        self.restoring_without_payees = "payees" not in data_map
+        self.restoring_without_asset_groups = "asset_groups" not in data_map
+
+    def sanitize_row(self, model, row: dict) -> dict:
+        clean_row = deserialize_row(model, row)
+
+        has_user_id = "user_id" in row
+        if has_user_id:
+            clean_row["user_id"] = self.user_id
+
+        is_transaction_model = model == Transaction
+        if is_transaction_model and self.restoring_without_payees:
+            payee_uuid = clean_row.get("payee_id")
+            is_unresolved_payee = payee_uuid and str(payee_uuid) not in self.existing_keys["payees"]
+            if is_unresolved_payee:
+                clean_row["payee_id"] = None
+
+        is_asset_model = model == Asset
+        if is_asset_model and self.restoring_without_asset_groups:
+            group_uuid = clean_row.get("group_id")
+            is_unresolved_group = group_uuid and str(group_uuid) not in self.existing_keys["asset_groups"]
+            if is_unresolved_group:
+                clean_row["group_id"] = None
+
+        has_connection_id = hasattr(model, "connection_id") or "connection_id" in row
+        if has_connection_id:
+            connection_uuid = clean_row.get("connection_id")
+            is_unresolved_connection = connection_uuid and str(connection_uuid) not in self.existing_keys["connections"]
+            if is_unresolved_connection:
+                clean_row["connection_id"] = None
+
+        return clean_row
+
+
+async def _insert_new_user_data(session: AsyncSession, user_id: UUID, data_map: dict, existing_keys: dict):
+    context = RestoreContext(user_id, data_map, existing_keys)
+
+    for key, model in EXPORT_MODELS_ORDER:
+        requires_insertion = key in data_map and data_map[key]
+        if not requires_insertion:
+            continue
+
+        for row in data_map[key]:
+            clean_row = context.sanitize_row(model, row)
+            await session.merge(model(**clean_row))
+
+        await session.flush()
+
+
+async def restore_user_data(session: AsyncSession, user_id: UUID, data_map: dict):
+    existing_keys = await _get_existing_foreign_keys(session, user_id, data_map)
+    await _insert_new_user_data(session, user_id, data_map, existing_keys)

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -86,109 +86,73 @@ class BackupArchiveHandler:
         return data_map
 
 
-async def export_user_data(session: AsyncSession, user_id: UUID) -> io.BytesIO:
-    """Extracts all user-related data from the database into structured zip bytes."""
-    entities: dict[str, list[DeclarativeBase]] = {}
+class ExportService:
+    """Service layer for securely exporting and incrementally merging (upserting) native User database models."""
 
-    for key, model in EXPORT_MODELS_ORDER:
-        if model == AssetValue:
-            asset_ids = [a.id for a in entities.get("assets", [])]
-            if asset_ids:
+    def __init__(self, session: AsyncSession, user_id: UUID):
+        self.session = session
+        self.user_id = user_id
+
+    async def export_data(self) -> io.BytesIO:
+        """Extracts all user-related data from the database into structured zip bytes."""
+        entities: dict[str, list[DeclarativeBase]] = {}
+
+        for key, model in EXPORT_MODELS_ORDER:
+            if model == AssetValue:
+                asset_ids = [a.id for a in entities.get("assets", [])]
+                if asset_ids:
+                    entities[key] = (
+                        (await self.session.execute(select(AssetValue).where(AssetValue.asset_id.in_(asset_ids))))
+                        .scalars()
+                        .all()
+                    )
+                else:
+                    entities[key] = []
+            else:
                 entities[key] = (
-                    (await session.execute(select(AssetValue).where(AssetValue.asset_id.in_(asset_ids))))
+                    (await self.session.execute(select(model).where(model.user_id == self.user_id)))
                     .scalars()
                     .all()
                 )
-            else:
-                entities[key] = []
-        else:
-            entities[key] = (
-                (await session.execute(select(model).where(model.user_id == user_id)))
-                .scalars()
-                .all()
-            )
 
-    return BackupArchiveHandler.create_zip_archive(entities)
+        return BackupArchiveHandler.create_zip_archive(entities)
 
+    async def _get_existing_foreign_keys(self, data_map: dict[str, list[dict[str, Any]]]) -> dict[str, set[str]]:
+        existing_payees: set[str] = set()
+        is_missing_payees = "payees" not in data_map
+        if is_missing_payees:
+            payee_ids = await self.session.execute(select(Payee.id).where(Payee.user_id == self.user_id))
+            existing_payees = {str(pid) for pid in payee_ids.scalars().all()}
 
-async def _get_existing_foreign_keys(session: AsyncSession, user_id: UUID, data_map: dict[str, list[dict[str, Any]]]) -> dict[str, set[str]]:
-    existing_payees: set[str] = set()
-    is_missing_payees = "payees" not in data_map
-    if is_missing_payees:
-        payee_ids = await session.execute(select(Payee.id).where(Payee.user_id == user_id))
-        existing_payees = {str(pid) for pid in payee_ids.scalars().all()}
+        existing_asset_groups: set[str] = set()
+        is_missing_asset_groups = "asset_groups" not in data_map
+        if is_missing_asset_groups:
+            group_ids = await self.session.execute(select(AssetGroup.id).where(AssetGroup.user_id == self.user_id))
+            existing_asset_groups = {str(gid) for gid in group_ids.scalars().all()}
 
-    existing_asset_groups: set[str] = set()
-    is_missing_asset_groups = "asset_groups" not in data_map
-    if is_missing_asset_groups:
-        group_ids = await session.execute(select(AssetGroup.id).where(AssetGroup.user_id == user_id))
-        existing_asset_groups = {str(gid) for gid in group_ids.scalars().all()}
+        connection_ids = await self.session.execute(select(BankConnection.id).where(BankConnection.user_id == self.user_id))
+        existing_connections: set[str] = {str(cid) for cid in connection_ids.scalars().all()}
 
-    connection_ids = await session.execute(select(BankConnection.id).where(BankConnection.user_id == user_id))
-    existing_connections: set[str] = {str(cid) for cid in connection_ids.scalars().all()}
+        return {
+            "payees": existing_payees,
+            "asset_groups": existing_asset_groups,
+            "connections": existing_connections,
+        }
 
-    return {
-        "payees": existing_payees,
-        "asset_groups": existing_asset_groups,
-        "connections": existing_connections,
-    }
+    async def _insert_new_user_data(self, data_map: dict[str, list[dict[str, Any]]], existing_keys: dict[str, set[str]]):
+        context = RestoreContext(self.user_id, data_map, existing_keys)
 
+        for key, model in EXPORT_MODELS_ORDER:
+            requires_insertion = key in data_map and data_map[key]
+            if not requires_insertion:
+                continue
 
-class RestoreContext:
-    def __init__(self, user_id: UUID, data_map: dict[str, list[dict[str, Any]]], existing_keys: dict[str, set[str]]):
-        self.user_id = user_id
-        self.data_map = data_map
-        self.existing_keys = existing_keys
-        
-        self.restoring_without_payees = "payees" not in data_map
-        self.restoring_without_asset_groups = "asset_groups" not in data_map
+            for row in data_map[key]:
+                clean_row = context.sanitize_row(model, row)
+                await self.session.merge(model(**clean_row))
 
-    def sanitize_row(self, model: type[DeclarativeBase], row: dict[str, Any]) -> dict[str, Any]:
-        clean_row = deserialize_row(model, row)
+            await self.session.flush()
 
-        has_user_id = "user_id" in row
-        if has_user_id:
-            clean_row["user_id"] = self.user_id
-
-        is_transaction_model = model == Transaction
-        if is_transaction_model and self.restoring_without_payees:
-            payee_uuid = clean_row.get("payee_id")
-            is_unresolved_payee = payee_uuid and str(payee_uuid) not in self.existing_keys["payees"]
-            if is_unresolved_payee:
-                clean_row["payee_id"] = None
-
-        is_asset_model = model == Asset
-        if is_asset_model and self.restoring_without_asset_groups:
-            group_uuid = clean_row.get("group_id")
-            is_unresolved_group = group_uuid and str(group_uuid) not in self.existing_keys["asset_groups"]
-            if is_unresolved_group:
-                clean_row["group_id"] = None
-
-        has_connection_id = hasattr(model, "connection_id") or "connection_id" in row
-        if has_connection_id:
-            connection_uuid = clean_row.get("connection_id")
-            is_unresolved_connection = connection_uuid and str(connection_uuid) not in self.existing_keys["connections"]
-            if is_unresolved_connection:
-                clean_row["connection_id"] = None
-
-        return clean_row
-
-
-async def _insert_new_user_data(session: AsyncSession, user_id: UUID, data_map: dict[str, list[dict[str, Any]]], existing_keys: dict[str, set[str]]):
-    context = RestoreContext(user_id, data_map, existing_keys)
-
-    for key, model in EXPORT_MODELS_ORDER:
-        requires_insertion = key in data_map and data_map[key]
-        if not requires_insertion:
-            continue
-
-        for row in data_map[key]:
-            clean_row = context.sanitize_row(model, row)
-            await session.merge(model(**clean_row))
-
-        await session.flush()
-
-
-async def restore_user_data(session: AsyncSession, user_id: UUID, data_map: dict[str, list[dict[str, Any]]]):
-    existing_keys = await _get_existing_foreign_keys(session, user_id, data_map)
-    await _insert_new_user_data(session, user_id, data_map, existing_keys)
+    async def restore_data(self, data_map: dict[str, list[dict[str, Any]]]):
+        existing_keys = await self._get_existing_foreign_keys(data_map)
+        await self._insert_new_user_data(data_map, existing_keys)

--- a/backend/app/services/export_service.py
+++ b/backend/app/services/export_service.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.core.utils import deserialize_row, serialize_model
 from app.models.account import Account
@@ -25,9 +26,7 @@ from app.models.recurring_transaction import RecurringTransaction
 from app.models.rule import Rule
 from app.models.transaction import Transaction
 
-# Order is crucial: children must be deleted before parents,
-# and parents must be inserted before children.
-# This list is in INSERT order (parents first).
+# IMPORTANT: The order matters. Parents must be inserted before children.
 EXPORT_MODELS_ORDER: list[tuple[str, type[DeclarativeBase]]] = [
     ("category_groups", CategoryGroup),
     ("categories", Category),
@@ -59,16 +58,28 @@ class BackupArchiveHandler:
         with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
             entity_counts: dict[str, int] = {}
             for name, rows in entities.items():
-                serialized = [serialize_model(r) for r in rows]
+                serialized = []
+                for r in rows:
+                    d = serialize_model(r)
+                    # Remove connection_id de Account, Asset e AssetGroup
+                    if name in {"accounts", "assets", "asset_groups"}:
+                        d.pop("connection_id", None)
+                    serialized.append(d)
                 entity_counts[name] = len(serialized)
-                zf.writestr(f"{name}{cls.JSON_EXT}", json.dumps(serialized, indent=2, ensure_ascii=False))
+                zf.writestr(
+                    f"{name}{cls.JSON_EXT}",
+                    json.dumps(serialized, indent=2, ensure_ascii=False),
+                )
 
             metadata = {
                 "export_date": datetime.utcnow().isoformat(),
                 "format_version": cls.EXPORT_FORMAT_VERSION,
                 "entity_counts": entity_counts,
             }
-            zf.writestr(f"metadata{cls.JSON_EXT}", json.dumps(metadata, indent=2, ensure_ascii=False))
+            zf.writestr(
+                f"metadata{cls.JSON_EXT}",
+                json.dumps(metadata, indent=2, ensure_ascii=False),
+            )
 
         buf.seek(0)
         return buf
@@ -102,7 +113,11 @@ class ExportService:
                 asset_ids = [a.id for a in entities.get("assets", [])]
                 if asset_ids:
                     entities[key] = (
-                        (await self.session.execute(select(AssetValue).where(AssetValue.asset_id.in_(asset_ids))))
+                        (
+                            await self.session.execute(
+                                select(AssetValue).where(AssetValue.asset_id.in_(asset_ids))
+                            )
+                        )
                         .scalars()
                         .all()
                     )
@@ -117,73 +132,90 @@ class ExportService:
 
         return BackupArchiveHandler.create_zip_archive(entities)
 
-    async def _get_existing_foreign_keys(self, data_map: dict[str, list[dict[str, Any]]]) -> dict[str, set[str]]:
-        existing_payees: set[str] = set()
-        is_missing_payees = "payees" not in data_map
-        if is_missing_payees:
-            payee_ids = await self.session.execute(select(Payee.id).where(Payee.user_id == self.user_id))
-            existing_payees = {str(pid) for pid in payee_ids.scalars().all()}
+    async def _get_existing_foreign_keys(
+        self, data_map: dict[str, list[dict[str, Any]]]
+    ) -> dict[str, set[str]]:
+        # Busca todos os IDs válidos do usuário para cada FK relevante
+        async def get_ids(model):
+            ids = await self.session.execute(select(model.id).where(model.user_id == self.user_id))
+            return {str(i) for i in ids.scalars().all()}
 
-        existing_asset_groups: set[str] = set()
-        is_missing_asset_groups = "asset_groups" not in data_map
-        if is_missing_asset_groups:
-            group_ids = await self.session.execute(select(AssetGroup.id).where(AssetGroup.user_id == self.user_id))
-            existing_asset_groups = {str(gid) for gid in group_ids.scalars().all()}
-
-        connection_ids = await self.session.execute(select(BankConnection.id).where(BankConnection.user_id == self.user_id))
-        existing_connections: set[str] = {str(cid) for cid in connection_ids.scalars().all()}
+        payees = await get_ids(Payee)
+        asset_groups = await get_ids(AssetGroup)
+        category_groups = await get_ids(CategoryGroup)
+        accounts = await get_ids(Account)
+        categories = await get_ids(Category)
+        assets = await get_ids(Asset)
+        bank_connections = await get_ids(BankConnection)
 
         return {
-            "payees": existing_payees,
-            "asset_groups": existing_asset_groups,
-            "connections": existing_connections,
+            "payees": payees,
+            "asset_groups": asset_groups,
+            "category_groups": category_groups,
+            "accounts": accounts,
+            "categories": categories,
+            "assets": assets,
+            "connections": bank_connections,
         }
 
-    def _sanitize_row(self, model: type[DeclarativeBase], row: dict[str, Any], data_map: dict[str, list[dict[str, Any]]], existing_keys: dict[str, set[str]]) -> dict[str, Any]:
+    def _sanitize_row(
+        self,
+        model: type[DeclarativeBase],
+        row: dict[str, Any],
+        data_map: dict[str, list[dict[str, Any]]],
+        existing_keys: dict[str, set[str]],
+    ) -> dict[str, Any]:
         clean_row = deserialize_row(model, row)
-        restoring_without_payees = "payees" not in data_map
-        restoring_without_asset_groups = "asset_groups" not in data_map
-
-        has_user_id = "user_id" in row
-        if has_user_id:
+        # Always overwrite user_id to ensure data consistency
+        if "user_id" in row:
             clean_row["user_id"] = self.user_id
 
-        is_transaction_model = model == Transaction
-        if is_transaction_model and restoring_without_payees:
-            payee_uuid = clean_row.get("payee_id")
-            is_unresolved_payee = payee_uuid and str(payee_uuid) not in existing_keys["payees"]
-            if is_unresolved_payee:
-                clean_row["payee_id"] = None
-
-        is_asset_model = model == Asset
-        if is_asset_model and restoring_without_asset_groups:
-            group_uuid = clean_row.get("group_id")
-            is_unresolved_group = group_uuid and str(group_uuid) not in existing_keys["asset_groups"]
-            if is_unresolved_group:
-                clean_row["group_id"] = None
-
-        has_connection_id = hasattr(model, "connection_id") or "connection_id" in row
-        if has_connection_id:
-            connection_uuid = clean_row.get("connection_id")
-            is_unresolved_connection = connection_uuid and str(connection_uuid) not in existing_keys["connections"]
-            if is_unresolved_connection:
-                clean_row["connection_id"] = None
+        # MAINTENANCE: If you add new models or foreign key fields, update this map to ensure all FKs are validated for user ownership.
+        # This is critical for multi-user security and data integrity in backup/restore.
+        fk_map = {
+            "account_id": "accounts",
+            "category_id": "categories",
+            "asset_id": "assets",
+            "group_id": "asset_groups" if model.__name__ == "Asset" else "category_groups",
+            "payee_id": "payees",
+            "connection_id": "connections",
+        }
+        for fk_field, key_set in fk_map.items():
+            if fk_field in clean_row and clean_row[fk_field] is not None:
+                if fk_field == "group_id" and model.__name__ != "Asset":
+                    key_set = "category_groups"
+                if str(clean_row[fk_field]) not in existing_keys.get(key_set, set()):
+                    clean_row[fk_field] = None
 
         return clean_row
 
-    async def _insert_new_user_data(self, data_map: dict[str, list[dict[str, Any]]], existing_keys: dict[str, set[str]]):
+    async def _insert_new_user_data(
+        self,
+        data_map: dict[str, list[dict[str, Any]]],
+        existing_keys: dict[str, set[str]],
+    ):
         for key, model in EXPORT_MODELS_ORDER:
-            requires_insertion = key in data_map and data_map[key]
-            if not requires_insertion:
+            if key not in data_map or not data_map[key]:
                 continue
 
-            for row in data_map[key]:
-                clean_row = self._sanitize_row(model, row, data_map, existing_keys)
-                await self.session.merge(model(**clean_row))
+            pk_columns = [col.name for col in model.__table__.primary_key.columns]
+            if not pk_columns:
+                continue
 
-            await self.session.flush()
+            stmt = (
+                pg_insert(model)
+                .values(
+                    [
+                        self._sanitize_row(model, row, data_map, existing_keys)
+                        for row in data_map[key]
+                    ]
+                )
+                .on_conflict_do_nothing(index_elements=pk_columns)
+            )
+            await self.session.execute(stmt)
+
+        await self.session.flush()
 
     async def restore_data(self, data_map: dict[str, list[dict[str, Any]]]):
         existing_keys = await self._get_existing_foreign_keys(data_map)
         await self._insert_new_user_data(data_map, existing_keys)
-

--- a/backend/tests/test_export_api.py
+++ b/backend/tests/test_export_api.py
@@ -142,3 +142,39 @@ async def test_backup_metadata_structure(client: AsyncClient, auth_headers):
         assert "export_date" in meta
         assert meta["format_version"] == "1.0"
         assert "entity_counts" in meta
+
+@pytest.mark.asyncio
+async def test_restore_backup_invalid_file(client: AsyncClient, auth_headers):
+    files = {"file": ("backup.txt", b"not a zip file", "text/plain")}
+    resp = await client.post("/api/export/restore", headers=auth_headers, files=files)
+    assert resp.status_code == 400
+    assert "Invalid backup file" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_restore_backup_success(client: AsyncClient, auth_headers, session: AsyncSession, test_user: User):
+    # First create a valid backup structure in memory
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        metadata = {
+            "export_date": datetime.utcnow().isoformat(),
+            "format_version": "1.0",
+            "entity_counts": {"accounts": 1}
+        }
+        zf.writestr("metadata.json", json.dumps(metadata))
+        
+        accounts_data = [{
+            "id": str(uuid.uuid4()),
+            "user_id": str(uuid.uuid4()),  # Testing if remapping user_id works
+            "name": "Test Restored Account",
+            "type": "Checking",
+            "currency": "USD"
+        }]
+        zf.writestr("accounts.json", json.dumps(accounts_data))
+
+    buf.seek(0)
+    files = {"file": ("backup.zip", buf.getvalue(), "application/zip")}
+    
+    resp = await client.post("/api/export/restore", headers=auth_headers, files=files)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"

--- a/backend/tests/test_export_api.py
+++ b/backend/tests/test_export_api.py
@@ -2,7 +2,7 @@ import io
 import json
 import uuid
 import zipfile
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 
 import pytest
@@ -104,17 +104,26 @@ async def test_backup_with_data(
 
 @pytest.mark.asyncio
 async def test_backup_with_assets(
-    client: AsyncClient, auth_headers, session: AsyncSession, test_user: User,
+    client: AsyncClient,
+    auth_headers,
+    session: AsyncSession,
+    test_user: User,
 ):
     asset = Asset(
-        id=uuid.uuid4(), user_id=test_user.id, name="Export Asset",
-        type="other", currency="BRL", purchase_price=Decimal("1000"),
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        name="Export Asset",
+        type="other",
+        currency="BRL",
+        purchase_price=Decimal("1000"),
     )
     session.add(asset)
     await session.flush()
     av = AssetValue(
-        id=uuid.uuid4(), asset_id=asset.id,
-        amount=Decimal("1200"), date=date.today(),
+        id=uuid.uuid4(),
+        asset_id=asset.id,
+        amount=Decimal("1200"),
+        date=date.today(),
     )
     session.add(av)
     await session.commit()
@@ -143,6 +152,7 @@ async def test_backup_metadata_structure(client: AsyncClient, auth_headers):
         assert meta["format_version"] == "1.0"
         assert "entity_counts" in meta
 
+
 @pytest.mark.asyncio
 async def test_restore_backup_invalid_file(client: AsyncClient, auth_headers):
     files = {"file": ("backup.txt", b"not a zip file", "text/plain")}
@@ -152,29 +162,33 @@ async def test_restore_backup_invalid_file(client: AsyncClient, auth_headers):
 
 
 @pytest.mark.asyncio
-async def test_restore_backup_success(client: AsyncClient, auth_headers, session: AsyncSession, test_user: User):
+async def test_restore_backup_success(
+    client: AsyncClient, auth_headers, session: AsyncSession, test_user: User
+):
     # First create a valid backup structure in memory
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         metadata = {
             "export_date": datetime.utcnow().isoformat(),
             "format_version": "1.0",
-            "entity_counts": {"accounts": 1}
+            "entity_counts": {"accounts": 1},
         }
         zf.writestr("metadata.json", json.dumps(metadata))
-        
-        accounts_data = [{
-            "id": str(uuid.uuid4()),
-            "user_id": str(uuid.uuid4()),  # Testing if remapping user_id works
-            "name": "Test Restored Account",
-            "type": "Checking",
-            "currency": "USD"
-        }]
+
+        accounts_data = [
+            {
+                "id": str(uuid.uuid4()),
+                "user_id": str(uuid.uuid4()),  # Testing if remapping user_id works
+                "name": "Test Restored Account",
+                "type": "Checking",
+                "currency": "USD",
+            }
+        ]
         zf.writestr("accounts.json", json.dumps(accounts_data))
 
     buf.seek(0)
     files = {"file": ("backup.zip", buf.getvalue(), "application/zip")}
-    
+
     resp = await client.post("/api/export/restore", headers=auth_headers, files=files)
     assert resp.status_code == 200
     assert resp.json()["status"] == "success"

--- a/backend/tests/test_export_service.py
+++ b/backend/tests/test_export_service.py
@@ -1,0 +1,72 @@
+import io
+import uuid
+import pytest
+from app.services.export_service import ExportService
+from app.models.transaction import Transaction
+
+
+class DummySession:
+    async def execute(self, stmt):
+        return self
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return []
+
+    async def flush(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_export_data_returns_bytesio():
+    session = DummySession()
+    user_id = "00000000-0000-0000-0000-000000000000"
+    service = ExportService(session, user_id)
+    result = await service.export_data()
+    assert isinstance(result, io.BytesIO)
+
+
+@pytest.mark.asyncio
+def test_sanitize_row_sets_invalid_fk_to_none():
+    user_id = uuid.uuid4()
+    service = ExportService(DummySession(), user_id)
+    # IDs válidos do usuário
+    valid_account_id = uuid.uuid4()
+    valid_category_id = uuid.uuid4()
+    existing_keys = {
+        "accounts": {str(valid_account_id)},
+        "categories": {str(valid_category_id)},
+        "payees": set(),
+        "asset_groups": set(),
+        "category_groups": set(),
+        "assets": set(),
+        "connections": set(),
+    }
+    # Row com FKs válidos
+    row_valid = {
+        "user_id": str(user_id),
+        "account_id": str(valid_account_id),
+        "category_id": str(valid_category_id),
+        "amount": "10.00",
+        "date": "2024-01-01",
+        "description": "ok",
+    }
+    # Row com FKs inválidos
+    row_invalid = {
+        "user_id": str(user_id),
+        "account_id": str(uuid.uuid4()),
+        "category_id": str(uuid.uuid4()),
+        "amount": "10.00",
+        "date": "2024-01-01",
+        "description": "fail",
+    }
+    # Deve manter FKs válidos
+    clean_valid = service._sanitize_row(Transaction, row_valid, {}, existing_keys)
+    assert clean_valid["account_id"] == valid_account_id
+    assert clean_valid["category_id"] == valid_category_id
+    # Deve setar FKs inválidos como None
+    clean_invalid = service._sanitize_row(Transaction, row_invalid, {}, existing_keys)
+    assert clean_invalid["account_id"] is None
+    assert clean_invalid["category_id"] is None

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1,0 +1,67 @@
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+
+from app.core.utils import deserialize_row, serialize_model
+from app.models.transaction import Transaction
+
+
+def test_serialize_model():
+    t_id = uuid.uuid4()
+    t_date = date(2023, 10, 1)
+    t_created_at = datetime(2023, 10, 1, 12, 0, 0)
+
+    transaction = Transaction(
+        id=t_id,
+        user_id=uuid.uuid4(),
+        account_id=uuid.uuid4(),
+        category_id=uuid.uuid4(),
+        amount=Decimal("150.25"),
+        date=t_date,
+        effective_date=t_date,
+        created_at=t_created_at,
+        currency="USD",
+        description="Grocery",
+    )
+
+    serialized = serialize_model(transaction)
+
+    assert serialized["id"] == str(t_id)
+    assert serialized["amount"] == "150.25"
+    assert serialized["date"] == "2023-10-01"
+    assert serialized["created_at"] == "2023-10-01T12:00:00"
+    assert serialized["currency"] == "USD"
+    assert serialized["description"] == "Grocery"
+
+
+def test_deserialize_row():
+    t_id_str = str(uuid.uuid4())
+    user_id_str = str(uuid.uuid4())
+    account_id_str = str(uuid.uuid4())
+    category_id_str = str(uuid.uuid4())
+
+    raw_row = {
+        "id": t_id_str,
+        "user_id": user_id_str,
+        "account_id": account_id_str,
+        "category_id": category_id_str,
+        "amount": "150.25",
+        "date": "2023-10-01",
+        "created_at": "2023-10-01T12:00:00+00:00",
+        "currency": "USD",
+        "description": "Grocery",
+        "invalid_extra_field": "should_be_ignored",
+        "raw_data": None,
+    }
+
+    deserialized = deserialize_row(Transaction, raw_row)
+
+    assert deserialized["id"] == uuid.UUID(t_id_str)
+    assert deserialized["user_id"] == uuid.UUID(user_id_str)
+    assert deserialized["amount"] == Decimal("150.25")
+    assert deserialized["date"] == date(2023, 10, 1)
+    assert deserialized["created_at"].isoformat() == "2023-10-01T12:00:00+00:00"
+    assert deserialized["currency"] == "USD"
+    assert deserialized["description"] == "Grocery"
+    assert "invalid_extra_field" not in deserialized
+    assert "raw_data" not in deserialized

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -64,4 +64,3 @@ def test_deserialize_row():
     assert deserialized["currency"] == "USD"
     assert deserialized["description"] == "Grocery"
     assert "invalid_extra_field" not in deserialized
-    assert "raw_data" not in deserialized

--- a/frontend/src/components/app-layout.tsx
+++ b/frontend/src/components/app-layout.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { getAccountName } from '@/lib/account-utils'
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
@@ -111,6 +111,8 @@ export function AppLayout() {
   const [changePasswordOpen, setChangePasswordOpen] = useState(false)
   const [twoFactorOpen, setTwoFactorOpen] = useState(false)
   const [backingUp, setBackingUp] = useState(false)
+  const [restoring, setRestoring] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false)
   useCommandPaletteHotkey(setPaletteOpen)
@@ -136,6 +138,28 @@ export function AppLayout() {
       // localStorage fallback is already set
     }
   }, [user, updateUser])
+
+  const handleRestore = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    if (!window.confirm(t('backup.restoreConfirm', { defaultValue: 'Restoring will OVERWRITE ALL your current data (except bank connections). This action cannot be undone. Are you sure?' }))) {
+      event.target.value = ''
+      return
+    }
+
+    setRestoring(true)
+    try {
+      await backupApi.restore(file)
+      toast.success(t('backup.restoreSuccess', { defaultValue: 'Backup restored successfully!' }))
+      window.location.reload()
+    } catch {
+      toast.error(t('backup.restoreError', { defaultValue: 'Failed to restore backup.' }))
+    } finally {
+      setRestoring(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
 
   const userInitial = user?.email?.charAt(0).toUpperCase() ?? '?'
   const currentLang = i18n.language
@@ -206,6 +230,7 @@ export function AppLayout() {
             onChangePassword={() => setChangePasswordOpen(true)}
             onTwoFactor={() => setTwoFactorOpen(true)}
             backingUp={backingUp}
+            restoring={restoring}
             onBackup={async () => {
               setBackingUp(true)
               try {
@@ -217,6 +242,7 @@ export function AppLayout() {
                 setBackingUp(false)
               }
             }}
+            onRestoreClick={() => fileInputRef.current?.click()}
             dark
             isAdmin={user?.is_superuser}
           />
@@ -461,7 +487,7 @@ export function AppLayout() {
                   {t('auth.twoFactorTitle')}
                 </DropdownMenuItem>
                 <DropdownMenuItem
-                  disabled={backingUp}
+                  disabled={backingUp || restoring}
                   onClick={async () => {
                     setBackingUp(true)
                     try {
@@ -477,6 +503,14 @@ export function AppLayout() {
                 >
                   <HardDriveDownload size={14} />
                   {backingUp ? t('backup.downloading') : t('backup.button')}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={backingUp || restoring}
+                  onClick={() => fileInputRef.current?.click()}
+                  className="flex items-center gap-2"
+                >
+                  <Upload size={14} />
+                  {restoring ? t('backup.restoring', { defaultValue: 'Restoring...' }) : t('backup.restoreButton', { defaultValue: 'Restore Backup' })}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => setUpdateDialogOpen(true)}
@@ -566,6 +600,13 @@ export function AppLayout() {
         open={updateDialogOpen}
         onClose={() => setUpdateDialogOpen(false)}
       />
+      <input 
+        type="file" 
+        ref={fileInputRef} 
+        className="hidden" 
+        accept=".zip" 
+        onChange={handleRestore} 
+      />
     </div>
   )
 }
@@ -576,7 +617,9 @@ function UserMenu({
   onChangePassword,
   onTwoFactor,
   onBackup,
+  onRestoreClick,
   backingUp,
+  restoring,
   dark,
   isAdmin,
 }: {
@@ -585,7 +628,9 @@ function UserMenu({
   onChangePassword: () => void
   onTwoFactor: () => void
   onBackup: () => void
+  onRestoreClick: () => void
   backingUp: boolean
+  restoring: boolean
   dark?: boolean
   isAdmin?: boolean
 }) {
@@ -637,12 +682,20 @@ function UserMenu({
           {t('auth.twoFactorTitle')}
         </DropdownMenuItem>
         <DropdownMenuItem
-          disabled={backingUp}
+          disabled={backingUp || restoring}
           onClick={onBackup}
           className="flex items-center gap-2"
         >
           <HardDriveDownload size={14} />
           {backingUp ? t('backup.downloading') : t('backup.button')}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          disabled={backingUp || restoring}
+          onClick={onRestoreClick}
+          className="flex items-center gap-2"
+        >
+          <Upload size={14} />
+          {restoring ? t('backup.restoring', { defaultValue: 'Restoring...' }) : t('backup.restoreButton', { defaultValue: 'Restore Backup' })}
         </DropdownMenuItem>
         <DropdownMenuSub>
           <DropdownMenuSubTrigger className="flex items-center gap-2">

--- a/frontend/src/components/app-layout.tsx
+++ b/frontend/src/components/app-layout.tsx
@@ -143,7 +143,7 @@ export function AppLayout() {
     const file = event.target.files?.[0]
     if (!file) return
 
-    if (!window.confirm(t('backup.restoreConfirm', { defaultValue: 'Restoring will OVERWRITE ALL your current data (except bank connections). This action cannot be undone. Are you sure?' }))) {
+    if (!window.confirm(t('backup.restoreConfirmMerge', { defaultValue: 'Restoring will safely MERGE the backup data with your existing records. No current data will be deleted. Do you want to proceed?' }))) {
       event.target.value = ''
       return
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -697,6 +697,11 @@ export const backup = {
     document.body.removeChild(a)
     URL.revokeObjectURL(url)
   },
+  restore: async (file: File): Promise<void> => {
+    const formData = new FormData()
+    formData.append('file', file)
+    await api.post('/export/restore', formData)
+  },
 }
 
 // Admin

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -819,7 +819,12 @@
     "button": "Backup",
     "downloading": "Downloading...",
     "success": "Backup downloaded successfully",
-    "error": "Failed to download backup"
+    "error": "Failed to download backup",
+    "restoreConfirmMerge": "Restoring will safely MERGE the backup data with your existing records. No current data will be deleted. Do you want to proceed?",
+    "restoreSuccess": "Backup restored successfully!",
+    "restoreError": "Failed to restore backup.",
+    "restoreButton": "Restore Backup",
+    "restoring": "Restoring..."
   },
   "update": {
     "title": "Server update",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -819,7 +819,12 @@
     "button": "Backup",
     "downloading": "Baixando...",
     "success": "Backup baixado com sucesso",
-    "error": "Erro ao baixar backup"
+    "error": "Erro ao baixar backup",
+    "restoreConfirmMerge": "A restauração irá MESCLAR com segurança os dados do backup com seus registros atuais. Nenhuma informação será perdida. Deseja continuar?",
+    "restoreSuccess": "Backup restaurado com sucesso!",
+    "restoreError": "Erro ao restaurar o backup.",
+    "restoreButton": "Restaurar Backup",
+    "restoring": "Restaurando..."
   },
   "update": {
     "title": "Atualização do servidor",


### PR DESCRIPTION
## What

- **Restore Capability**: The main feature added is the ability to securely **restore backups** into the application using an incremental **"Safe Merge / Upsert"** methodology (`session.merge()`). Existing data is preserved entirely during imports.
- **Export Refactoring**: To support the new restore feature smoothly and increase code readability, the export functionality was heavily refactored. Extracted the monolithic API logic into a cleanly isolated Object-Oriented architecture (`ExportService`) and cleanly localized ZIP map processing into an extensible `BackupArchiveHandler`.
- **Typing & i18n Improvements**: Added structured data types and implemented comprehensive frontend Portuguese and English locale translations (`pt-BR.json`, `en.json`) matching the restoration dialog prompts seamlessly.

## Why

Why are these changes needed?
Adding restore capabilities closes the loop on system portability, ensuring that users can safely return their backed-up archives without destroying live configuration records. The internal export code natively needed a cleanup to accommodate this cleanly — doing so vastly scales future extensibility, strips procedural block redundancies, and sets strong PEP 8 boundaries aligned with the core structural architecture. 

## How to Test

Steps to verify the changes work:

1. **Verify Extracted Locales**: View the front-end localized modal strings internally by verifying that the "Restore Backup" prompt functions smoothly inside English or Portuguese.
2. **Execute Restore Integration**: Export a ZIP, insert a manual transaction locally into the UI, then use the brand new "Restore" function to upload your saved ZIP. 
3. Verify that your newest manual transaction is still there intact, proving that the backup successfully _merged_ with live states instead of wiping out the DB entirely.

## Checklist

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)

## Screenshots
https://github.com/user-attachments/assets/c844ace6-22c4-479c-84ed-ce9c3f3fef9f


