### PR TITLE
Feat/payee on rule conditions

### DIFF
--- a/backend/app/schemas/rule.py
+++ b/backend/app/schemas/rule.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict
 
 
 class RuleCondition(BaseModel):
-    field: str   # description, notes, amount, type, account_id, date
+    field: str   # description, notes, amount, type, account_id, payee_id, date
     op: str      # contains, not_contains, equals, not_equals, starts_with, ends_with, regex, gt, gte, lt, lte
     value: Any   # str or number depending on field
 

--- a/backend/tests/test_rule_engine.py
+++ b/backend/tests/test_rule_engine.py
@@ -13,6 +13,7 @@ def make_tx(**kwargs) -> types.SimpleNamespace:
         id=uuid.uuid4(),
         user_id=uuid.uuid4(),
         account_id=uuid.uuid4(),
+        payee_id=uuid.uuid4(),
         category_id=None,
         description="UBER TRIP",
         amount=Decimal("25.50"),
@@ -316,6 +317,39 @@ def test_set_payee_action():
     tx.payee_id = None
     apply_rule_actions(actions, tx, category_already_set=False)
     assert tx.payee_id == payee_id
+
+
+# --- payee_id condition tests ---
+
+
+def test_payee_id_equals_match():
+    payee_id = uuid.uuid4()
+    conditions = [{"field": "payee_id", "op": "equals", "value": str(payee_id)}]
+    tx = make_tx(payee_id=payee_id)
+    assert evaluate_conditions("and", conditions, tx) is True
+
+
+def test_payee_id_equals_no_match():
+    payee_id = uuid.uuid4()
+    other_payee_id = uuid.uuid4()
+    conditions = [{"field": "payee_id", "op": "equals", "value": str(other_payee_id)}]
+    tx = make_tx(payee_id=payee_id)
+    assert evaluate_conditions("and", conditions, tx) is False
+
+
+def test_payee_id_not_equals():
+    payee_id = uuid.uuid4()
+    other_payee_id = uuid.uuid4()
+    conditions = [{"field": "payee_id", "op": "not_equals", "value": str(other_payee_id)}]
+    tx = make_tx(payee_id=payee_id)
+    assert evaluate_conditions("and", conditions, tx) is True
+
+
+def test_payee_id_none_not_equals_real_payee():
+    payee_id = uuid.uuid4()
+    conditions = [{"field": "payee_id", "op": "not_equals", "value": str(payee_id)}]
+    tx = make_tx(payee_id=None)
+    assert evaluate_conditions("and", conditions, tx) is True
 
 
 def test_set_payee_invalid_uuid_ignored():

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -528,6 +528,7 @@
     "fieldAmount": "Amount",
     "fieldType": "Type",
     "fieldAccount": "Account",
+    "fieldPayee": "Payee",
     "fieldDate": "Date",
     "opContains": "contains",
     "opNotContains": "does not contain",
@@ -537,6 +538,7 @@
     "opEndsWith": "ends with",
     "opRegex": "regex",
     "opIs": "is",
+    "opIsNot": "is not",
     "typeExpense": "Expense (debit)",
     "typeIncome": "Income (credit)",
     "valuePlaceholder": "Value...",
@@ -806,7 +808,7 @@
     "searchIcon": "Search icon...",
     "noIconsFound": "No icons found",
     "primaryCurrency": "Primary Currency",
