### PR TITLE
 fix: reset bulk category select on page navigation

### DIFF
--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -1176,6 +1176,7 @@ export default function TransactionsPage() {
 
             {/* Categorize — fires on selection, no separate Apply button */}
             <CategorySelect
+              key={bulkCategory}
               value={bulkCategory}
               onChange={(next) => {
                 setBulkCategory(next)


### PR DESCRIPTION
## What

Reset the bulk category selector when navigating between pages on /transactions.

## Why

After selecting a category for bulk categorization and navigating to the next page, the category selector remained visually selected. Clicking that same category again had no effect — the mutation never fired.

Root cause: CategorySelect passes value={undefined} to Radix UI Select when no category is chosen (allowNone=false). This puts Radix in uncontrolled mode, where it maintains its own internal state. When page navigation reset bulkCategory to '', Radix still held the old value internally — so re-selecting the same category was a no-op.

Fix: added key={bulkCategory} to the CategorySelect in the bulk action bar. When bulkCategory resets to '', the key changes and React remounts the component with clean state.

## How to Test

  1. Go to /transactions, select one or more transactions
  2. Pick a category from the bulk selector — confirm the mutation fires (success toast)
  3. Navigate to the next page, select transactions again
  4. Pick the same category — confirm the mutation fires again (was broken before)
  5. On the same page, select category A → B → A — confirm all three fire correctly

## Checklist

- [X] Backend tests pass (`pytest`)
- [X] Frontend lints clean (`npm run lint`)
- [X] Frontend builds (`npm run build`)
- [X] Translations updated (if user-facing strings changed)
