### PR TITLE
fix: pending sync txs with effective_bill_date no longer vanish (#162)

### DIFF
--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -615,10 +615,22 @@ async def get_account_summary(
         # txs so an in-progress cycle's bar/total doesn't double-count past-
         # bill txs whose date falls in the window (see get_transactions).
         if unbilled_only:
+            # Forward-pointing override catch (issue #162): mirror
+            # get_transactions so the in-progress cycle's totals include
+            # txs whose manual override points past the cycle window.
+            # Without this the tx list and totals diverge — the tx shows
+            # in the list (after the catch in get_transactions) but its
+            # amount drops out of the strip pill / summary card.
+            future_override = _and(
+                Transaction.effective_bill_date.is_not(None),
+                Transaction.effective_bill_date > date_to,
+            )
             return query.where(
                 Transaction.bill_id.is_(None),
-                bucket_date >= date_from,
-                bucket_date <= date_to,
+                or_(
+                    _and(bucket_date >= date_from, bucket_date <= date_to),
+                    future_override,
+                ),
             )
         return query.where(bucket_date >= date_from, bucket_date <= date_to)
 

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -594,9 +594,17 @@ async def get_account_summary(
                 # different bill. If effective_date matches, the tx is
                 # pre-classified to this bill and we include it (the
                 # in-progress case abdalanervoso reported empty).
+                #
+                # Manual override (effective_bill_date) bypasses the
+                # exclusion entirely — the user explicitly hand-corrected
+                # the bucketing, so the totals must reflect that even if
+                # the override doesn't snap to a real bill due_date and
+                # bill_id stays null (issue #162). Mirrors the same
+                # carve-out in get_transactions.
                 _not(_and(
                     Transaction.source == "sync",
                     Transaction.status == "pending",
+                    Transaction.effective_bill_date.is_(None),
                     Transaction.effective_date != active_due_subq,
                 )),
                 bucket_date >= date_from,

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -219,9 +219,18 @@ async def get_transactions(
                 # because pending txs there have effective_date pointing
                 # forward to a later bill (ingrid's case stays clean).
                 # Issue #92, abdalanervoso's empty-May.
+                #
+                # Manual override (effective_bill_date) bypasses the
+                # exclusion entirely: the user has hand-corrected the
+                # bucketing and that signal beats both cycle-math
+                # classification and sync-pending caution. Without this
+                # carve-out, a pending tx whose override doesn't snap to
+                # an existing bill's due_date (so bill_id stays null)
+                # gets filtered out of every closed-bill view (issue #162).
                 _not(_and(
                     Transaction.source == "sync",
                     Transaction.status == "pending",
+                    Transaction.effective_bill_date.is_(None),
                     Transaction.effective_date != active_due_subq,
                 )),
             ]

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -249,10 +249,32 @@ async def get_transactions(
         # /transactions list and other generic callers leave it False.
         if unbilled_only:
             base_query = base_query.where(Transaction.bill_id.is_(None))
-        if from_date:
-            base_query = base_query.where(filter_date_col >= from_date)
-        if to_date:
-            base_query = base_query.where(filter_date_col <= to_date)
+        # Forward-pointing override catch (issue #162): a manual override
+        # pointing past this cycle's right edge (e.g., user wants the tx
+        # on a future bill that doesn't exist yet) won't fit any closed
+        # bill window either — past bills are by definition behind us.
+        # Honor the user's explicit intent by including those orphans in
+        # the in-progress cycle so the tx stays visible until a real bill
+        # eventually anchors it. Limited to `unbilled_only` so the global
+        # /transactions list isn't reshaped by the same rule.
+        if unbilled_only and to_date is not None:
+            from sqlalchemy import and_ as _and
+            window_clauses = []
+            if from_date:
+                window_clauses.append(filter_date_col >= from_date)
+            window_clauses.append(filter_date_col <= to_date)
+            base_query = base_query.where(or_(
+                _and(*window_clauses),
+                _and(
+                    Transaction.effective_bill_date.is_not(None),
+                    Transaction.effective_bill_date > to_date,
+                ),
+            ))
+        else:
+            if from_date:
+                base_query = base_query.where(filter_date_col >= from_date)
+            if to_date:
+                base_query = base_query.where(filter_date_col <= to_date)
     if search:
         term = f"%{search}%"
         base_query = base_query.where(

--- a/backend/tests/test_credit_card_accounting_mode.py
+++ b/backend/tests/test_credit_card_accounting_mode.py
@@ -1561,3 +1561,52 @@ class TestEffectiveBillDateFiltersList:
             accounting_mode="cash",
         )
         assert any(t.id == tx.id for t in apr_txs)
+
+    @pytest.mark.asyncio
+    async def test_override_on_pending_sync_tx_shows_in_target_bill(
+        self, session, test_user, cc_account
+    ):
+        """A pending sync tx with a manual `effective_bill_date` whose value
+        does NOT exactly match any bill's due_date (so `bill_id` stays null)
+        must still appear in the bill view whose cycle window contains the
+        override. The sync-pending exclusion clause exists to keep auto-
+        classified pending charges out of the wrong bill — but a manual
+        override is the user's explicit correction and beats that caution
+        (issue #162: txs disappearing after setting effective_bill_date)."""
+        from app.services.transaction_service import get_transactions
+        from app.models.credit_card_bill import CreditCardBill
+        from datetime import datetime, timezone
+
+        may = CreditCardBill(
+            user_id=test_user.id, account_id=cc_account.id,
+            external_id="bill-may", due_date=date(2026, 5, 16),
+            total_amount=Decimal("100"), currency="BRL",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        session.add(may)
+        await session.flush()
+
+        # Pending sync tx, override 2026-05-10 (within May's [Apr 17, May 16]
+        # window but NOT equal to May's due_date 2026-05-16, so the
+        # auto-relink leaves bill_id null).
+        tx = await _make_tx(
+            session, test_user.id, cc_account.id,
+            date(2026, 5, 11), Decimal("105"),
+            effective_date=date(2026, 5, 10),
+            source="sync",
+        )
+        tx.status = "pending"
+        tx.effective_bill_date = date(2026, 5, 10)
+        await session.commit()
+
+        may_txs, _ = await get_transactions(
+            session, test_user.id, account_id=cc_account.id,
+            bill_id=may.id,
+            from_date=date(2026, 4, 17), to_date=date(2026, 5, 16),
+            accounting_mode="cash",
+        )
+        assert any(t.id == tx.id for t in may_txs), (
+            "pending sync tx with manual override in window must be "
+            "visible in the target bill view"
+        )

--- a/backend/tests/test_credit_card_accounting_mode.py
+++ b/backend/tests/test_credit_card_accounting_mode.py
@@ -1650,3 +1650,47 @@ class TestEffectiveBillDateFiltersList:
             bill_id=may.id,
         )
         assert summary["monthly_expenses"] == 105.0
+
+    @pytest.mark.asyncio
+    async def test_override_past_in_progress_window_lands_in_in_progress(
+        self, session, test_user, cc_account
+    ):
+        """User sets `effective_bill_date` to a date past the in-progress
+        cycle's right edge — typically because they want the tx on a future
+        bill that doesn't exist yet. Closed bill windows can't host such
+        forward-pointing overrides (they're by definition past), so the
+        in-progress cycle catches them as the only forward-looking bucket.
+        Otherwise the tx vanishes (issue #162)."""
+        from app.services.transaction_service import get_transactions
+        from app.services.account_service import get_account_summary
+
+        # Tx with override well past the in-progress cycle's right edge
+        tx = await _make_tx(
+            session, test_user.id, cc_account.id,
+            date(2026, 3, 22), Decimal("59.90"),
+            effective_date=date(2026, 6, 11),
+            source="sync",
+        )
+        tx.status = "posted"
+        tx.effective_bill_date = date(2026, 6, 11)
+        await session.commit()
+
+        # In-progress cycle window for close=11/due=16 around early May:
+        # cycle = [Apr 12, May 11]. Override 6/11 lies past 5/11.
+        in_prog_txs, _ = await get_transactions(
+            session, test_user.id, account_id=cc_account.id,
+            from_date=date(2026, 4, 12), to_date=date(2026, 5, 11),
+            unbilled_only=True,
+            accounting_mode="cash",
+        )
+        assert any(t.id == tx.id for t in in_prog_txs), (
+            "tx with override past the in-progress cycle must be visible "
+            "in the in-progress view as the catch-all bucket"
+        )
+
+        summary = await get_account_summary(
+            session, cc_account.id, test_user.id,
+            date_from=date(2026, 4, 12), date_to=date(2026, 5, 11),
+            unbilled_only=True,
+        )
+        assert summary["monthly_expenses"] == 59.90

--- a/backend/tests/test_credit_card_accounting_mode.py
+++ b/backend/tests/test_credit_card_accounting_mode.py
@@ -1610,3 +1610,43 @@ class TestEffectiveBillDateFiltersList:
             "pending sync tx with manual override in window must be "
             "visible in the target bill view"
         )
+
+    @pytest.mark.asyncio
+    async def test_summary_includes_pending_sync_with_override(
+        self, session, test_user, cc_account
+    ):
+        """get_account_summary mirrors get_transactions: a pending sync tx
+        with `effective_bill_date` in the cycle window must contribute to
+        the totals card and bar chart even when the override doesn't snap
+        to a bill's due_date (so bill_id stays null). Without this the
+        strip pill totals diverge from the tx list (issue #162)."""
+        from app.services.account_service import get_account_summary
+        from app.models.credit_card_bill import CreditCardBill
+        from datetime import datetime, timezone
+
+        may = CreditCardBill(
+            user_id=test_user.id, account_id=cc_account.id,
+            external_id="bill-may-sum", due_date=date(2026, 5, 16),
+            total_amount=Decimal("0"), currency="BRL",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        session.add(may)
+        await session.flush()
+
+        tx = await _make_tx(
+            session, test_user.id, cc_account.id,
+            date(2026, 5, 11), Decimal("105"),
+            effective_date=date(2026, 5, 10),
+            source="sync",
+        )
+        tx.status = "pending"
+        tx.effective_bill_date = date(2026, 5, 10)
+        await session.commit()
+
+        summary = await get_account_summary(
+            session, cc_account.id, test_user.id,
+            date_from=date(2026, 4, 17), date_to=date(2026, 5, 16),
+            bill_id=may.id,
+        )
+        assert summary["monthly_expenses"] == 105.0


### PR DESCRIPTION
Pending sync txs whose `effective_bill_date` doesn't snap to a bill's `due_date` were filtered out of every bill view by the sync-pending exclusion clause. Manual override now bypasses that exclusion — user intent wins.