-    "showLess":"Show less",
+    "showLess": "Show less",
     "showMore": "+{{count}} more"
   },
   "privacy": {

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -528,6 +528,7 @@
     "fieldAmount": "Valor",
     "fieldType": "Tipo",
     "fieldAccount": "Conta",
+    "fieldPayee": "Beneficiário",
     "fieldDate": "Data",
     "opContains": "contém",
     "opNotContains": "não contém",
@@ -537,6 +538,7 @@
     "opEndsWith": "termina com",
     "opRegex": "regex",
     "opIs": "é",
+    "opIsNot": "não é",
     "typeExpense": "Despesa (debit)",
     "typeIncome": "Receita (credit)",
     "valuePlaceholder": "Valor...",
@@ -806,7 +808,7 @@
     "searchIcon": "Buscar ícone...",
     "noIconsFound": "Nenhum ícone encontrado",
     "primaryCurrency": "Moeda Principal",
-    "showLess":"Mostrar menos",
+    "showLess": "Mostrar menos",
     "showMore": "Mostrar +{{count}}"
   },
   "privacy": {

--- a/frontend/src/pages/rules.tsx
+++ b/frontend/src/pages/rules.tsx
@@ -470,7 +470,7 @@ function RuleDialog({
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto overflow-x-hidden">
         <DialogHeader>
           <DialogTitle>{rule ? t('rules.editRule') : t('rules.newRule')}</DialogTitle>
         </DialogHeader>
@@ -509,7 +509,7 @@ function RuleDialog({
             </div>
             <div className="space-y-2">
               {conditions.map((cond, i) => (
-                <div key={i} className="flex items-center gap-2">
+                <div key={i} className="flex items-center gap-2 min-w-0">
                   <select
                     className={`${selectClass} w-32 shrink-0`}
                     value={cond.field}
@@ -530,7 +530,7 @@ function RuleDialog({
                   </select>
                   {cond.field === 'type' ? (
                     <select
-                      className={`${selectClass} flex-1`}
+                      className={`${selectClass} w-0 flex-1 min-w-0`}
                       value={String(cond.value)}
                       onChange={(e) => updateCondition(i, 'value', e.target.value)}
                     >
@@ -539,7 +539,7 @@ function RuleDialog({
                     </select>
                   ) : cond.field === 'account_id' ? (
                     <select
-                      className={`${selectClass} flex-1`}
+                      className={`${selectClass} w-0 flex-1 min-w-0`}
                       value={String(cond.value)}
                       onChange={(e) => updateCondition(i, 'value', e.target.value)}
                     >
@@ -550,7 +550,7 @@ function RuleDialog({
                     </select>
                   ) : cond.field === 'payee_id' ? (
                     <select
-                      className={`${selectClass} flex-1`}
+                      className={`${selectClass} w-0 flex-1 min-w-0`}
                       value={String(cond.value)}
                       onChange={(e) => updateCondition(i, 'value', e.target.value)}
                     >
@@ -561,7 +561,7 @@ function RuleDialog({
                     </select>
                   ) : (
                     <Input
-                      className="flex-1 h-8 text-sm"
+                      className="w-0 flex-1 min-w-0 h-8 text-sm"
                       value={String(cond.value)}
                       onChange={(e) => updateCondition(i, 'value', e.target.value)}
                       placeholder={cond.field === 'amount' ? '0.00' : cond.field === 'date' ? 'YYYY-MM-DD' : t('rules.valuePlaceholder')}
@@ -592,7 +592,7 @@ function RuleDialog({
             <Label>{t('rules.actions')}</Label>
             <div className="space-y-2">
               {actions.map((action, i) => (
-                <div key={i} className="flex items-center gap-2">
+                <div key={i} className="flex items-center gap-2 min-w-0">
                   <select
                     className={`${selectClass} w-40 shrink-0`}
                     value={action.op}
@@ -604,7 +604,7 @@ function RuleDialog({
                   </select>
                   {action.op === 'set_category' ? (
                     <select
-                      className={`${selectClass} flex-1`}
+                      className={`${selectClass} w-0 flex-1 min-w-0`}
                       value={action.value}
                       onChange={(e) => updateAction(i, 'value', e.target.value)}
                       required
@@ -616,7 +616,7 @@ function RuleDialog({
                     </select>
                   ) : action.op === 'set_payee' ? (
                     <select
-                      className={`${selectClass} flex-1`}
+                      className={`${selectClass} w-0 flex-1 min-w-0`}
                       value={action.value}
                       onChange={(e) => updateAction(i, 'value', e.target.value)}
                       required
@@ -628,7 +628,7 @@ function RuleDialog({
                     </select>
                   ) : (
                     <Input
-                      className="flex-1 h-8 text-sm"
+                      className="w-0 flex-1 min-w-0 h-8 text-sm"
                       value={action.value}
                       onChange={(e) => updateAction(i, 'value', e.target.value)}
                       placeholder="Ex: #work #reimbursable"

--- a/frontend/src/pages/rules.tsx
+++ b/frontend/src/pages/rules.tsx
@@ -43,6 +43,7 @@ const CONDITION_FIELDS = [
   { value: 'amount', label: 'rules.fieldAmount' },
   { value: 'type', label: 'rules.fieldType' },
   { value: 'account_id', label: 'rules.fieldAccount' },
+  { value: 'payee_id', label: 'rules.fieldPayee' },
   { value: 'date', label: 'rules.fieldDate' },
 ] as const
 
@@ -67,10 +68,14 @@ const NUMERIC_OPS = [
 function getOpsForField(field: string) {
   if (field === 'amount' || field === 'date') return NUMERIC_OPS
   if (field === 'type') return [{ value: 'equals', label: 'rules.opIs' }]
+  if (field === 'payee_id' || field === 'account_id') return [
+    { value: 'equals', label: 'rules.opIs' },
+    { value: 'not_equals', label: 'rules.opIsNot' },
+  ]
   return STRING_OPS
 }
 
-function conditionSummary(conditions: RuleCondition[], conditionsOp: string, t: (key: string) => string): string {
+function conditionSummary(conditions: RuleCondition[], conditionsOp: string, t: (key: string) => string, payeesList: Payee[]): string {
   const fieldLabel = (f: string) => {
     const key = CONDITION_FIELDS.find(x => x.value === f)?.label
     return key ? t(key) : f
@@ -79,7 +84,14 @@ function conditionSummary(conditions: RuleCondition[], conditionsOp: string, t: 
     const key = getOpsForField(f).find(x => x.value === op)?.label
     return key ? t(key) : op
   }
-  const parts = conditions.map(c => `${fieldLabel(c.field)} ${opLabel(c.field, c.op)} "${c.value}"`)
+  const valueLabel = (c: RuleCondition) => {
+    if (c.field === 'payee_id') {
+      const p = payeesList.find(p => p.id === c.value)
+      return p ? p.name : String(c.value)
+    }
+    return String(c.value)
+  }
+  const parts = conditions.map(c => `${fieldLabel(c.field)} ${opLabel(c.field, c.op)} "${valueLabel(c)}"`)
   return parts.join(` ${conditionsOp === 'or' ? t('rules.orOp') : t('rules.andOp')} `) || t('rules.noConditions')
 }
 
@@ -283,7 +295,7 @@ export default function RulesPage() {
                       </span>
                     </div>
                     <p className="text-xs text-muted-foreground font-mono truncate">
-                      {conditionSummary(rule.conditions, rule.conditions_op, t)}
+                      {conditionSummary(rule.conditions, rule.conditions_op, t, payees)}
                     </p>
                     <p className="text-xs text-emerald-600 font-medium mt-0.5">
                       {actionSummary(rule.actions, categories, payees, t)}
@@ -534,6 +546,17 @@ function RuleDialog({
                       <option value="">{t('rules.selectAccount')}</option>
                       {accounts.map(acc => (
                         <option key={acc.id} value={acc.id}>{getAccountName(acc)}</option>
+                      ))}
+                    </select>
+                  ) : cond.field === 'payee_id' ? (
+                    <select
+                      className={`${selectClass} flex-1`}
+                      value={String(cond.value)}
+                      onChange={(e) => updateCondition(i, 'value', e.target.value)}
+                    >
+                      <option value="">{t('rules.selectPayee')}</option>
+                      {payees.map(p => (
+                        <option key={p.id} value={p.id}>{p.name}</option>
                       ))}
                     </select>
                   ) : (


### PR DESCRIPTION
## What
Add the **payee** as a selectable condition on the **Rules** page and close the issue #143 .

![[Screenshot from 2026-05-02 21-42-19](https://github.com/user-attachments/assets/8d36852a-1fa4-4cdf-af99-821e6d36e40d)](https://github.com/user-attachments/assets/8d36852a-1fa4-4cdf-af99-821e6d36e40d)

## Why
This change allows users to create rules based on the **payee** field, enabling more granular and flexible automation for transaction categorization and handling.

## How to Test
1. Open the **Rules** page.
2. Attempt to create or edit a rule.
3. Verify that the **payee** field is available as a condition.
4. Confirm that the rule works as expected when the payee condition is applied.

## Checklist
- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)