### PR TITLE
chore(.gitignore): add .vscode to ignore local configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .claude
 docs/plans/
 tmp/
+
+# Ignore local configuration files
+.vscode/


### PR DESCRIPTION
## What
Add `.vscode/` to the `.gitignore` file to exclude the VS Code workspace settings directory from version control.

## Why
The `.vscode/` folder contains project-specific configurations for extensions (e.g., Prettier, ESLint) and custom tasks. Currently, contributors must manually exclude these settings to avoid committing them, which is error-prone and repetitive. Ignoring this folder by default ensures consistency and reduces unnecessary noise in the repository.

## How to Test
No testing required. Verify that the `.vscode/` folder is excluded by checking `git status` after adding it to `.gitignore`.

## Checklist
- [x] Updated `.gitignore` to include `.vscode/`.
- [x] Confirmed `.vscode/` is no longer tracked in Git.
