### PR TITLE
fix: align asset values and net worth evolution with selected period

### DIFF
--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -162,6 +162,19 @@ async def _get_latest_value(session: AsyncSession, asset_id: uuid.UUID) -> Optio
     return result.scalar_one_or_none()
 
 
+async def _get_value_as_of(
+    session: AsyncSession, asset_id: uuid.UUID, as_of_date: date
+) -> Optional[AssetValue]:
+    """Get the most recent AssetValue for an asset on or before as_of_date."""
+    result = await session.execute(
+        select(AssetValue)
+        .where(AssetValue.asset_id == asset_id, AssetValue.date <= as_of_date)
+        .order_by(desc(AssetValue.date), desc(AssetValue.id))
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
 async def _get_value_count(session: AsyncSession, asset_id: uuid.UUID) -> int:
     """Get the number of AssetValue entries for an asset."""
     result = await session.scalar(
@@ -633,11 +646,19 @@ async def get_portfolio_trend(
     return {"assets": asset_meta, "trend": trend, "total": round(total, 2)}
 
 
-async def get_total_asset_value(
-    session: AsyncSession, user_id: uuid.UUID
-) -> dict[str, float]:
-    """Get total asset value grouped by currency (for dashboard).
-    Only includes non-archived assets that haven't been sold."""
+async def get_asset_values_at(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    as_of_date: Optional[date] = None,
+    primary_currency: Optional[str] = None,
+) -> tuple[dict[str, float], float]:
+    """Return (per_currency_totals, primary_total) for all active assets.
+
+    - as_of_date=None: uses live prices (current view).
+    - as_of_date set: uses the latest AssetValue on or before that date,
+      falling back to purchase_price only if the asset existed by that date.
+    - primary_currency=None: primary_total is 0.0.
+    """
     result = await session.execute(
         select(Asset).where(
             Asset.user_id == user_id,
@@ -648,12 +669,35 @@ async def get_total_asset_value(
     assets = list(result.scalars().all())
 
     totals: dict[str, float] = {}
+    primary_total = 0.0
+
     for asset in assets:
-        latest = await _get_latest_value(session, asset.id)
-        current = _compute_current_value(asset, latest)
-        if current is not None:
-            totals[asset.currency] = totals.get(asset.currency, 0.0) + current
-    return totals
+        if as_of_date is not None:
+            value_entry = await _get_value_as_of(session, asset.id, as_of_date)
+            if value_entry is not None:
+                amount: Optional[float] = float(value_entry.amount)
+            elif asset.purchase_price is not None and (
+                asset.purchase_date is None or asset.purchase_date <= as_of_date
+            ):
+                amount = float(asset.purchase_price)
+            else:
+                amount = None
+        else:
+            latest = await _get_latest_value(session, asset.id)
+            amount = _compute_current_value(asset, latest)
+
+        if not amount:
+            continue
+
+        totals[asset.currency] = totals.get(asset.currency, 0.0) + amount
+
+        if primary_currency is not None:
+            converted, _ = await convert(
+                session, Decimal(str(amount)), asset.currency, primary_currency, as_of_date
+            )
+            primary_total += float(converted)
+
+    return totals, primary_total
 
 
 # ============================================================================

--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -22,7 +22,7 @@ from app.services._query_filters import (
 )
 from app.services.admin_service import get_credit_card_accounting_mode
 from app.services.recurring_transaction_service import get_occurrences_in_range
-from app.services.asset_service import get_total_asset_value
+from app.services.asset_service import get_asset_values_at
 from app.services.fx_rate_service import convert
 from app.models.user import User
 
@@ -199,15 +199,17 @@ async def get_summary(
         .where(*pending_cat_filters)
     ) or 0))
 
-    # Asset values
-    assets_value = await get_total_asset_value(session, user_id)
+    # Get user's primary currency (user already loaded above for reporting mode)
+    primary_currency = user.primary_currency if user else get_settings().default_currency
+
+    # Asset values — use cutoff so past months show historical values
+    assets_value, assets_value_primary = await get_asset_values_at(
+        session, user_id, as_of_date=cutoff, primary_currency=primary_currency
+    )
 
     # Add asset values to total balance
     for currency, amount in assets_value.items():
         total_balance[currency] = total_balance.get(currency, 0.0) + amount
-
-    # Get user's primary currency (user already loaded above for reporting mode)
-    primary_currency = user.primary_currency if user else get_settings().default_currency
 
     # Convert totals to primary currency
     total_balance_primary = 0.0
@@ -318,12 +320,6 @@ async def get_summary(
             monthly_income_primary += float(proj_converted)
         else:
             monthly_expenses_primary += float(proj_converted)
-
-    # Convert asset values to primary currency
-    assets_value_primary = 0.0
-    for currency, amount in assets_value.items():
-        converted, _ = await convert(session, Decimal(str(amount)), currency, primary_currency)
-        assets_value_primary += float(converted)
 
     # Aggregate the user's net pending balance across all groups they
     # participate in. We reuse the group balance computation so partial

--- a/backend/app/services/goal_service.py
+++ b/backend/app/services/goal_service.py
@@ -12,7 +12,7 @@ from app.models.asset import Asset
 from app.models.goal import Goal
 from app.models.user import User
 from app.schemas.goal import GoalCreate, GoalRead, GoalSummary, GoalUpdate
-from app.services.asset_service import _compute_current_value, _get_latest_value, get_total_asset_value
+from app.services.asset_service import _compute_current_value, _get_latest_value, get_asset_values_at
 from app.services.dashboard_service import _account_balance_at, _get_open_accounts
 from app.services.account_service import get_account_name
 from app.services.fx_rate_service import convert
@@ -73,7 +73,7 @@ async def _resolve_current_amount(
                 total += converted
 
         # Add asset values
-        assets_by_currency = await get_total_asset_value(session, user_id)
+        assets_by_currency, _ = await get_asset_values_at(session, user_id)
         for currency, amount in assets_by_currency.items():
             if currency == goal_currency:
                 total += Decimal(str(amount))

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -30,6 +30,7 @@ from app.schemas.report import (
     ReportResponse,
     ReportSummary,
 )
+from app.services.asset_service import get_asset_values_at
 from app.services.dashboard_service import _get_open_accounts, _account_balance_at
 
 CATEGORY_TREND_TOP_N = 11
@@ -39,48 +40,10 @@ async def _asset_value_at(
     session: AsyncSession, user_id: uuid.UUID, cutoff: date,
     primary_currency: str = "USD",
 ) -> float:
-    """Sum of all active (non-archived, non-sold) asset values at a given date,
-    converted to primary currency.
-
-    For each asset, finds the most recent AssetValue with date <= cutoff.
-    Falls back to purchase_price if no value entries exist before the cutoff
-    (but only if purchase_date <= cutoff or purchase_date is None).
-    """
-    result = await session.execute(
-        select(Asset).where(
-            Asset.user_id == user_id,
-            Asset.is_archived == False,
-            Asset.sell_date.is_(None),
-        )
+    """Sum of all active asset values at a given date, converted to primary currency."""
+    _, total = await get_asset_values_at(
+        session, user_id, as_of_date=cutoff, primary_currency=primary_currency
     )
-    assets = list(result.scalars().all())
-
-    total = 0.0
-    for asset in assets:
-        # Find most recent value entry at or before the cutoff
-        val_result = await session.execute(
-            select(AssetValue.amount)
-            .where(
-                AssetValue.asset_id == asset.id,
-                AssetValue.date <= cutoff,
-            )
-            .order_by(desc(AssetValue.date), desc(AssetValue.id))
-            .limit(1)
-        )
-        row = val_result.scalar_one_or_none()
-        amount = 0.0
-        if row is not None:
-            amount = float(row)
-        elif asset.purchase_price is not None:
-            if asset.purchase_date is None or asset.purchase_date <= cutoff:
-                amount = float(asset.purchase_price)
-
-        if amount != 0.0:
-            converted, _ = await convert(
-                session, Decimal(str(amount)), asset.currency, primary_currency, cutoff
-            )
-            total += float(converted)
-
     return total
 
 
@@ -154,15 +117,18 @@ def _date_points(
             current += timedelta(weeks=1)
     elif interval == "monthly":
         while current <= end:
-            points.append(current)
-            # Advance by one month
+            # Snapshot at end-of-month so the bar for "May" reflects May's
+            # closing balance, not May 1st (which equals April's closing balance).
+            last_day = calendar.monthrange(current.year, current.month)[1]
+            eom = date(current.year, current.month, last_day)
+            points.append(min(eom, end))
+            # Advance to the 1st of the next month for loop control
             month = current.month + 1
             year = current.year
             if month > 12:
                 month = 1
                 year += 1
-            day = min(current.day, 28)
-            current = date(year, month, day)
+            current = date(year, month, 1)
     elif interval == "yearly":
         while current <= end:
             points.append(current)


### PR DESCRIPTION
When trying to  fix https://github.com/securo-finance/securo/issues/197

A new bug appeared: 
In the Reports → Net Worth screen, the monthly evolution bar chart displays correct values but each bar is labelled with the wrong month — every value is shifted forward by one month (e.g. the "May" bar displays April's closing balance).

Steps to Reproduce
Go to Reports → Net Worth
Set the interval to "Monthly"
Hover over any bar in the Evolution chart and note the tooltip value
Compare it against the actual net worth for that labelled month (e.g. cross-reference with the Dashboard for the same month)
Expected Behavior
Each bar should represent the net worth at the end of the labelled month — for example, the "May" bar should show the closing balance as of May 31st.

So the bugs were : 
The dashboard summary endpoint had a cutoff date computed from the selected month (last day of that month for past months, today for the current month). This cutoff was already being used correctly for account balances and income/expenses — but the asset value lookup in dashboard screen completely ignored it. It always called get_total_asset_value with no date parameter, which internally fetched the most recent AssetValue row for each asset regardless of date, and for market-priced assets it went even further and used last_price × units directly from the asset record (the live price). The FX conversion to primary currency also had no date, so it used today's exchange rate instead of the rate at the period's closing date. On top of that, the purchase_price fallback — used when no AssetValue entries exist yet — had no guard on purchase_date, so assets acquired after the selected period were silently included.

Bug 2 — Net Worth Evolution Chart Bars Offset by One Month

The evolution chart builds a series of date points, one per month, and takes a net worth snapshot at each. Those points were generated as the 1st of each month (e.g. 2025-05-01, 2025-06-01, …). The snapshot query sums all transactions up to and including that date — so a snapshot on May 1st only captures transactions on May 1st itself, which is functionally the same as the closing state of April 30th. The snapshot is then labelled "2025-05" in the chart. The result is that every bar displays the previous month's closing balance under the current month's label — a consistent one-month forward shift across the entire chart.


And the fixes in place:

- Dashboard assets widget now reflects the selected month's historical value instead of the current live price; uses the same cutoff date for FX conversion as the reports view, and guards the purchase_price fallback with a purchase_date <= cutoff check.

- Consolidate duplicate asset lookup logic into a single get_asset_values_at() in asset_service, replacing the separate get_total_asset_value() (dashboard) and _asset_value_at() (reports). goal_service updated to use the new function.

- Fix net worth evolution chart one-month offset: monthly snapshots were taken on the 1st of each month (= previous month's closing balance). Now snapshots use the last day of each month, capped at today for the current month.



This PR make all assets historical value calculation consistent in the home dashboard, the Reports/Networfh first widget and the Evolution charts.








## Checklist

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
