### PR TITLE
feat: sync URL with search filters for transactions page

### DIFF
--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -93,12 +93,50 @@ export default function TransactionsPage() {
     const nextQ = searchParams.get('q') ?? ''
     setSearchInput(nextQ)
     setSearchQuery(nextQ)
+    const tags = searchParams.get('tags');
+    setTagFilters(tags ? tags.split(',') : []);
     setFilterPayee(searchParams.get('payee_id') ?? '')
-    const nextCategory = searchParams.get('category_id')
-    setFilterCategoryIds(nextCategory ? [nextCategory] : [])
-    setFilterUncategorized(false)
+    const categories = searchParams.get('category_id');
+    setFilterCategoryIds(categories ? categories.split(',') : []);
+    setFilterUncategorized(searchParams.get('uncategorized') === '1');
+    const accounts = searchParams.get('account_id');
+    setFilterAccountIds(accounts ? accounts.split(',') : []);
+    setFilterFrom(searchParams.get('from') ?? '');
+    setFilterTo(searchParams.get('to') ?? '');
     setPage(1)
   }, [searchParams])
+
+  // Keep the URL in sync with the current filters, so that the current page can be
+  // refreshed, bookmarked or shared.
+  useEffect(() => {
+    const params = new URLSearchParams(
+      [
+        ['q', searchQuery],
+        ['tags', tagFilters.join(',')],
+        ['payee_id', filterPayee],
+        ['category_id', filterCategoryIds.join(',')],
+        ['uncategorized', filterUncategorized ? '1' : ''],
+        ['account_id', filterAccountIds.join(',')],
+        ['from', filterFrom],
+        ['to', filterTo],
+      ].filter(([, v]) => v.length),
+    );
+
+    window.history.replaceState(
+      null,
+      '',
+      params.size ? `?${params}` : window.location.pathname,
+    );
+  }, [
+    searchQuery,
+    tagFilters,
+    filterPayee,
+    filterCategoryIds,
+    filterUncategorized,
+    filterAccountIds,
+    filterFrom,
+    filterTo,
+  ]);
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current)


### PR DESCRIPTION
## What

Update URL query parameters when filters or search query change in the transactions page.

## Why

I was getting annoyed of refreshing the page and having my filters reset every time.

## How to Test

Steps to verify the changes work:

1. Open transactions page
2. Write something in the search input, select filters, tags, etc.
3. Refresh the page, or copy the URL and open it in a different tab or window

## Checklist

- [x] Backend tests pass (`pytest`) (N/A)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed) (N/A)
