### PR TITLE
fix(assets): refetch portfolio chart when asset values change (#119)

### DIFF
--- a/frontend/src/pages/assets.tsx
+++ b/frontend/src/pages/assets.tsx
@@ -1671,6 +1671,7 @@ function AssetDetail({ assetId, currency, locale: loc, purchasePrice, purchaseDa
       queryClient.refetchQueries({ queryKey: ['assets'] })
       queryClient.refetchQueries({ queryKey: ['asset-values', assetId] })
       queryClient.refetchQueries({ queryKey: ['asset-trend', assetId] })
+      queryClient.refetchQueries({ queryKey: ['portfolio-trend'] })
       queryClient.refetchQueries({ queryKey: ['dashboard'] })
       setValueAmount('')
       toast.success(t('assets.valueAdded'))
@@ -1684,6 +1685,7 @@ function AssetDetail({ assetId, currency, locale: loc, purchasePrice, purchaseDa
       queryClient.refetchQueries({ queryKey: ['assets'] })
       queryClient.refetchQueries({ queryKey: ['asset-values', assetId] })
       queryClient.refetchQueries({ queryKey: ['asset-trend', assetId] })
+      queryClient.refetchQueries({ queryKey: ['portfolio-trend'] })
       queryClient.refetchQueries({ queryKey: ['dashboard'] })
       toast.success(t('assets.valueDeleted'))
     },


### PR DESCRIPTION
addValueMutation and deleteValueMutation in AssetDetail were refetching ['assets'], ['asset-values'], ['asset-trend'], and ['dashboard'], but not ['portfolio-trend']. As a result, the Portfolio Value graph at the top of the Assets page kept showing stale data after the user added or deleted a value from an asset's history — only a manual refresh fixed it. Add the missing key to both mutations.

## What

Brief description of the changes.

## Why

Why are these changes needed?

## How to Test

Steps to verify the changes work:

1. ...
2. ...

## Checklist

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
