### PR TITLE
fix: update select all functionality to exclude shared transactions

### DIFF
--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -426,19 +426,20 @@ export default function TransactionsPage() {
   // Tag filtering is now applied server-side, so the visible list and the
   // page count both reflect the same filtered total — issue #88.
   const filteredItems = data?.items ?? []
+  const selectableItems = filteredItems.filter(tx => !tx.is_shared)
 
   const toggleSelectAll = () => {
-    if (!filteredItems.length) return
-    const allSelected = filteredItems.every(tx => selectedIds.has(tx.id))
+    if (!selectableItems.length) return
+    const allSelected = selectableItems.every(tx => selectedIds.has(tx.id))
     if (allSelected) {
       setSelectedIds(new Set())
     } else {
-      setSelectedIds(new Set(filteredItems.map(tx => tx.id)))
+      setSelectedIds(new Set(selectableItems.map(tx => tx.id)))
     }
   }
 
-  const allSelected = filteredItems.length > 0 && filteredItems.every(tx => selectedIds.has(tx.id))
-  const someSelected = filteredItems.some(tx => selectedIds.has(tx.id)) && !allSelected
+  const allSelected = selectableItems.length > 0 && selectableItems.every(tx => selectedIds.has(tx.id))
+  const someSelected = selectableItems.some(tx => selectedIds.has(tx.id)) && !allSelected
 
   // Resolve the currently-selected transactions into a valid debit/credit pair
   // for the "Link as transfer" action. Returns null if the pair is invalid


### PR DESCRIPTION
## What

This PR fixes the "select all" behavior when there are transactions shared from a group.

## Why

Currently, the select all checkbox selects even transactions that cannot be selected:

<img height="400" alt="before" src="https://github.com/user-attachments/assets/3bf74857-61a3-4063-aedc-993bf57dc666" />

Also, notice that selecting the only two transactions does not make the top checkbox fully checked.

This is what it looks like after this PR:

<img height="400" alt="after" src="https://github.com/user-attachments/assets/ed514019-09f2-4027-8dcc-2852d51e449e" />


## How to Test

Steps to verify the changes work:

1. Open a transactions page that contains shared transactions from groups
2. Toggle the "select all" checkbox

## Checklist

- [x] Backend tests pass (`pytest`) (N/A)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed) (N/A)
