### PR TITLE
fix: shared/split transactions for non-owner group members (#155)

### DIFF
--- a/backend/app/services/group_service.py
+++ b/backend/app/services/group_service.py
@@ -23,7 +23,30 @@ def _tag_owner(group: Group, user_id: uuid.UUID) -> Group:
     `is_owner` as derived per-request, not stored on the model.
     """
     group.is_owner = group.user_id == user_id  # type: ignore[attr-defined]
+    if getattr(group, "members", None):
+        for m in group.members:
+            _tag_member_self(m, user_id, group.user_id)
     return group
+
+
+def _tag_member_self(
+    member: GroupMember, user_id: uuid.UUID, group_owner_id: uuid.UUID
+) -> GroupMember:
+    """Override `is_self` per-request so the "(you)" tag tracks the
+    requesting user rather than the stored flag (which only marks the
+    owner's own member). Falls back to the stored flag for an owner
+    whose self-member isn't linked to a Securo account.
+    """
+    is_linked_to_caller = (
+        member.linked_user_id is not None and member.linked_user_id == user_id
+    )
+    is_owner_self_unlinked = (
+        group_owner_id == user_id
+        and member.linked_user_id is None
+        and bool(member.is_self)
+    )
+    member.is_self = is_linked_to_caller or is_owner_self_unlinked
+    return member
 
 
 async def _resolve_member_email(
@@ -176,14 +199,15 @@ async def list_members(
     # stale snapshot after upstream mutations like `_clear_self_flag`.
     # A direct query always reflects the current row state.
     # Visible to owners AND linked members (read-only context).
-    if not await get_group_visible(session, group_id, user_id):
+    group = await get_group_visible(session, group_id, user_id)
+    if not group:
         return None
     result = await session.execute(
         select(GroupMember)
         .where(GroupMember.group_id == group_id)
         .order_by(GroupMember.created_at)
     )
-    return list(result.scalars().all())
+    return [_tag_member_self(m, user_id, group.user_id) for m in result.scalars().all()]
 
 
 async def create_member(

--- a/backend/app/services/split_service.py
+++ b/backend/app/services/split_service.py
@@ -10,7 +10,7 @@ import uuid
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Optional
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.group import Group, GroupMember
@@ -87,12 +87,21 @@ async def _validate_members(
     member_ids: list[uuid.UUID],
     user_id: uuid.UUID,
 ) -> uuid.UUID:
-    """Ensure all members belong to a single group owned by `user_id`.
-    Returns that group's id."""
+    """Ensure all members belong to a single group VISIBLE to `user_id`
+    (owner OR linked member). Returns that group's id."""
+    # A group is visible if the user owns it or is linked as a member.
+    linked_group_ids = (
+        select(GroupMember.group_id)
+        .where(GroupMember.linked_user_id == user_id)
+        .distinct()
+    )
     result = await session.execute(
         select(GroupMember, Group)
         .join(Group, GroupMember.group_id == Group.id)
-        .where(GroupMember.id.in_(member_ids), Group.user_id == user_id)
+        .where(
+            GroupMember.id.in_(member_ids),
+            or_(Group.user_id == user_id, Group.id.in_(linked_group_ids)),
+        )
     )
     rows = result.all()
     if len(rows) != len(set(member_ids)):

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -1096,8 +1096,17 @@ async def bulk_add_to_group(
     if not transaction_ids:
         return {"updated": 0, "skipped": 0}
 
+    # The caller may own the group OR be a linked member of it.
+    linked_group_ids = (
+        select(GroupMember.group_id)
+        .where(GroupMember.linked_user_id == user_id)
+        .distinct()
+    )
     group_result = await session.execute(
-        select(Group).where(Group.id == group_id, Group.user_id == user_id)
+        select(Group).where(
+            Group.id == group_id,
+            or_(Group.user_id == user_id, Group.id.in_(linked_group_ids)),
+        )
     )
     group = group_result.scalar_one_or_none()
     if group is None:

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -1061,6 +1061,10 @@ export default function TransactionsPage() {
           setEditingTx(null)
           setDuplicateDraft(null)
           setPendingTransferCategoryUpdate(null)
+          // Drop any prior mutation error so reopening the dialog
+          // doesn't surface a stale message (issue #155).
+          createMutation.reset()
+          updateMutation.reset()
         }}
         transaction={editingTx}
         duplicateDraft={duplicateDraft}


### PR DESCRIPTION
Three related bugs surfaced when a linked secondary user tried to use a shared/split transaction on a group they don't own:

1. The "(you)" tag latched onto the stored is_self flag (which only marks the owner's own member), so secondary users saw "(you)" next to the owner instead of their own member.
2. _validate_members in split_service required Group.user_id == user_id, so saving the split returned "One or more split members not found" for any non-owner. The bulk add-to-group path in transaction_service had the same constraint.
3. The Add Transaction dialog kept the prior mutation error visible when reopened, because createMutation/updateMutation weren't reset on close.

Fix: compute is_self per-request from linked_user_id (with a fallback to the stored flag for an owner whose self-member isn't linked); allow the visibility predicate (owner OR linked member) in both validation paths; reset the mutations when the dialog closes.

## What

Brief description of the changes.

## Why

Why are these changes needed?

## How to Test

Steps to verify the changes work:

1. ...
2. ...

## Checklist

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
