### PR TITLE
feat: unify category selection UI and introduce category grouping

### DIFF
--- a/frontend/src/components/category-select.tsx
+++ b/frontend/src/components/category-select.tsx
@@ -1,10 +1,10 @@
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import type { Category } from '@/types'
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select'
+import type { CategoryGroup } from '@/types'
 
 interface CategorySelectProps {
   value: string
   onChange: (value: string) => void
-  categories: Category[]
+  groups: CategoryGroup[]
   placeholder?: string
   disabled?: boolean
   className?: string
@@ -15,7 +15,7 @@ interface CategorySelectProps {
 export function CategorySelect({
   value,
   onChange,
-  categories,
+  groups,
   placeholder = 'Select category',
   disabled = false,
   className = "w-full border border-border rounded-md px-3 py-2 text-sm bg-background disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]",
@@ -39,16 +39,23 @@ export function CategorySelect({
             {uncategorizedLabel}
           </SelectItem>
         )}
-        {categories.map((cat) => (
-          <SelectItem key={cat.id} value={cat.id}>
-            {cat.color ? (
-              <span
-                className="size-2.5 shrink-0 rounded-full border border-black/5"
-                style={{ backgroundColor: cat.color }}
-              />
-            ) : null}
-            <span>{cat.name}</span>
-          </SelectItem>
+        {groups.map((group) => (
+          <SelectGroup key={group.id}>
+            <SelectLabel className="px-2 py-1.5 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
+              {group.name}
+            </SelectLabel>
+            {group.categories.map((cat) => (
+              <SelectItem key={cat.id} value={cat.id}>
+                {cat.color ? (
+                  <span
+                    className="size-2.5 shrink-0 rounded-full border border-black/5"
+                    style={{ backgroundColor: cat.color }}
+                  />
+                ) : null}
+                <span>{cat.name}</span>
+              </SelectItem>
+            ))}
+          </SelectGroup>
         ))}
       </SelectContent>
     </Select>

--- a/frontend/src/components/category-select.tsx
+++ b/frontend/src/components/category-select.tsx
@@ -1,0 +1,56 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import type { Category } from '@/types'
+
+interface CategorySelectProps {
+  value: string
+  onChange: (value: string) => void
+  categories: Category[]
+  placeholder?: string
+  disabled?: boolean
+  className?: string
+  uncategorizedLabel?: string
+  contentProps?: React.ComponentProps<typeof SelectContent>
+}
+
+export function CategorySelect({
+  value,
+  onChange,
+  categories,
+  placeholder = 'Select category',
+  disabled = false,
+  className = "w-full border border-border rounded-md px-3 py-2 text-sm bg-background disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]",
+  uncategorizedLabel,
+  contentProps,
+}: CategorySelectProps) {
+  return (
+    <Select
+      value={value === '' ? 'uncategorized-internal-value' : value}
+      onValueChange={(nextValue) => {
+        onChange(nextValue === 'uncategorized-internal-value' ? '' : nextValue)
+      }}
+      disabled={disabled}
+    >
+      <SelectTrigger className={className}>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent position="popper" {...contentProps}>
+        {uncategorizedLabel && (
+          <SelectItem value="uncategorized-internal-value" className="italic text-muted-foreground">
+            {uncategorizedLabel}
+          </SelectItem>
+        )}
+        {categories.map((cat) => (
+          <SelectItem key={cat.id} value={cat.id}>
+            {cat.color ? (
+              <span
+                className="size-2.5 shrink-0 rounded-full border border-black/5"
+                style={{ backgroundColor: cat.color }}
+              />
+            ) : null}
+            <span>{cat.name}</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/frontend/src/components/category-select.tsx
+++ b/frontend/src/components/category-select.tsx
@@ -1,32 +1,52 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select'
-import type { CategoryGroup } from '@/types'
+import type { Category, CategoryGroup } from '@/types'
 
 interface CategorySelectProps {
   value: string
   onChange: (value: string) => void
+  categories: Category[]
   groups: CategoryGroup[]
   placeholder?: string
   disabled?: boolean
   className?: string
-  uncategorizedLabel?: string
+  allowNone?: boolean
   contentProps?: React.ComponentProps<typeof SelectContent>
 }
 
 export function CategorySelect({
   value,
   onChange,
+  categories,
   groups,
   placeholder = 'Select category',
   disabled = false,
   className = "w-full border border-border rounded-md px-3 py-2 text-sm bg-background disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]",
-  uncategorizedLabel,
+  allowNone = false,
   contentProps,
 }: CategorySelectProps) {
+  const { t } = useTranslation()
+
+  const displayGroups = useMemo(() => {
+    const ungrouped = (categories ?? []).filter((c) => !c.group_id)
+    if (ungrouped.length === 0) return groups
+
+    return [
+      ...groups,
+      {
+        id: 'ungrouped-virtual',
+        name: t('groups.noGroup'),
+        categories: ungrouped,
+      } as CategoryGroup,
+    ]
+  }, [categories, groups, t])
+
   return (
     <Select
-      value={value === '' ? 'uncategorized-internal-value' : value}
+      value={value === '' ? (allowNone ? 'none' : undefined) : value}
       onValueChange={(nextValue) => {
-        onChange(nextValue === 'uncategorized-internal-value' ? '' : nextValue)
+        onChange(nextValue === 'none' ? '' : nextValue)
       }}
       disabled={disabled}
     >
@@ -34,12 +54,12 @@ export function CategorySelect({
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent position="popper" {...contentProps}>
-        {uncategorizedLabel && (
-          <SelectItem value="uncategorized-internal-value" className="italic text-muted-foreground">
-            {uncategorizedLabel}
+        {allowNone && (
+          <SelectItem value="none" className="italic text-muted-foreground">
+            {t('transactions.noCategory')}
           </SelectItem>
         )}
-        {groups.map((group) => (
+        {displayGroups.map((group) => (
           <SelectGroup key={group.id}>
             <SelectLabel className="px-2 py-1.5 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
               {group.name}

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -23,10 +23,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { CategorySelect } from '@/components/category-select'
 import { TransactionAttachments } from '@/components/transaction-attachments'
 import type { AttachmentPreview } from '@/components/transaction-attachments'
 import { TransactionSplitsSection } from '@/components/transaction-splits-section'
-import type { Transaction, RecurringTransaction, TransactionSplitsInput } from '@/types'
+import type { Transaction, RecurringTransaction, TransactionSplitsInput, Category } from '@/types'
 import { toast } from 'sonner'
 
 export type SaveAction = 'save' | 'saveAndNew' | 'saveAndDuplicate'
@@ -78,7 +79,7 @@ export function TransactionDialog({
   open: boolean
   onClose: () => void
   transaction: Transaction | null
-  categories: { id: string; name: string; icon: string }[]
+  categories: Category[]
   accounts: { id: string; name: string; type?: string }[]
   recurringMatch?: RecurringTransaction
   onSave: (data: Partial<Transaction>, recurringData?: { frequency: string; end_date?: string }, pendingFiles?: File[], action?: SaveAction) => void
@@ -278,7 +279,7 @@ function TransactionForm({
 }: {
   transaction: Transaction | null
   duplicateDraft: Partial<Transaction> | null
-  categories: { id: string; name: string; icon: string }[]
+  categories: Category[]
   accounts: { id: string; name: string; type?: string }[]
   recurringMatch?: RecurringTransaction
   onSave: (data: Partial<Transaction>, recurringData?: { frequency: string; end_date?: string }, pendingFiles?: File[], action?: SaveAction) => void
@@ -652,16 +653,13 @@ function TransactionForm({
         </div>
         <div className="space-y-2">
           <Label>{t('transactions.category')}</Label>
-          <select
-            className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
+          <CategorySelect
             value={categoryId}
-            onChange={(e) => setCategoryId(e.target.value)}
-          >
-            <option value="">{t('transactions.noCategory')}</option>
-            {categories.map((cat) => (
-              <option key={cat.id} value={cat.id}>{cat.name}</option>
-            ))}
-          </select>
+            onChange={setCategoryId}
+            categories={categories}
+            uncategorizedLabel={t('transactions.noCategory')}
+            disabled={isSynced}
+          />
         </div>
       </div>
       <div className={cn("grid gap-4", isSynced ? "grid-cols-1" : "grid-cols-2")}>

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -27,7 +27,7 @@ import { CategorySelect } from '@/components/category-select'
 import { TransactionAttachments } from '@/components/transaction-attachments'
 import type { AttachmentPreview } from '@/components/transaction-attachments'
 import { TransactionSplitsSection } from '@/components/transaction-splits-section'
-import type { Transaction, RecurringTransaction, TransactionSplitsInput, Category } from '@/types'
+import type { Transaction, RecurringTransaction, TransactionSplitsInput, CategoryGroup } from '@/types'
 import { toast } from 'sonner'
 
 export type SaveAction = 'save' | 'saveAndNew' | 'saveAndDuplicate'
@@ -64,7 +64,7 @@ export function TransactionDialog({
   open,
   onClose,
   transaction,
-  categories,
+  categoryGroups,
   accounts,
   recurringMatch,
   onSave,
@@ -79,7 +79,7 @@ export function TransactionDialog({
   open: boolean
   onClose: () => void
   transaction: Transaction | null
-  categories: Category[]
+  categoryGroups: CategoryGroup[]
   accounts: { id: string; name: string; type?: string }[]
   recurringMatch?: RecurringTransaction
   onSave: (data: Partial<Transaction>, recurringData?: { frequency: string; end_date?: string }, pendingFiles?: File[], action?: SaveAction) => void
@@ -148,7 +148,7 @@ export function TransactionDialog({
               key={transaction?.id ?? `new-${formResetKey}`}
               transaction={transaction}
               duplicateDraft={duplicateDraft}
-              categories={categories}
+              categoryGroups={categoryGroups}
               accounts={accounts}
               recurringMatch={recurringMatch}
               onSave={onSave}
@@ -263,7 +263,7 @@ export function TransactionDialog({
 function TransactionForm({
   transaction,
   duplicateDraft,
-  categories,
+  categoryGroups,
   accounts,
   recurringMatch,
   onSave,
@@ -279,7 +279,7 @@ function TransactionForm({
 }: {
   transaction: Transaction | null
   duplicateDraft: Partial<Transaction> | null
-  categories: Category[]
+  categoryGroups: CategoryGroup[]
   accounts: { id: string; name: string; type?: string }[]
   recurringMatch?: RecurringTransaction
   onSave: (data: Partial<Transaction>, recurringData?: { frequency: string; end_date?: string }, pendingFiles?: File[], action?: SaveAction) => void
@@ -656,7 +656,7 @@ function TransactionForm({
           <CategorySelect
             value={categoryId}
             onChange={setCategoryId}
-            categories={categories}
+            groups={categoryGroups}
             uncategorizedLabel={t('transactions.noCategory')}
             disabled={isSynced}
           />

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -27,7 +27,7 @@ import { CategorySelect } from '@/components/category-select'
 import { TransactionAttachments } from '@/components/transaction-attachments'
 import type { AttachmentPreview } from '@/components/transaction-attachments'
 import { TransactionSplitsSection } from '@/components/transaction-splits-section'
-import type { Transaction, RecurringTransaction, TransactionSplitsInput, CategoryGroup } from '@/types'
+import type { Transaction, RecurringTransaction, TransactionSplitsInput, CategoryGroup, Category } from '@/types'
 import { toast } from 'sonner'
 
 export type SaveAction = 'save' | 'saveAndNew' | 'saveAndDuplicate'
@@ -64,6 +64,7 @@ export function TransactionDialog({
   open,
   onClose,
   transaction,
+  categories,
   categoryGroups,
   accounts,
   recurringMatch,
@@ -79,6 +80,7 @@ export function TransactionDialog({
   open: boolean
   onClose: () => void
   transaction: Transaction | null
+  categories: Category[]
   categoryGroups: CategoryGroup[]
   accounts: { id: string; name: string; type?: string }[]
   recurringMatch?: RecurringTransaction
@@ -148,6 +150,7 @@ export function TransactionDialog({
               key={transaction?.id ?? `new-${formResetKey}`}
               transaction={transaction}
               duplicateDraft={duplicateDraft}
+              categories={categories}
               categoryGroups={categoryGroups}
               accounts={accounts}
               recurringMatch={recurringMatch}
@@ -263,6 +266,7 @@ export function TransactionDialog({
 function TransactionForm({
   transaction,
   duplicateDraft,
+  categories,
   categoryGroups,
   accounts,
   recurringMatch,
@@ -279,6 +283,7 @@ function TransactionForm({
 }: {
   transaction: Transaction | null
   duplicateDraft: Partial<Transaction> | null
+  categories: Category[]
   categoryGroups: CategoryGroup[]
   accounts: { id: string; name: string; type?: string }[]
   recurringMatch?: RecurringTransaction
@@ -656,9 +661,9 @@ function TransactionForm({
           <CategorySelect
             value={categoryId}
             onChange={setCategoryId}
+            categories={categories}
             groups={categoryGroups}
-            uncategorizedLabel={t('transactions.noCategory')}
-            disabled={isSynced}
+            allowNone={true}
           />
         </div>
       </div>

--- a/frontend/src/components/transactions-filter-bar.tsx
+++ b/frontend/src/components/transactions-filter-bar.tsx
@@ -19,6 +19,7 @@ import { ptBR, enUS } from 'date-fns/locale'
 
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
@@ -346,18 +347,27 @@ export function TransactionsFilterBar({
                         </div>
                       ) : (
                         accounts.map((a) => (
-                          <CheckRow
+                          <DropdownMenuCheckboxItem
                             key={a.id}
                             checked={filterAccountIds.includes(a.id)}
-                            onToggle={() => {
+                            onSelect={(e) => {
+                              e.preventDefault()
                               keepAccountSubOpenRef.current = true
                               onAccountIdsChange(
                                 toggleInArray(filterAccountIds, a.id),
                               )
                             }}
-                            label={getAccountName(a)}
-                            sublabel={a.currency}
-                          />
+                            className="gap-2 rounded-sm py-1.5 text-[13px]"
+                          >
+                            <span className="min-w-0 flex-1 truncate text-left">
+                              {getAccountName(a)}
+                            </span>
+                            {a.currency && (
+                              <span className="text-[10.5px] uppercase tracking-wide text-muted-foreground/70">
+                                {a.currency}
+                              </span>
+                            )}
+                          </DropdownMenuCheckboxItem>
                         ))
                       )}
                       {filterAccountIds.length > 0 && (
@@ -399,15 +409,19 @@ export function TransactionsFilterBar({
                       sideOffset={8}
                       className="max-h-[320px] w-[240px] overflow-y-auto p-1"
                     >
-                      <CheckRow
+                      <DropdownMenuCheckboxItem
                         checked={filterUncategorized}
-                        onToggle={() => {
+                        onSelect={(e) => {
+                          e.preventDefault()
                           keepCategorySubOpenRef.current = true
                           onUncategorizedChange(!filterUncategorized)
                         }}
-                        label={t('transactions.uncategorized')}
-                        italic
-                      />
+                        className="gap-2 rounded-sm py-1.5 text-[13px]"
+                      >
+                        <span className="min-w-0 flex-1 truncate text-left italic text-muted-foreground">
+                          {t('transactions.uncategorized')}
+                        </span>
+                      </DropdownMenuCheckboxItem>
                       <div className="my-1 h-px bg-border/60" />
                       {categories.length === 0 ? (
                         <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
@@ -415,18 +429,28 @@ export function TransactionsFilterBar({
                         </div>
                       ) : (
                         categories.map((c) => (
-                          <CheckRow
+                          <DropdownMenuCheckboxItem
                             key={c.id}
                             checked={filterCategoryIds.includes(c.id)}
-                            onToggle={() => {
+                            onSelect={(e) => {
+                              e.preventDefault()
                               keepCategorySubOpenRef.current = true
                               onCategoryIdsChange(
                                 toggleInArray(filterCategoryIds, c.id),
                               )
                             }}
-                            label={c.name}
-                            swatchColor={c.color ?? undefined}
-                          />
+                            className="gap-2 rounded-sm py-1.5 text-[13px]"
+                          >
+                            {c.color ? (
+                              <span
+                                className="size-2.5 shrink-0 rounded-full border border-black/5"
+                                style={{ backgroundColor: c.color }}
+                              />
+                            ) : null}
+                            <span className="min-w-0 flex-1 truncate text-left">
+                              {c.name}
+                            </span>
+                          </DropdownMenuCheckboxItem>
                         ))
                       )}
                       {(filterCategoryIds.length > 0 || filterUncategorized) && (
@@ -917,69 +941,6 @@ function FilterChip({ icon, label, value, tint, onRemove }: FilterChipProps) {
     </button>
   )
 }
-
-interface CheckRowProps {
-  checked: boolean
-  onToggle: () => void
-  label: string
-  sublabel?: string
-  swatchColor?: string
-  italic?: boolean
-}
-
-function CheckRow({
-  checked,
-  onToggle,
-  label,
-  sublabel,
-  swatchColor,
-  italic,
-}: CheckRowProps) {
-  return (
-    <DropdownMenuItem
-      onSelect={(e) => {
-        // Keep the menu open so users can select multiple options.
-        e.preventDefault()
-        onToggle()
-      }}
-      className={cn(
-        'gap-2 rounded-sm px-2 py-1.5 text-[13px]',
-        checked && 'bg-primary/5 data-[highlighted]:bg-primary/10',
-      )}
-    >
-      <span
-        className={cn(
-          'flex size-[14px] shrink-0 items-center justify-center rounded-[4px] border transition-colors',
-          checked
-            ? 'border-primary bg-primary text-primary-foreground'
-            : 'border-border/80 bg-background',
-        )}
-      >
-        {checked && <Check size={10} strokeWidth={3} />}
-      </span>
-      {swatchColor ? (
-        <span
-          className="size-2.5 shrink-0 rounded-full border border-black/5"
-          style={{ backgroundColor: swatchColor }}
-        />
-      ) : null}
-      <span
-        className={cn(
-          'min-w-0 flex-1 truncate text-left',
-          italic && 'italic text-muted-foreground',
-        )}
-      >
-        {label}
-      </span>
-      {sublabel && (
-        <span className="text-[10.5px] uppercase tracking-wide text-muted-foreground/70">
-          {sublabel}
-        </span>
-      )}
-    </DropdownMenuItem>
-  )
-}
-
 
 // Search input with inline `#tag` chips. Free text is a normal input;
 // `#`-prefixed words become purple chips when committed via comma, space

--- a/frontend/src/components/transactions-filter-bar.tsx
+++ b/frontend/src/components/transactions-filter-bar.tsx
@@ -39,7 +39,7 @@ import {
 import { Calendar } from '@/components/ui/calendar'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import type { Account, Category, Group, Payee } from '@/types'
+import type { Account, Category, CategoryGroup, Group, Payee } from '@/types'
 
 interface TransactionsFilterBarProps {
   searchInput: string
@@ -62,7 +62,7 @@ interface TransactionsFilterBarProps {
   onDateRangeChange: (from: string, to: string) => void
   onClearAll: () => void
   accounts: Account[]
-  categories: Category[]
+  categories: CategoryGroup[]
   payees: Payee[]
   groups: Group[]
 }
@@ -149,7 +149,9 @@ export function TransactionsFilterBar({
 
   const categoryById = useMemo(() => {
     const map = new Map<string, Category>()
-    categories.forEach((c) => map.set(c.id, c))
+    categories.forEach((g) => {
+      g.categories.forEach((c) => map.set(c.id, c))
+    })
     return map
   }, [categories])
 
@@ -428,29 +430,36 @@ export function TransactionsFilterBar({
                           {t('transactions.filtersBar.noOptions')}
                         </div>
                       ) : (
-                        categories.map((c) => (
-                          <DropdownMenuCheckboxItem
-                            key={c.id}
-                            checked={filterCategoryIds.includes(c.id)}
-                            onSelect={(e) => {
-                              e.preventDefault()
-                              keepCategorySubOpenRef.current = true
-                              onCategoryIdsChange(
-                                toggleInArray(filterCategoryIds, c.id),
-                              )
-                            }}
-                            className="gap-2 rounded-sm py-1.5 text-[13px]"
-                          >
-                            {c.color ? (
-                              <span
-                                className="size-2.5 shrink-0 rounded-full border border-black/5"
-                                style={{ backgroundColor: c.color }}
-                              />
-                            ) : null}
-                            <span className="min-w-0 flex-1 truncate text-left">
-                              {c.name}
-                            </span>
-                          </DropdownMenuCheckboxItem>
+                        categories.map((group) => (
+                          <DropdownMenuGroup key={group.id}>
+                            <DropdownMenuLabel className="px-2 py-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
+                              {group.name}
+                            </DropdownMenuLabel>
+                            {group.categories.map((c) => (
+                              <DropdownMenuCheckboxItem
+                                key={c.id}
+                                checked={filterCategoryIds.includes(c.id)}
+                                onSelect={(e) => {
+                                  e.preventDefault()
+                                  keepCategorySubOpenRef.current = true
+                                  onCategoryIdsChange(
+                                    toggleInArray(filterCategoryIds, c.id),
+                                  )
+                                }}
+                                className="gap-2 rounded-sm py-1.5 text-[13px]"
+                              >
+                                {c.color ? (
+                                  <span
+                                    className="size-2.5 shrink-0 rounded-full border border-black/5"
+                                    style={{ backgroundColor: c.color }}
+                                  />
+                                ) : null}
+                                <span className="min-w-0 flex-1 truncate text-left">
+                                  {c.name}
+                                </span>
+                              </DropdownMenuCheckboxItem>
+                            ))}
+                          </DropdownMenuGroup>
                         ))
                       )}
                       {(filterCategoryIds.length > 0 || filterUncategorized) && (

--- a/frontend/src/components/transactions-filter-bar.tsx
+++ b/frontend/src/components/transactions-filter-bar.tsx
@@ -62,7 +62,8 @@ interface TransactionsFilterBarProps {
   onDateRangeChange: (from: string, to: string) => void
   onClearAll: () => void
   accounts: Account[]
-  categories: CategoryGroup[]
+  categories: Category[]
+  categoryGroups: CategoryGroup[]
   payees: Payee[]
   groups: Group[]
 }
@@ -97,6 +98,7 @@ export function TransactionsFilterBar({
   onClearAll,
   accounts,
   categories,
+  categoryGroups,
   payees,
   groups,
 }: TransactionsFilterBarProps) {
@@ -149,11 +151,23 @@ export function TransactionsFilterBar({
 
   const categoryById = useMemo(() => {
     const map = new Map<string, Category>()
-    categories.forEach((g) => {
-      g.categories.forEach((c) => map.set(c.id, c))
-    })
+    categories.forEach((c) => map.set(c.id, c))
     return map
   }, [categories])
+
+  const displayCategoryGroups = useMemo(() => {
+    const ungroupedCategories = categories.filter((c) => !c.group_id)
+    if (ungroupedCategories.length === 0) return categoryGroups
+
+    return [
+      ...categoryGroups,
+      {
+        id: 'ungrouped',
+        name: t('groups.noGroup'),
+        categories: ungroupedCategories,
+      } as CategoryGroup,
+    ]
+  }, [categories, categoryGroups, t])
 
   const selectedPayee = useMemo(
     () => payees.find((p) => p.id === filterPayee),
@@ -425,12 +439,12 @@ export function TransactionsFilterBar({
                         </span>
                       </DropdownMenuCheckboxItem>
                       <div className="my-1 h-px bg-border/60" />
-                      {categories.length === 0 ? (
+                      {displayCategoryGroups.length === 0 ? (
                         <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
                           {t('transactions.filtersBar.noOptions')}
                         </div>
                       ) : (
-                        categories.map((group) => (
+                        displayCategoryGroups.map((group) => (
                           <DropdownMenuGroup key={group.id}>
                             <DropdownMenuLabel className="px-2 py-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
                               {group.name}

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -92,15 +92,23 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        checked && "bg-primary/5 data-[highlighted]:bg-primary/10",
         className
       )}
       checked={checked}
       {...props}
     >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+      <span
+        className={cn(
+          "flex size-[14px] shrink-0 items-center justify-center rounded-[4px] border transition-colors",
+          checked
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-border/80 bg-background"
+        )}
+      >
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <CheckIcon className="size-2.5" strokeWidth={3} />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,188 @@
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "w-full min-w-[var(--radix-select-trigger-width)] max-h-[var(--radix-select-content-available-height)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/frontend/src/pages/account-detail.tsx
+++ b/frontend/src/pages/account-detail.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
 import { format, addDays, addMonths, parseISO } from 'date-fns'
 import { ptBR, enUS } from 'date-fns/locale'
-import { accounts, transactions, categories as categoriesApi } from '@/lib/api'
+import { accounts, transactions, categoryGroups as categoryGroupsApi } from '@/lib/api'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import type { CreditCardBill, Transaction } from '@/types'
@@ -518,9 +518,9 @@ export default function AccountDetailPage() {
     enabled: !!id,
   })
 
-  const { data: categoriesList } = useQuery({
-    queryKey: ['categories'],
-    queryFn: categoriesApi.list,
+  const { data: categoryGroupsList } = useQuery({
+    queryKey: ['categoryGroups'],
+    queryFn: categoryGroupsApi.list,
   })
 
   const updateMutation = useMutation({
@@ -1436,7 +1436,7 @@ export default function AccountDetailPage() {
         open={dialogOpen}
         onClose={() => { setDialogOpen(false); setEditingTx(null) }}
         transaction={editingTx}
-        categories={categoriesList ?? []}
+        categoryGroups={categoryGroupsList ?? []}
         accounts={accountsList ?? []}
         onSave={(data) => {
           if (editingTx) {

--- a/frontend/src/pages/account-detail.tsx
+++ b/frontend/src/pages/account-detail.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
 import { format, addDays, addMonths, parseISO } from 'date-fns'
 import { ptBR, enUS } from 'date-fns/locale'
-import { accounts, transactions, categoryGroups as categoryGroupsApi } from '@/lib/api'
+import { accounts, transactions, categories as categoriesApi, categoryGroups as categoryGroupsApi } from '@/lib/api'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import type { CreditCardBill, Transaction } from '@/types'
@@ -516,6 +516,11 @@ export default function AccountDetailPage() {
       include_opening_balance: true,
     }),
     enabled: !!id,
+  })
+
+  const { data: categoriesList } = useQuery({
+    queryKey: ['categories'],
+    queryFn: categoriesApi.list,
   })
 
   const { data: categoryGroupsList } = useQuery({
@@ -1436,6 +1441,7 @@ export default function AccountDetailPage() {
         open={dialogOpen}
         onClose={() => { setDialogOpen(false); setEditingTx(null) }}
         transaction={editingTx}
+        categories={categoriesList ?? []}
         categoryGroups={categoryGroupsList ?? []}
         accounts={accountsList ?? []}
         onSave={(data) => {

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { ptBR, enUS } from 'date-fns/locale'
-import { dashboard, transactions, budgets, categoryGroups as categoryGroupsApi, accounts as accountsApi, goals as goalsApi, groups as groupsApi } from '@/lib/api'
+import { dashboard, transactions, budgets, categories as categoriesApi, categoryGroups as categoryGroupsApi, accounts as accountsApi, goals as goalsApi, groups as groupsApi } from '@/lib/api'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
@@ -147,6 +147,11 @@ export default function DashboardPage() {
   const { data: budgetComparison } = useQuery({
     queryKey: ['budgets', 'comparison', selectedMonth],
     queryFn: () => budgets.comparison(monthParam),
+  })
+
+  const { data: categoriesList } = useQuery({
+    queryKey: ['categories'],
+    queryFn: categoriesApi.list,
   })
 
   const { data: categoryGroupsList } = useQuery({
@@ -1043,6 +1048,7 @@ export default function DashboardPage() {
         open={dialogOpen}
         onClose={() => { setDialogOpen(false); setEditingTx(null) }}
         transaction={editingTx}
+        categories={categoriesList ?? []}
         categoryGroups={categoryGroupsList ?? []}
         accounts={(accountsList ?? []).map((a: { id: string; name: string; display_name?: string | null }) => ({ id: a.id, name: getAccountName(a) }))}
         onSave={(data) => {

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { ptBR, enUS } from 'date-fns/locale'
-import { dashboard, transactions, budgets, categories as categoriesApi, accounts as accountsApi, goals as goalsApi, groups as groupsApi } from '@/lib/api'
+import { dashboard, transactions, budgets, categoryGroups as categoryGroupsApi, accounts as accountsApi, goals as goalsApi, groups as groupsApi } from '@/lib/api'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
@@ -149,9 +149,9 @@ export default function DashboardPage() {
     queryFn: () => budgets.comparison(monthParam),
   })
 
-  const { data: categoriesList } = useQuery({
-    queryKey: ['categories'],
-    queryFn: categoriesApi.list,
+  const { data: categoryGroupsList } = useQuery({
+    queryKey: ['categoryGroups'],
+    queryFn: categoryGroupsApi.list,
   })
 
   const { data: accountsList } = useQuery({
@@ -1043,7 +1043,7 @@ export default function DashboardPage() {
         open={dialogOpen}
         onClose={() => { setDialogOpen(false); setEditingTx(null) }}
         transaction={editingTx}
-        categories={(categoriesList ?? []).map((c: { id: string; name: string; icon: string }) => ({ id: c.id, name: c.name, icon: c.icon }))}
+        categoryGroups={categoryGroupsList ?? []}
         accounts={(accountsList ?? []).map((a: { id: string; name: string; display_name?: string | null }) => ({ id: a.id, name: getAccountName(a) }))}
         onSave={(data) => {
           if (editingTx) updateMutation.mutate({ id: editingTx.id, ...data })

--- a/frontend/src/pages/recurring.tsx
+++ b/frontend/src/pages/recurring.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { categories as categoriesApi, recurring as recurringApi, accounts as accountsApi, currencies as currenciesApi } from '@/lib/api'
+import { categoryGroups as categoryGroupsApi, recurring as recurringApi, accounts as accountsApi, currencies as currenciesApi } from '@/lib/api'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -15,7 +15,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog'
-import type { Category, RecurringTransaction } from '@/types'
+import type { CategoryGroup, RecurringTransaction } from '@/types'
 import { Pencil, Trash2, Plus, RefreshCw, Info } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PageHeader } from '@/components/page-header'
@@ -73,9 +73,9 @@ function RecurringTab() {
     queryFn: recurringApi.list,
   })
 
-  const { data: categoriesList } = useQuery({
-    queryKey: ['categories'],
-    queryFn: categoriesApi.list,
+  const { data: categoryGroupsList } = useQuery({
+    queryKey: ['categoryGroups'],
+    queryFn: categoryGroupsApi.list,
   })
 
   const { data: accountsList } = useQuery({
@@ -233,7 +233,7 @@ function RecurringTab() {
           <RecurringForm
             key={editing?.id ?? 'new'}
             recurring={editing}
-            categories={categoriesList ?? []}
+            categoryGroups={categoryGroupsList ?? []}
             accounts={accountsList ?? []}
             onSave={(data) => {
               if (editing) {
@@ -253,14 +253,14 @@ function RecurringTab() {
 
 function RecurringForm({
   recurring,
-  categories,
+  categoryGroups,
   accounts,
   onSave,
   onCancel,
   loading,
 }: {
   recurring: RecurringTransaction | null
-  categories: Category[]
+    categoryGroups: CategoryGroup[]
   accounts: { id: string; name: string }[]
   onSave: (data: Partial<RecurringTransaction>) => void
   onCancel: () => void
@@ -365,7 +365,7 @@ function RecurringForm({
           <CategorySelect
             value={categoryId}
             onChange={setCategoryId}
-            categories={categories}
+            groups={categoryGroups}
             uncategorizedLabel={t('transactions.noCategory')}
             className={selectClass}
           />

--- a/frontend/src/pages/recurring.tsx
+++ b/frontend/src/pages/recurring.tsx
@@ -19,6 +19,7 @@ import type { Category, RecurringTransaction } from '@/types'
 import { Pencil, Trash2, Plus, RefreshCw, Info } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PageHeader } from '@/components/page-header'
+import { CategorySelect } from '@/components/category-select'
 import { DatePickerInput } from '@/components/ui/date-picker-input'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
@@ -361,12 +362,13 @@ function RecurringForm({
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
           <Label>{t('recurring.category')}</Label>
-          <select className={selectClass} value={categoryId} onChange={(e) => setCategoryId(e.target.value)}>
-            <option value="">{t('transactions.noCategory')}</option>
-            {categories.map((cat) => (
-              <option key={cat.id} value={cat.id}>{cat.name}</option>
-            ))}
-          </select>
+          <CategorySelect
+            value={categoryId}
+            onChange={setCategoryId}
+            categories={categories}
+            uncategorizedLabel={t('transactions.noCategory')}
+            className={selectClass}
+          />
         </div>
         <div className="space-y-2">
           <Label>{t('recurring.account')}</Label>

--- a/frontend/src/pages/recurring.tsx
+++ b/frontend/src/pages/recurring.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { categoryGroups as categoryGroupsApi, recurring as recurringApi, accounts as accountsApi, currencies as currenciesApi } from '@/lib/api'
+import { categories as categoriesApi, categoryGroups as categoryGroupsApi, recurring as recurringApi, accounts as accountsApi, currencies as currenciesApi } from '@/lib/api'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -15,7 +15,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog'
-import type { CategoryGroup, RecurringTransaction } from '@/types'
+import type { Category, CategoryGroup, RecurringTransaction } from '@/types'
 import { Pencil, Trash2, Plus, RefreshCw, Info } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PageHeader } from '@/components/page-header'
@@ -71,6 +71,11 @@ function RecurringTab() {
   const { data: recurringList } = useQuery({
     queryKey: ['recurring'],
     queryFn: recurringApi.list,
+  })
+
+  const { data: categoriesList } = useQuery({
+    queryKey: ['categories'],
+    queryFn: categoriesApi.list,
   })
 
   const { data: categoryGroupsList } = useQuery({
@@ -233,6 +238,7 @@ function RecurringTab() {
           <RecurringForm
             key={editing?.id ?? 'new'}
             recurring={editing}
+            categories={categoriesList ?? []}
             categoryGroups={categoryGroupsList ?? []}
             accounts={accountsList ?? []}
             onSave={(data) => {
@@ -253,6 +259,7 @@ function RecurringTab() {
 
 function RecurringForm({
   recurring,
+  categories,
   categoryGroups,
   accounts,
   onSave,
@@ -260,7 +267,8 @@ function RecurringForm({
   loading,
 }: {
   recurring: RecurringTransaction | null
-    categoryGroups: CategoryGroup[]
+  categories: Category[]
+  categoryGroups: CategoryGroup[]
   accounts: { id: string; name: string }[]
   onSave: (data: Partial<RecurringTransaction>) => void
   onCancel: () => void
@@ -365,8 +373,9 @@ function RecurringForm({
           <CategorySelect
             value={categoryId}
             onChange={setCategoryId}
+            categories={categories}
             groups={categoryGroups}
-            uncategorizedLabel={t('transactions.noCategory')}
+            allowNone={true}
             className={selectClass}
           />
         </div>

--- a/frontend/src/pages/rules.tsx
+++ b/frontend/src/pages/rules.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react'
 import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { categories as categoriesApi, rules as rulesApi, accounts as accountsApi, payees as payeesApi } from '@/lib/api'
+import { categoryGroups as categoryGroupsApi, rules as rulesApi, accounts as accountsApi, payees as payeesApi } from '@/lib/api'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -15,7 +15,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog'
-import type { Category, Payee, Rule, RuleCondition, RuleAction } from '@/types'
+import type { Category, CategoryGroup, Payee, Rule, RuleCondition, RuleAction } from '@/types'
 import { Trash2, Plus, RefreshCw, X, Package, Check, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { CategorySelect } from '@/components/category-select'
@@ -123,9 +123,9 @@ export default function RulesPage() {
     queryFn: rulesApi.list,
   })
 
-  const { data: categoriesList } = useQuery({
-    queryKey: ['categories'],
-    queryFn: categoriesApi.list,
+  const { data: categoryGroupsList } = useQuery({
+    queryKey: ['categoryGroups'],
+    queryFn: categoryGroupsApi.list,
   })
 
   const { data: accountsList } = useQuery({
@@ -193,7 +193,7 @@ export default function RulesPage() {
     onError: () => toast.error(t('common.error')),
   })
 
-  const categories = categoriesList ?? []
+  const categories = useMemo(() => (categoryGroupsList ?? []).flatMap(g => g.categories), [categoryGroupsList])
   const payees = payeesList ?? []
 
   const [sortBy, setSortBy] = useState<'priority' | 'name' | 'category'>('priority')
@@ -330,7 +330,7 @@ export default function RulesPage() {
         open={dialogOpen}
         onClose={() => { setDialogOpen(false); setEditing(null) }}
         rule={editing}
-        categories={categories}
+        categoryGroups={categoryGroupsList ?? []}
         accounts={accountsList ?? []}
         payees={payees}
         onSave={(data) => {
@@ -415,12 +415,12 @@ function RulePacksDialog({ open, onClose }: { open: boolean; onClose: () => void
 }
 
 function RuleDialog({
-  open, onClose, rule, categories, accounts, payees, onSave, loading,
+  open, onClose, rule, categoryGroups, accounts, payees, onSave, loading,
 }: {
   open: boolean
   onClose: () => void
   rule: Rule | null
-  categories: Category[]
+  categoryGroups: CategoryGroup[]
   accounts: { id: string; name: string }[]
   payees: Payee[]
   onSave: (data: Partial<Rule>) => void
@@ -608,7 +608,7 @@ function RuleDialog({
                       <CategorySelect
                         value={action.value}
                         onChange={(val) => updateAction(i, 'value', val)}
-                        categories={categories}
+                        groups={categoryGroups}
                         placeholder={t('rules.selectCategory')}
                         className={`${selectClass} w-full`}
                       />

--- a/frontend/src/pages/rules.tsx
+++ b/frontend/src/pages/rules.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react'
 import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { categoryGroups as categoryGroupsApi, rules as rulesApi, accounts as accountsApi, payees as payeesApi } from '@/lib/api'
+import { categories as categoriesApi, categoryGroups as categoryGroupsApi, rules as rulesApi, accounts as accountsApi, payees as payeesApi } from '@/lib/api'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -123,6 +123,11 @@ export default function RulesPage() {
     queryFn: rulesApi.list,
   })
 
+  const { data: categoriesList } = useQuery({
+    queryKey: ['categories'],
+    queryFn: categoriesApi.list,
+  })
+
   const { data: categoryGroupsList } = useQuery({
     queryKey: ['categoryGroups'],
     queryFn: categoryGroupsApi.list,
@@ -193,7 +198,7 @@ export default function RulesPage() {
     onError: () => toast.error(t('common.error')),
   })
 
-  const categories = useMemo(() => (categoryGroupsList ?? []).flatMap(g => g.categories), [categoryGroupsList])
+  const categories = categoriesList ?? []
   const payees = payeesList ?? []
 
   const [sortBy, setSortBy] = useState<'priority' | 'name' | 'category'>('priority')
@@ -330,6 +335,7 @@ export default function RulesPage() {
         open={dialogOpen}
         onClose={() => { setDialogOpen(false); setEditing(null) }}
         rule={editing}
+        categories={categories}
         categoryGroups={categoryGroupsList ?? []}
         accounts={accountsList ?? []}
         payees={payees}
@@ -415,11 +421,12 @@ function RulePacksDialog({ open, onClose }: { open: boolean; onClose: () => void
 }
 
 function RuleDialog({
-  open, onClose, rule, categoryGroups, accounts, payees, onSave, loading,
+  open, onClose, rule, categories, categoryGroups, accounts, payees, onSave, loading,
 }: {
   open: boolean
   onClose: () => void
   rule: Rule | null
+  categories: Category[]
   categoryGroups: CategoryGroup[]
   accounts: { id: string; name: string }[]
   payees: Payee[]
@@ -608,6 +615,7 @@ function RuleDialog({
                       <CategorySelect
                         value={action.value}
                         onChange={(val) => updateAction(i, 'value', val)}
+                        categories={categories}
                         groups={categoryGroups}
                         placeholder={t('rules.selectCategory')}
                         className={`${selectClass} w-full`}

--- a/frontend/src/pages/rules.tsx
+++ b/frontend/src/pages/rules.tsx
@@ -18,6 +18,7 @@ import {
 import type { Category, Payee, Rule, RuleCondition, RuleAction } from '@/types'
 import { Trash2, Plus, RefreshCw, X, Package, Check, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { CategorySelect } from '@/components/category-select'
 import { PageHeader } from '@/components/page-header'
 
 function SectionCard({ children }: { children: React.ReactNode }) {
@@ -603,17 +604,15 @@ function RuleDialog({
                     <option value="append_notes">{t('rules.appendNotes')}</option>
                   </select>
                   {action.op === 'set_category' ? (
-                    <select
-                      className={`${selectClass} w-0 flex-1 min-w-0`}
-                      value={action.value}
-                      onChange={(e) => updateAction(i, 'value', e.target.value)}
-                      required
-                    >
-                      <option value="">{t('rules.selectCategory')}</option>
-                      {categories.map(cat => (
-                        <option key={cat.id} value={cat.id}>{cat.name}</option>
-                      ))}
-                    </select>
+                    <div className="w-0 flex-1 min-w-0">
+                      <CategorySelect
+                        value={action.value}
+                        onChange={(val) => updateAction(i, 'value', val)}
+                        categories={categories}
+                        placeholder={t('rules.selectCategory')}
+                        className={`${selectClass} w-full`}
+                      />
+                    </div>
                   ) : action.op === 'set_payee' ? (
                     <select
                       className={`${selectClass} w-0 flex-1 min-w-0`}

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -15,13 +15,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import {
   Table,
   TableBody,
   TableCell,
@@ -34,6 +27,7 @@ import { AlertTriangle, ArrowLeftRight, Check, Download, HelpCircle, Info, Paper
 import type { Transaction } from '@/types'
 import { PageHeader } from '@/components/page-header'
 import { CategoryIcon } from '@/components/category-icon'
+import { CategorySelect } from '@/components/category-select'
 import { TransactionDialog, extractApiError, type SaveAction } from '@/components/transaction-dialog'
 import { TransferDialog } from '@/components/transfer-dialog'
 import { LinkTransferDialog } from '@/components/link-transfer-dialog'
@@ -905,36 +899,21 @@ export default function TransactionsPage() {
             <div className="w-px bg-border/60 self-stretch" />
 
             {/* Categorize — fires on selection, no separate Apply button */}
-            <Select
+            <CategorySelect
               value={bulkCategory}
-              onValueChange={(next) => {
+              onChange={(next) => {
                 setBulkCategory(next)
                 if (next) {
                   bulkCategorizeMutation.mutate({ ids: Array.from(selectedIds), categoryId: next === 'uncategorized' ? null : next })
                 }
               }}
+              categories={categoriesList ?? []}
+              placeholder={t('transactions.selectCategory')}
+              uncategorizedLabel={t('transactions.uncategorized')}
               disabled={bulkCategorizeMutation.isPending}
-            >
-              <SelectTrigger className="w-44 md:w-56 h-auto py-2 border-transparent bg-transparent hover:bg-muted/60 focus:bg-muted/60 focus-visible:ring-0">
-                <SelectValue placeholder={t('transactions.selectCategory')} />
-              </SelectTrigger>
-              <SelectContent position="popper" side="top" sideOffset={8}>
-                <SelectItem value="uncategorized" className="italic text-muted-foreground">
-                  {t('transactions.uncategorized')}
-                </SelectItem>
-                {categoriesList?.map((cat) => (
-                  <SelectItem key={cat.id} value={cat.id}>
-                    {cat.color ? (
-                      <span
-                        className="size-2.5 shrink-0 rounded-full border border-black/5"
-                        style={{ backgroundColor: cat.color }}
-                      />
-                    ) : null}
-                    <span>{cat.name}</span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              className="w-44 md:w-56 h-auto py-2 border-transparent bg-transparent hover:bg-muted/60 focus:bg-muted/60 focus-visible:ring-0"
+              contentProps={{ side: 'top', sideOffset: 8 }}
+            />
 
             <div className="w-px bg-border/60 self-stretch" />
 

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -3,7 +3,7 @@ import { getAccountName } from '@/lib/account-utils'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { transactions, categoryGroups as categoryGroupsApi, accounts as accountsApi, recurring, payees as payeesApi, admin, groups as groupsApi } from '@/lib/api'
+import { transactions, categories as categoriesApi, categoryGroups as categoryGroupsApi, accounts as accountsApi, recurring, payees as payeesApi, admin, groups as groupsApi } from '@/lib/api'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -239,6 +239,11 @@ export default function TransactionsPage() {
         q: searchQuery || undefined,
         tags: tagFilters.length > 0 ? tagFilters : undefined,
       }),
+  })
+
+  const { data: categoriesList } = useQuery({
+    queryKey: ['categories'],
+    queryFn: categoriesApi.list,
   })
 
   const { data: categoryGroupsList } = useQuery({
@@ -601,7 +606,8 @@ export default function TransactionsPage() {
           setPage(1)
         }}
         accounts={accountsList ?? []}
-        categories={categoryGroupsList ?? []}
+        categories={categoriesList ?? []}
+        categoryGroups={categoryGroupsList ?? []}
         payees={payeesList ?? []}
         groups={allGroups ?? []}
       />
@@ -904,12 +910,12 @@ export default function TransactionsPage() {
               onChange={(next) => {
                 setBulkCategory(next)
                 if (next) {
-                  bulkCategorizeMutation.mutate({ ids: Array.from(selectedIds), categoryId: next === 'uncategorized' ? null : next })
+                  bulkCategorizeMutation.mutate({ ids: Array.from(selectedIds), categoryId: next })
                 }
               }}
+              categories={categoriesList ?? []}
               groups={categoryGroupsList ?? []}
               placeholder={t('transactions.selectCategory')}
-              uncategorizedLabel={t('transactions.uncategorized')}
               disabled={bulkCategorizeMutation.isPending}
               className="w-44 md:w-56 h-auto py-2 border-transparent bg-transparent hover:bg-muted/60 focus:bg-muted/60 focus-visible:ring-0"
               contentProps={{ side: 'top', sideOffset: 8 }}
@@ -1013,6 +1019,7 @@ export default function TransactionsPage() {
         transaction={editingTx}
         duplicateDraft={duplicateDraft}
         formResetKey={formResetKey}
+        categories={categoriesList ?? []}
         categoryGroups={categoryGroupsList ?? []}
         accounts={accountsList ?? []}
         recurringMatch={editingTx ? recurringList?.find(r => r.description === editingTx.description && r.type === editingTx.type) : undefined}

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -3,7 +3,7 @@ import { getAccountName } from '@/lib/account-utils'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { transactions, categories as categoriesApi, accounts as accountsApi, recurring, payees as payeesApi, admin, groups as groupsApi } from '@/lib/api'
+import { transactions, categoryGroups as categoryGroupsApi, accounts as accountsApi, recurring, payees as payeesApi, admin, groups as groupsApi } from '@/lib/api'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -241,9 +241,9 @@ export default function TransactionsPage() {
       }),
   })
 
-  const { data: categoriesList } = useQuery({
-    queryKey: ['categories'],
-    queryFn: categoriesApi.list,
+  const { data: categoryGroupsList } = useQuery({
+    queryKey: ['categoryGroups'],
+    queryFn: categoryGroupsApi.list,
   })
 
   const { data: accountsList } = useQuery({
@@ -601,7 +601,7 @@ export default function TransactionsPage() {
           setPage(1)
         }}
         accounts={accountsList ?? []}
-        categories={categoriesList ?? []}
+        categories={categoryGroupsList ?? []}
         payees={payeesList ?? []}
         groups={allGroups ?? []}
       />
@@ -907,7 +907,7 @@ export default function TransactionsPage() {
                   bulkCategorizeMutation.mutate({ ids: Array.from(selectedIds), categoryId: next === 'uncategorized' ? null : next })
                 }
               }}
-              categories={categoriesList ?? []}
+              groups={categoryGroupsList ?? []}
               placeholder={t('transactions.selectCategory')}
               uncategorizedLabel={t('transactions.uncategorized')}
               disabled={bulkCategorizeMutation.isPending}
@@ -1013,7 +1013,7 @@ export default function TransactionsPage() {
         transaction={editingTx}
         duplicateDraft={duplicateDraft}
         formResetKey={formResetKey}
-        categories={categoriesList ?? []}
+        categoryGroups={categoryGroupsList ?? []}
         accounts={accountsList ?? []}
         recurringMatch={editingTx ? recurringList?.find(r => r.description === editingTx.description && r.type === editingTx.type) : undefined}
         onSave={handleTransactionSave}

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -15,6 +15,13 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
   Table,
   TableBody,
   TableCell,
@@ -898,23 +905,36 @@ export default function TransactionsPage() {
             <div className="w-px bg-border/60 self-stretch" />
 
             {/* Categorize — fires on selection, no separate Apply button */}
-            <select
-              className="rounded-lg px-3 py-2 text-sm bg-transparent text-foreground hover:bg-muted/60 focus:outline-none focus-visible:bg-muted/60 cursor-pointer w-44 md:w-56"
+            <Select
               value={bulkCategory}
-              onChange={(e) => {
-                const next = e.target.value
+              onValueChange={(next) => {
                 setBulkCategory(next)
                 if (next) {
-                  bulkCategorizeMutation.mutate({ ids: Array.from(selectedIds), categoryId: next })
+                  bulkCategorizeMutation.mutate({ ids: Array.from(selectedIds), categoryId: next === 'uncategorized' ? null : next })
                 }
               }}
               disabled={bulkCategorizeMutation.isPending}
             >
-              <option value="">{t('transactions.selectCategory')}</option>
-              {categoriesList?.map((cat) => (
-                <option key={cat.id} value={cat.id}>{cat.name}</option>
-              ))}
-            </select>
+              <SelectTrigger className="w-44 md:w-56 h-auto py-2 border-transparent bg-transparent hover:bg-muted/60 focus:bg-muted/60 focus-visible:ring-0">
+                <SelectValue placeholder={t('transactions.selectCategory')} />
+              </SelectTrigger>
+              <SelectContent position="popper" side="top" sideOffset={8}>
+                <SelectItem value="uncategorized" className="italic text-muted-foreground">
+                  {t('transactions.uncategorized')}
+                </SelectItem>
+                {categoriesList?.map((cat) => (
+                  <SelectItem key={cat.id} value={cat.id}>
+                    {cat.color ? (
+                      <span
+                        className="size-2.5 shrink-0 rounded-full border border-black/5"
+                        style={{ backgroundColor: cat.color }}
+                      />
+                    ) : null}
+                    <span>{cat.name}</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
 
             <div className="w-px bg-border/60 self-stretch" />
 


### PR DESCRIPTION
## What

This PR improves the category selection UI across the app. The final result replaces native `<select>` dropdowns with a custom component that shows category colors, and organizes the options by category groups.

<img width="400" alt="Screen Shot 2026-05-06 at 08 16 05" src="https://github.com/user-attachments/assets/c911b201-800c-48e9-8c34-327e5d1d5933" />
<img width="400" alt="Screen Shot 2026-05-06 at 08 15 41" src="https://github.com/user-attachments/assets/471592e6-5926-4317-a605-2b4c23073373" />

## Why

I initially just wanted to make the category selection in the bulk action bar prettier, with colors, similar to how it looks in the filter bar. 

To get there, the work is split into a few progressive commits. If you don't like the final grouping feature, we can just drop the last commit.

**1. Filter bar refactor (Commit 1)**
Replaces the custom `CheckRow` in the filter bar with the standard `DropdownMenuCheckboxItem`. I did this because I originally thought I'd reuse it for the bulk action bar. I ended up not doing that, but I kept the commit because it removes custom stuff in favor of standard components.

If you feel this is unnecessary, I can remove this commit from the PR and just add grouping (or not) using the `CheckRow` component.

**2. Unified Category Select with colors (Commits 2 & 3)**
Adds the shadcn `Select` component and creates a reusable `CategorySelect`. This replaces the ugly native selects in the bulk action bar, manual transaction dialog, rules, and recurring forms so they all share the same UI and category colors logic.

(I just ran `npx shadcn add select` to add that `Select` component) in commit.

|BEFORE|AFTER|
|----|----|
|<img width="100%" alt="Screen Shot 2026-05-06 at 08 21 23" src="https://github.com/user-attachments/assets/301115d7-6777-484f-b0ac-f8f43ce306cc" />|<img width="100%" alt="Screen Shot 2026-05-06 at 08 20 17" src="https://github.com/user-attachments/assets/69657688-bb47-4075-b2c3-bce6b19e44c9" />|
|<img width="100%" alt="transaction-0" src="https://github.com/user-attachments/assets/33ea470a-f2e6-4635-915a-a5b681ea3163" />|<img width="100%" alt="transaction-1" src="https://github.com/user-attachments/assets/da470a1e-0c37-4a16-9bb9-dbcf83db3ef7" />|

**3. Category grouping (Commit 4)**
Since category groups already exist in the DB, I updated the new `CategorySelect` and the filter bar to actually group the categories in the dropdowns. 

This commit changes a lot of code, since I needed to move from using categories lists to category groups lists.

|BEFORE|AFTER|
|----|----|
|<img width="100%" alt="dropdown-0" src="https://github.com/user-attachments/assets/dee32189-d65f-433f-b1fb-40169c215b4c" />|<img width="100%" alt="dropdown-2" src="https://github.com/user-attachments/assets/db45759d-ae0e-4904-af6b-5e055b133935" />|
|<img width="100%" alt="Screen Shot 2026-05-06 at 08 20 17" src="https://github.com/user-attachments/assets/69657688-bb47-4075-b2c3-bce6b19e44c9" />|<img width="100%" alt="Screen Shot 2026-05-06 at 08 15 41" src="https://github.com/user-attachments/assets/58fdc77a-fdfb-4bc1-89ca-0a951d43274a" />|
|<img width="100%" alt="rules-1" src="https://github.com/user-attachments/assets/1240a58a-6208-4548-961e-6fc95552319f" />|<img width="100%" alt="rules-2" src="https://github.com/user-attachments/assets/e5a65d2e-a7fa-41ad-869f-f67a2f9ffa80" />|
|<img width="100%" alt="recurring-1" src="https://github.com/user-attachments/assets/4026aaf4-ee03-498a-b3d7-79955deee949" />|<img width="100%" alt="recurring-2" src="https://github.com/user-attachments/assets/e2c445d0-7f2c-4cae-87a3-1fdd639c19ca" />|

## How to Test

Steps to verify the changes work:

1. Open the filter bar and check the categories submenu (grouped, standard checkboxes).
2. Select transactions and use the bulk action category dropdown (grouped, with colors).
3. Open the manual transaction, recurring, or rules dialogs and check the category dropdowns (grouped, with colors).

## Checklist

- [x] Backend tests pass (`pytest`) (N/A)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)

***Disclaimer:** Gemini helped me a bit with this one*