### PR TITLE
fix: forward OPENEXCHANGERATES_APP_ID to securo production container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,6 +7,7 @@ x-backend-env: &backend-env
   FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
   PLUGGY_CLIENT_ID: ${PLUGGY_CLIENT_ID:-}
   PLUGGY_CLIENT_SECRET: ${PLUGGY_CLIENT_SECRET:-}
+  OPENEXCHANGERATES_APP_ID: ${OPENEXCHANGERATES_APP_ID:-}
   PLUGGY_OAUTH_REDIRECT_URI: ${PLUGGY_OAUTH_REDIRECT_URI:-http://localhost:3000/oauth/callback}
   REDIS_URL: redis://redis:6379/0
   STORAGE_LOCAL_PATH: /app/data/attachments


### PR DESCRIPTION


## What

Add OPENEXCHANGERATES_APP_ID env var to backend service on docker-compose.production.yaml

## Why

I was getting those errors when running the production container even though i had the OPENEXCHANGERATES_APP_ID defined in my .env file.

`Traceback (most recent call last):
securo-backend        |   File "/app/app/services/fx_rate_service.py", line 84, in get_rate
securo-backend        |     synced = await sync_rates(session, target)
securo-backend        |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
securo-backend        |   File "/app/app/services/fx_rate_service.py", line 34, in sync_rates
securo-backend        |     rates = await _provider.fetch_latest()
securo-backend        |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
securo-backend        |   File "/app/app/providers/openexchangerates.py", line 32, in fetch_latest
securo-backend        |     raise ValueError("openexchangerates_app_id not configured")
securo-backend        | ValueError: openexchangerates_app_id not configured`



## How to Test

Steps to verify the changes work:
1. Add OPENEXCHANGERATES_APP_ID to you .env file
2. Execute docker compose using the production docker-compose.production.yaml
3. Have any account or investment in a currency other than you main one
4. Verify the conversion rate in the ui is different from 1:1
5. Verify you don't get the errors showed above.

## Checklist

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
