### PR TITLE
feat: badge effective bill date overrides on CC tx list (#162)

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -240,6 +240,7 @@
     "transferInfo": "This is a transfer — changes to description, date, and notes will apply to both sides",
     "transferTooltip": "Transfers are excluded from report and dashboard totals",
     "installmentTooltip": "Installment plan — {{count}} charges totaling {{total}}",
+    "billOverrideTooltip": "Moved to the bill due {{date}}",
     "linkAsTransfer": "Link as transfer",
     "linkTransferTitle": "Link as transfer",
     "linkTransferDescription": "Mark these two transactions as a single inter-account transfer. They will be excluded from spending and income reports.",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -240,6 +240,7 @@
     "transferInfo": "Esta é uma transferência — alterações na descrição, data e notas serão aplicadas em ambos os lados",
     "transferTooltip": "Transferências são excluídas dos totais de relatórios e dashboard",
     "installmentTooltip": "Compra parcelada — {{count}} parcelas totalizando {{total}}",
+    "billOverrideTooltip": "Movida para a fatura com vencimento em {{date}}",
     "linkAsTransfer": "Vincular como transferência",
     "linkTransferTitle": "Vincular como transferência",
     "linkTransferDescription": "Marcar estas duas transações como uma única transferência entre contas. Elas serão excluídas dos relatórios de gastos e receitas.",

--- a/frontend/src/pages/account-detail.tsx
+++ b/frontend/src/pages/account-detail.tsx
@@ -11,7 +11,7 @@ import { toast } from 'sonner'
 import type { CreditCardBill, Transaction } from '@/types'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
-import { ArrowLeft, ArrowLeftRight, ChevronLeft, ChevronRight, Clock, HelpCircle, Paperclip, Pencil, X } from 'lucide-react'
+import { ArrowLeft, ArrowLeftRight, CalendarClock, ChevronLeft, ChevronRight, Clock, HelpCircle, Paperclip, Pencil, X } from 'lucide-react'
 import { CategoryIcon } from '@/components/category-icon'
 import { TransactionDialog, extractApiError } from '@/components/transaction-dialog'
 import { TransferDialog } from '@/components/transfer-dialog'
@@ -1391,6 +1391,15 @@ export default function AccountDetailPage() {
                                   : undefined}
                               >
                                 {tx.installment_number}/{tx.total_installments}
+                              </span>
+                            )}
+                            {tx.effective_bill_date && (
+                              <span
+                                className="ml-2 inline-flex items-center gap-1 text-xs text-violet-600 dark:text-violet-400 font-normal bg-violet-50 dark:bg-violet-500/10 border border-violet-200 dark:border-violet-500/30 rounded px-1.5 py-0.5"
+                                title={t('transactions.billOverrideTooltip', 'Movida para a fatura com vencimento em {{date}}', { date: formatDateStr(tx.effective_bill_date, locale) })}
+                              >
+                                <CalendarClock className="h-3 w-3" />
+                                {formatDateStr(tx.effective_bill_date, locale)}
                               </span>
                             )}
                             {(tx.attachment_count ?? 0) > 0 && (


### PR DESCRIPTION
Closes #162.

Shows a violet badge with the override date next to transactions whose `effective_bill_date` is set, on the account-detail tx list.