### PR TITLE
fix(assets): respect growth_start_date when seeding growth values (#121)

### DIFF
--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -70,14 +70,22 @@ def _generate_growth_values(
     growth_frequency: str,
     growth_start_date: Optional[date],
 ) -> list[AssetValue]:
-    """Generate all AssetValue rows from base_date to today using the growth rule."""
+    """Generate all AssetValue rows from base_date to today using the growth rule.
+    When growth_start_date is set, growth iteration begins from that date — not
+    from base_date — so the asset accrues no growth for the gap between
+    purchase and the configured growth start."""
     today = date.today()
     if growth_start_date and today < growth_start_date:
         return []
 
     values: list[AssetValue] = []
     current_amount = base_amount
-    current_date = base_date
+    # Match the frontend preview: `growth_start_date or base_date`. Otherwise
+    # backfill applied growth periods between purchase_date and
+    # growth_start_date that the form said wouldn't accrue, leaving the
+    # list-page total exactly N growth periods higher than the edit
+    # dialog's calculated value.
+    current_date = growth_start_date if growth_start_date else base_date
 
     while True:
         next_due = _next_due_date(current_date, growth_frequency)


### PR DESCRIPTION
_generate_growth_values used base_date (= purchase_date) as the iteration anchor, so when the user set a separate growth_start_date the backend applied growth periods between purchase and growth start that the form's preview said wouldn't accrue. The list page therefore showed a value exactly N growth periods higher than the edit dialog calculated.

Iterate from growth_start_date when set, matching the frontend preview in pages/assets.tsx exactly. The seed AssetValue stays at purchase_date so the chart still pins the purchase point.

## What

Brief description of the changes.

## Why

Why are these changes needed?

## How to Test

Steps to verify the changes work:

1. ...
2. ...

## Checklist

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
