### PR TITLE
fix(assets): show portfolio chart with single data point (#118)

### DIFF
--- a/frontend/src/pages/assets.tsx
+++ b/frontend/src/pages/assets.tsx
@@ -850,7 +850,7 @@ export default function AssetsPage() {
       />
 
       {/* Portfolio Stacked Area Chart */}
-      {portfolioData && portfolioData.trend.length > 1 && (
+      {portfolioData && portfolioData.trend.length > 0 && (
         <PortfolioChart
           data={portfolioData}
           wallets={sortedWallets}


### PR DESCRIPTION
The Portfolio Value chart was hidden until trend.length > 1, so users who had just created their first asset (or whose value history had only one date) saw nothing until they added a second value or refreshed. Loosen the threshold to > 0 so the chart renders as soon as there is any data to plot.

## What

Brief description of the changes.

## Why

Why are these changes needed?

## How to Test

Steps to verify the changes work:

1. ...
2. ...

## Checklist

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
