### PR TITLE
fix: reset bulk category select on selection change

### DIFF
--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -207,6 +207,11 @@ export default function TransactionsPage() {
     setBulkCategory('')
   }, [page, filterAccountIds, filterCategoryIds, filterUncategorized, filterPayee, filterType, filterFrom, filterTo, searchQuery])
 
+  // Reset bulk category when selection changes so the same category can be re-applied
+  useEffect(() => {
+    setBulkCategory('')
+  }, [selectedIds])
+
   // Scroll to and flash a highlighted row after navigation (e.g. opened via
   // the command palette). Re-runs whenever highlightId or the current data
   // set changes so that when results finish loading we animate the row.


### PR DESCRIPTION
## What

Reset the bulk category select dropdown whenever the transaction selection changes.

## Why

When users select multiple transactions and apply a bulk category, the category dropdown retains the previously selected value. If the user then modifies their selection (adding or removing transactions), the dropdown still shows the old category. Because Radix Select's `onValueChange` doesn't fire when re-selecting the already-active value, users are unable to re-apply the same category to the new selection without first picking a different category and switching back.

This makes the bulk categorization workflow frustrating - especially when categorizing many transactions with the same category across different selection groups.

## How to Test

1. Select multiple transactions
2. Pick a category from the bulk action bar - it applies successfully
3. Modify the selection (add or remove a transaction)
4. Verify the category select resets to the placeholder
5. Verify you can now pick the same category again and it applies to the new selection

## Checklist

- [ ] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)