### PR TITLE
fix: allow clicking member name to toggle split selection (#174)

### DIFF
--- a/frontend/src/components/transaction-splits-section.tsx
+++ b/frontend/src/components/transaction-splits-section.tsx
@@ -249,22 +249,24 @@ export function TransactionSplitsSection({
                               : null
                         return (
                           <div key={m.id} className="flex items-center gap-2">
-                            <input
-                              type="checkbox"
-                              checked={row.selected}
-                              onChange={(e) =>
-                                updateRow(m.id, { selected: e.target.checked })
-                              }
-                              className="h-4 w-4 rounded border-border accent-primary"
-                            />
-                            <span className="text-sm flex-1 min-w-0 truncate">
-                              {m.name}
-                              {m.is_self && (
-                                <span className="ml-1.5 text-xs text-primary">
-                                  ({t('splitGroups.you')})
-                                </span>
-                              )}
-                            </span>
+                            <label className="flex items-center gap-2 flex-1 min-w-0 cursor-pointer">
+                              <input
+                                type="checkbox"
+                                checked={row.selected}
+                                onChange={(e) =>
+                                  updateRow(m.id, { selected: e.target.checked })
+                                }
+                                className="h-4 w-4 rounded border-border accent-primary"
+                              />
+                              <span className="text-sm flex-1 min-w-0 truncate">
+                                {m.name}
+                                {m.is_self && (
+                                  <span className="ml-1.5 text-xs text-primary">
+                                    ({t('splitGroups.you')})
+                                  </span>
+                                )}
+                              </span>
+                            </label>
                             {computed !== null && (
                               <span className="text-xs text-muted-foreground tabular-nums">
                                 {formatCurrency(computed, currency)}


### PR DESCRIPTION
Fixes #174.

In the split transaction section of the add/edit transaction dialog, each group member row only let the user toggle selection by clicking the small checkbox itself — the member name next to it was not clickable. The parent "Split this transaction" row already wraps its checkbox + label in a `<label>` element, so this aligns the per-member rows with the same behavior.

Wrapped the checkbox + name in a `<label>` with `cursor-pointer`, leaving the per-row amount/percent inputs as siblings so they don't accidentally toggle the checkbox when interacted with.

## Test plan
- [x] Open Add Transaction → enter amount → toggle "Dividir esta transação"
- [x] Click on each member's name (Marcelo, tassio, Tereza) — checkbox toggles
- [x] Click on a member's checkbox directly — still toggles
- [x] Equal split recomputes per-member amount when (de)selecting via name click