### PR TITLE
fix: align asset values and net worth evolution with selected period

### DIFF
--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -175,6 +175,67 @@ async def _get_value_as_of(
     return result.scalar_one_or_none()
 
 
+async def _load_asset_native_values(
+    session: AsyncSession,
+    assets: list[Asset],
+    up_to_date: Optional[date] = None,
+) -> dict[str, list[tuple[date, float]]]:
+    """Bulk-load AssetValue rows for all assets in one query.
+
+    Returns {aid: [(date, amount), ...]} sorted ascending by (date, id).
+    When purchase_price and purchase_date are both set and purchase_date
+    predates the first recorded value, it is prepended as the earliest anchor.
+    """
+    if not assets:
+        return {}
+
+    asset_ids = [a.id for a in assets]
+    q = (
+        select(AssetValue.asset_id, AssetValue.date, AssetValue.amount)
+        .where(AssetValue.asset_id.in_(asset_ids))
+        .order_by(AssetValue.asset_id, AssetValue.date, AssetValue.id)
+    )
+    if up_to_date is not None:
+        q = q.where(AssetValue.date <= up_to_date)
+
+    rows = (await session.execute(q)).all()
+
+    values_map: dict[str, list[tuple[date, float]]] = {str(a.id): [] for a in assets}
+    for aid, d, amt in rows:
+        values_map[str(aid)].append((d, float(amt)))
+
+    for asset in assets:
+        aid = str(asset.id)
+        vals = values_map[aid]
+        if asset.purchase_price is not None and asset.purchase_date is not None:
+            if not vals or asset.purchase_date < vals[0][0]:
+                vals.insert(0, (asset.purchase_date, float(asset.purchase_price)))
+
+    return values_map
+
+
+def _fill_forward_at(
+    asset: Asset,
+    sorted_vals: list[tuple[date, float]],
+    as_of: date,
+) -> Optional[float]:
+    """Return the fill-forwarded native value of asset at as_of, or None.
+
+    Scans sorted_vals for the latest entry on or before as_of. Falls back
+    to purchase_price when purchase_date is None (asset predates any known
+    date) and no value history is available for the requested date.
+    """
+    result = None
+    for d, v in sorted_vals:
+        if d <= as_of:
+            result = v
+        else:
+            break
+    if result is None and asset.purchase_price is not None and asset.purchase_date is None:
+        result = float(asset.purchase_price)
+    return result
+
+
 async def _get_value_count(session: AsyncSession, asset_id: uuid.UUID) -> int:
     """Get the number of AssetValue entries for an asset."""
     result = await session.scalar(
@@ -537,16 +598,16 @@ async def get_portfolio_trend(
     if not active_assets:
         return {"assets": [], "trend": [], "total": 0.0}
 
-    # Collect all values per asset and all unique dates
-    asset_meta = []
-    asset_values_map: dict[str, list[tuple[date, float]]] = {}
-    asset_currency: dict[str, str] = {}
-    sell_date_by_aid: dict[str, date] = {}
-    all_dates: set[date] = set()
-
     # Get user's primary currency for conversion
     user = await session.get(User, user_id)
     primary_currency = user.primary_currency if user else get_settings().default_currency
+
+    values_map = await _load_asset_native_values(session, active_assets)
+
+    asset_meta = []
+    asset_currency: dict[str, str] = {}
+    sell_date_by_aid: dict[str, date] = {}
+    all_dates: set[date] = set()
 
     for asset in active_assets:
         aid = str(asset.id)
@@ -558,17 +619,7 @@ async def get_portfolio_trend(
         })
         asset_currency[aid] = asset.currency
 
-        rows = await session.execute(
-            select(AssetValue.date, AssetValue.amount)
-            .where(AssetValue.asset_id == asset.id)
-            .order_by(AssetValue.date)
-        )
-        vals = [(r[0], float(r[1])) for r in rows.all()]
-
-        # Prepend purchase_price as the first data point if it predates existing values
-        if asset.purchase_price is not None and asset.purchase_date is not None:
-            if not vals or asset.purchase_date < vals[0][0]:
-                vals.insert(0, (asset.purchase_date, float(asset.purchase_price)))
+        vals = values_map[aid]
 
         # If the asset was sold and a sell_price is recorded, treat it as the
         # asset's terminal value on sell_date so the chart reflects the
@@ -579,11 +630,8 @@ async def get_portfolio_trend(
                 vals = [(d, v) for d, v in vals if d <= asset.sell_date]
                 if not vals or vals[-1][0] != asset.sell_date:
                     vals.append((asset.sell_date, float(asset.sell_price)))
+                values_map[aid] = vals
 
-        # Values are stored in native currency; FX conversion happens per display
-        # date in the trend loop below so fill-forwarded values are always
-        # converted at the date being displayed — matching get_asset_values_at.
-        asset_values_map[aid] = vals
         for d, _ in vals:
             all_dates.add(d)
 
@@ -596,9 +644,9 @@ async def get_portfolio_trend(
     value_lookup: dict[str, dict[date, float]] = {}
     first_date: dict[str, date] = {}
     for aid in [a["id"] for a in asset_meta]:
-        value_lookup[aid] = {d: v for d, v in asset_values_map[aid]}
-        if asset_values_map[aid]:
-            first_date[aid] = asset_values_map[aid][0][0]
+        value_lookup[aid] = dict(values_map[aid])
+        if values_map[aid]:
+            first_date[aid] = values_map[aid][0][0]
 
     # Build trend with fill-forward; 0 before first date (for stacking).
     # Each native-currency amount is converted at the display date `d` so that
@@ -673,17 +721,12 @@ async def get_asset_values_at(
     totals: dict[str, float] = {}
     primary_total = 0.0
 
+    if as_of_date is not None:
+        values_map = await _load_asset_native_values(session, assets, up_to_date=as_of_date)
+
     for asset in assets:
         if as_of_date is not None:
-            value_entry = await _get_value_as_of(session, asset.id, as_of_date)
-            if value_entry is not None:
-                amount: Optional[float] = float(value_entry.amount)
-            elif asset.purchase_price is not None and (
-                asset.purchase_date is None or asset.purchase_date <= as_of_date
-            ):
-                amount = float(asset.purchase_price)
-            else:
-                amount = None
+            amount: Optional[float] = _fill_forward_at(asset, values_map[str(asset.id)], as_of_date)
         else:
             latest = await _get_latest_value(session, asset.id)
             amount = _compute_current_value(asset, latest)

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -540,6 +540,7 @@ async def get_portfolio_trend(
     # Collect all values per asset and all unique dates
     asset_meta = []
     asset_values_map: dict[str, list[tuple[date, float]]] = {}
+    asset_currency: dict[str, str] = {}
     sell_date_by_aid: dict[str, date] = {}
     all_dates: set[date] = set()
 
@@ -555,6 +556,7 @@ async def get_portfolio_trend(
             "type": asset.type,
             "group_id": str(asset.group_id) if asset.group_id else None,
         })
+        asset_currency[aid] = asset.currency
 
         rows = await session.execute(
             select(AssetValue.date, AssetValue.amount)
@@ -578,21 +580,9 @@ async def get_portfolio_trend(
                 if not vals or vals[-1][0] != asset.sell_date:
                     vals.append((asset.sell_date, float(asset.sell_price)))
 
-        # Convert every value to the primary currency at its own date so the
-        # stacked areas and the tooltip total are all in the same unit. Before
-        # this, a USD-quoted asset like AAPL contributed its raw $ value to
-        # `_total`, making the tooltip disagree with the header (which does
-        # FX-convert). `convert` falls back to the nearest available rate, so
-        # dates missing exact FX data still produce a sensible number.
-        if asset.currency != primary_currency:
-            converted_vals: list[tuple[date, float]] = []
-            for d, amt in vals:
-                converted, _ = await convert(
-                    session, Decimal(str(amt)), asset.currency, primary_currency, d,
-                )
-                converted_vals.append((d, float(converted)))
-            vals = converted_vals
-
+        # Values are stored in native currency; FX conversion happens per display
+        # date in the trend loop below so fill-forwarded values are always
+        # converted at the date being displayed — matching get_asset_values_at.
         asset_values_map[aid] = vals
         for d, _ in vals:
             all_dates.add(d)
@@ -610,9 +600,12 @@ async def get_portfolio_trend(
         if asset_values_map[aid]:
             first_date[aid] = asset_values_map[aid][0][0]
 
-    # Build trend with fill-forward; 0 before first date (for stacking)
+    # Build trend with fill-forward; 0 before first date (for stacking).
+    # Each native-currency amount is converted at the display date `d` so that
+    # fill-forwarded values reflect current FX rates — consistent with
+    # get_asset_values_at(as_of_date=d).
     trend = []
-    last_known: dict[str, float] = {}
+    last_known: dict[str, float] = {}  # native currency amounts
     for aid in [a["id"] for a in asset_meta]:
         last_known[aid] = 0.0
 
@@ -624,24 +617,33 @@ async def get_portfolio_trend(
                 last_known[aid] = value_lookup[aid][d]
             # Use 0 before asset exists (stacking needs numeric values)
             if aid in first_date and d >= first_date[aid]:
-                val = round(last_known[aid], 2)
+                native = last_known[aid]
             else:
-                val = 0
+                native = 0.0
             # After sell_date, the asset has been liquidated — drop to 0 so
             # it stops contributing to the portfolio total going forward.
             if aid in sell_date_by_aid and d > sell_date_by_aid[aid]:
-                val = 0
+                native = 0.0
                 last_known[aid] = 0.0
+
+            # Convert native amount to primary currency at this display date
+            currency = asset_currency[aid]
+            if native != 0.0 and currency != primary_currency:
+                converted, _ = await convert(
+                    session, Decimal(str(native)), currency, primary_currency, d
+                )
+                val = round(float(converted), 2)
+            else:
+                val = round(native, 2)
+
             row[aid] = val
             date_total += val
         row["_total"] = round(date_total, 2)
         trend.append(row)
 
-    # `last_known` already holds primary-currency values (we converted per-date
-    # above when building asset_values_map). Summing directly keeps the header
-    # total in lockstep with the tooltip's `_total` on the final row — any
-    # second conversion here would double-count for non-primary assets.
-    total = sum(last_known.values())
+    # The header total matches the last row's _total — both use the same
+    # per-display-date conversion so no second conversion is needed.
+    total = trend[-1]["_total"] if trend else 0.0
 
     return {"assets": asset_meta, "trend": trend, "total": round(total, 2)}
 

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -162,6 +162,19 @@ async def _get_latest_value(session: AsyncSession, asset_id: uuid.UUID) -> Optio
     return result.scalar_one_or_none()
 
 
+async def _get_value_as_of(
+    session: AsyncSession, asset_id: uuid.UUID, as_of_date: date
+) -> Optional[AssetValue]:
+    """Get the most recent AssetValue for an asset on or before as_of_date."""
+    result = await session.execute(
+        select(AssetValue)
+        .where(AssetValue.asset_id == asset_id, AssetValue.date <= as_of_date)
+        .order_by(desc(AssetValue.date), desc(AssetValue.id))
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
 async def _get_value_count(session: AsyncSession, asset_id: uuid.UUID) -> int:
     """Get the number of AssetValue entries for an asset."""
     result = await session.scalar(
@@ -633,11 +646,19 @@ async def get_portfolio_trend(
     return {"assets": asset_meta, "trend": trend, "total": round(total, 2)}
 
 
-async def get_total_asset_value(
-    session: AsyncSession, user_id: uuid.UUID
-) -> dict[str, float]:
-    """Get total asset value grouped by currency (for dashboard).
-    Only includes non-archived assets that haven't been sold."""
+async def get_asset_values_at(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    as_of_date: Optional[date] = None,
+    primary_currency: Optional[str] = None,
+) -> tuple[dict[str, float], float]:
+    """Return (per_currency_totals, primary_total) for all active assets.
+
+    - as_of_date=None: uses live prices (current view).
+    - as_of_date set: uses the latest AssetValue on or before that date,
+      falling back to purchase_price only if the asset existed by that date.
+    - primary_currency=None: primary_total is 0.0.
+    """
     result = await session.execute(
         select(Asset).where(
             Asset.user_id == user_id,
@@ -648,12 +669,35 @@ async def get_total_asset_value(
     assets = list(result.scalars().all())
 
     totals: dict[str, float] = {}
+    primary_total = 0.0
+
     for asset in assets:
-        latest = await _get_latest_value(session, asset.id)
-        current = _compute_current_value(asset, latest)
-        if current is not None:
-            totals[asset.currency] = totals.get(asset.currency, 0.0) + current
-    return totals
+        if as_of_date is not None:
+            value_entry = await _get_value_as_of(session, asset.id, as_of_date)
+            if value_entry is not None:
+                amount: Optional[float] = float(value_entry.amount)
+            elif asset.purchase_price is not None and (
+                asset.purchase_date is None or asset.purchase_date <= as_of_date
+            ):
+                amount = float(asset.purchase_price)
+            else:
+                amount = None
+        else:
+            latest = await _get_latest_value(session, asset.id)
+            amount = _compute_current_value(asset, latest)
+
+        if not amount:
+            continue
+
+        totals[asset.currency] = totals.get(asset.currency, 0.0) + amount
+
+        if primary_currency is not None:
+            converted, _ = await convert(
+                session, Decimal(str(amount)), asset.currency, primary_currency, as_of_date
+            )
+            primary_total += float(converted)
+
+    return totals, primary_total
 
 
 # ============================================================================

--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -22,7 +22,7 @@ from app.services._query_filters import (
 )
 from app.services.admin_service import get_credit_card_accounting_mode
 from app.services.recurring_transaction_service import get_occurrences_in_range
-from app.services.asset_service import get_total_asset_value
+from app.services.asset_service import get_asset_values_at
 from app.services.fx_rate_service import convert
 from app.models.user import User
 
@@ -199,15 +199,17 @@ async def get_summary(
         .where(*pending_cat_filters)
     ) or 0))
 
-    # Asset values
-    assets_value = await get_total_asset_value(session, user_id)
+    # Get user's primary currency (user already loaded above for reporting mode)
+    primary_currency = user.primary_currency if user else get_settings().default_currency
+
+    # Asset values — use cutoff so past months show historical values
+    assets_value, assets_value_primary = await get_asset_values_at(
+        session, user_id, as_of_date=cutoff, primary_currency=primary_currency
+    )
 
     # Add asset values to total balance
     for currency, amount in assets_value.items():
         total_balance[currency] = total_balance.get(currency, 0.0) + amount
-
-    # Get user's primary currency (user already loaded above for reporting mode)
-    primary_currency = user.primary_currency if user else get_settings().default_currency
 
     # Convert totals to primary currency
     total_balance_primary = 0.0
@@ -318,12 +320,6 @@ async def get_summary(
             monthly_income_primary += float(proj_converted)
         else:
             monthly_expenses_primary += float(proj_converted)
-
-    # Convert asset values to primary currency
-    assets_value_primary = 0.0
-    for currency, amount in assets_value.items():
-        converted, _ = await convert(session, Decimal(str(amount)), currency, primary_currency)
-        assets_value_primary += float(converted)
 
     # Aggregate the user's net pending balance across all groups they
     # participate in. We reuse the group balance computation so partial

--- a/backend/app/services/goal_service.py
+++ b/backend/app/services/goal_service.py
@@ -12,7 +12,7 @@ from app.models.asset import Asset
 from app.models.goal import Goal
 from app.models.user import User
 from app.schemas.goal import GoalCreate, GoalRead, GoalSummary, GoalUpdate
-from app.services.asset_service import _compute_current_value, _get_latest_value, get_total_asset_value
+from app.services.asset_service import _compute_current_value, _get_latest_value, get_asset_values_at
 from app.services.dashboard_service import _account_balance_at, _get_open_accounts
 from app.services.account_service import get_account_name
 from app.services.fx_rate_service import convert
@@ -73,7 +73,7 @@ async def _resolve_current_amount(
                 total += converted
 
         # Add asset values
-        assets_by_currency = await get_total_asset_value(session, user_id)
+        assets_by_currency, _ = await get_asset_values_at(session, user_id)
         for currency, amount in assets_by_currency.items():
             if currency == goal_currency:
                 total += Decimal(str(amount))

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -30,6 +30,7 @@ from app.schemas.report import (
     ReportResponse,
     ReportSummary,
 )
+from app.services.asset_service import get_asset_values_at
 from app.services.dashboard_service import _get_open_accounts, _account_balance_at
 
 CATEGORY_TREND_TOP_N = 11
@@ -39,48 +40,10 @@ async def _asset_value_at(
     session: AsyncSession, user_id: uuid.UUID, cutoff: date,
     primary_currency: str = "USD",
 ) -> float:
-    """Sum of all active (non-archived, non-sold) asset values at a given date,
-    converted to primary currency.
-
-    For each asset, finds the most recent AssetValue with date <= cutoff.
-    Falls back to purchase_price if no value entries exist before the cutoff
-    (but only if purchase_date <= cutoff or purchase_date is None).
-    """
-    result = await session.execute(
-        select(Asset).where(
-            Asset.user_id == user_id,
-            Asset.is_archived == False,
-            Asset.sell_date.is_(None),
-        )
+    """Sum of all active asset values at a given date, converted to primary currency."""
+    _, total = await get_asset_values_at(
+        session, user_id, as_of_date=cutoff, primary_currency=primary_currency
     )
-    assets = list(result.scalars().all())
-
-    total = 0.0
-    for asset in assets:
-        # Find most recent value entry at or before the cutoff
-        val_result = await session.execute(
-            select(AssetValue.amount)
-            .where(
-                AssetValue.asset_id == asset.id,
-                AssetValue.date <= cutoff,
-            )
-            .order_by(desc(AssetValue.date), desc(AssetValue.id))
-            .limit(1)
-        )
-        row = val_result.scalar_one_or_none()
-        amount = 0.0
-        if row is not None:
-            amount = float(row)
-        elif asset.purchase_price is not None:
-            if asset.purchase_date is None or asset.purchase_date <= cutoff:
-                amount = float(asset.purchase_price)
-
-        if amount != 0.0:
-            converted, _ = await convert(
-                session, Decimal(str(amount)), asset.currency, primary_currency, cutoff
-            )
-            total += float(converted)
-
     return total
 
 
@@ -154,15 +117,18 @@ def _date_points(
             current += timedelta(weeks=1)
     elif interval == "monthly":
         while current <= end:
-            points.append(current)
-            # Advance by one month
+            # Snapshot at end-of-month so the bar for "May" reflects May's
+            # closing balance, not May 1st (which equals April's closing balance).
+            last_day = calendar.monthrange(current.year, current.month)[1]
+            eom = date(current.year, current.month, last_day)
+            points.append(min(eom, end))
+            # Advance to the 1st of the next month for loop control
             month = current.month + 1
             year = current.year
             if month > 12:
                 month = 1
                 year += 1
-            day = min(current.day, 28)
-            current = date(year, month, day)
+            current = date(year, month, 1)
     elif interval == "yearly":
         while current <= end:
             points.append(current)

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -116,12 +116,19 @@ def _date_points(
             points.append(current)
             current += timedelta(weeks=1)
     elif interval == "monthly":
+        # Always include the start date for period boundary and accurate change calculation
+        points.append(start)
+        # Generate end-of-month snapshots for each subsequent month
+        current = date(start.year, start.month + 1, 1)
         while current <= end:
-            # Snapshot at end-of-month so the bar for "May" reflects May's
-            # closing balance, not May 1st (which equals April's closing balance).
             last_day = calendar.monthrange(current.year, current.month)[1]
             eom = date(current.year, current.month, last_day)
-            points.append(min(eom, end))
+            # Snapshot at end-of-month, but capped at the period's end date
+            snapshot = min(eom, end)
+            points.append(snapshot)
+            # Stop when we've reached the end date
+            if snapshot >= end:
+                break
             # Advance to the 1st of the next month for loop control
             month = current.month + 1
             year = current.year

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -116,28 +116,15 @@ def _date_points(
             points.append(current)
             current += timedelta(weeks=1)
     elif interval == "monthly":
-        # Always include the start date for period boundary and accurate change calculation
-        points.append(start)
-        # Generate end-of-month snapshots for each subsequent month
-        next_month = start.month % 12 + 1
-        next_year = start.year + (1 if start.month == 12 else 0)
-        current = date(next_year, next_month, 1)
+        # One snapshot per month: last day of the month, capped at end
+        current = date(start.year, start.month, 1)
         while current <= end:
             last_day = calendar.monthrange(current.year, current.month)[1]
-            eom = date(current.year, current.month, last_day)
-            # Snapshot at end-of-month, but capped at the period's end date
-            snapshot = min(eom, end)
-            points.append(snapshot)
-            # Stop when we've reached the end date
-            if snapshot >= end:
-                break
-            # Advance to the 1st of the next month for loop control
-            month = current.month + 1
-            year = current.year
-            if month > 12:
-                month = 1
-                year += 1
-            current = date(year, month, 1)
+            points.append(min(date(current.year, current.month, last_day), end))
+            if current.month == 12:
+                current = date(current.year + 1, 1, 1)
+            else:
+                current = date(current.year, current.month + 1, 1)
     elif interval == "yearly":
         while current <= end:
             points.append(current)
@@ -183,11 +170,12 @@ async def get_net_worth_report(
         dp.date = _format_date_label(point, interval)
         trend.append(dp)
 
-    # Current snapshot (last point) and previous (first point) for summary
+    # Current snapshot (last point) for summary; baseline at period start for delta
     current = trend[-1] if trend else ReportDataPoint(
         date="", value=0, breakdowns={"accounts": 0, "assets": 0, "liabilities": 0}
     )
-    previous = trend[0] if len(trend) > 1 else current
+    baseline = await _net_worth_at(session, user_id, start, primary_currency)
+    previous = baseline if trend else current
 
     change_amount = current.value - previous.value
     change_percent = (

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -119,7 +119,9 @@ def _date_points(
         # Always include the start date for period boundary and accurate change calculation
         points.append(start)
         # Generate end-of-month snapshots for each subsequent month
-        current = date(start.year, start.month + 1, 1)
+        next_month = start.month % 12 + 1
+        next_year = start.year + (1 if start.month == 12 else 0)
+        current = date(next_year, next_month, 1)
         while current <= end:
             last_day = calendar.monthrange(current.year, current.month)[1]
             eom = date(current.year, current.month, last_day)

--- a/backend/tests/test_asset_service.py
+++ b/backend/tests/test_asset_service.py
@@ -242,7 +242,7 @@ async def test_get_asset_value_trend(session: AsyncSession, test_user: User, tes
 
 @pytest.mark.asyncio
 async def test_get_total_asset_value(session: AsyncSession, test_user: User, test_asset_with_values: Asset):
-    totals = await asset_service.get_total_asset_value(session, test_user.id)
+    totals, _ = await asset_service.get_asset_values_at(session, test_user.id)
     assert "BRL" in totals
     assert totals["BRL"] >= 550000.0  # latest value
 
@@ -272,7 +272,7 @@ async def test_total_asset_value_excludes_sold(session: AsyncSession, test_user:
     session.add(v)
     await session.commit()
 
-    totals = await asset_service.get_total_asset_value(session, test_user.id)
+    totals, _ = await asset_service.get_asset_values_at(session, test_user.id)
     assert isinstance(totals, dict)
 
 
@@ -565,7 +565,7 @@ async def test_total_asset_value_includes_purchase_fallback(session: AsyncSessio
     session.add(asset)
     await session.commit()
 
-    totals = await asset_service.get_total_asset_value(session, test_user.id)
+    totals, _ = await asset_service.get_asset_values_at(session, test_user.id)
     assert "BRL" in totals
     assert totals["BRL"] >= 200000.0
 
@@ -586,7 +586,7 @@ async def test_total_asset_value_excludes_archived(session: AsyncSession, test_u
     session.add(asset)
     await session.commit()
 
-    totals = await asset_service.get_total_asset_value(session, test_user.id)
+    totals, _ = await asset_service.get_asset_values_at(session, test_user.id)
     # If this is the only asset, BRL should not be in totals (or should not include 999999)
     assert totals.get("BRL", 0) < 999999.0
 

--- a/backend/tests/test_asset_service.py
+++ b/backend/tests/test_asset_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.asset import Asset
 from app.models.asset_value import AssetValue
+from app.models.fx_rate import FxRate
 from app.models.user import User
 from app.schemas.asset import AssetCreate, AssetUpdate, AssetValueCreate
 from app.services import asset_service
@@ -796,6 +797,72 @@ async def test_portfolio_trend_with_assets(session: AsyncSession, test_user: Use
     assert len(result["assets"]) == 2
     assert len(result["trend"]) > 0
     assert result["total"] > 0
+
+
+@pytest.mark.asyncio
+async def test_portfolio_trend_total_consistent_with_get_asset_values_at(
+    session: AsyncSession, test_user: User
+):
+    """portfolio trend _total must match get_asset_values_at at the same date.
+
+    Uses a USD asset whose value entry pre-dates the display date, so
+    it is fill-forwarded. Two different BRL/USD rates are inserted so the
+    old behavior (convert at value-entry date) and the new behavior
+    (convert at display date) produce different numbers — only the new
+    behavior matches get_asset_values_at.
+    """
+    date_jan = date(2025, 1, 31)  # USD asset gets its value here (rate 5.0)
+    date_mar = date(2025, 3, 31)  # display date — different rate (6.0)
+
+    # Two FX snapshots so convert() finds an exact match at each date
+    for fx_date, fx_rate in [(date_jan, "5.0"), (date_mar, "6.0")]:
+        session.add(FxRate(
+            id=uuid.uuid4(),
+            base_currency="USD",
+            quote_currency="BRL",
+            date=fx_date,
+            rate=Decimal(fx_rate),
+            source="test",
+        ))
+
+    # USD asset: one value entry in January, no subsequent entries (fill-forwarded in March)
+    usd_asset = Asset(
+        id=uuid.uuid4(), user_id=test_user.id, name="Stock",
+        type="investment", currency="USD", valuation_method="manual",
+        purchase_date=date_jan, purchase_price=Decimal("100"), position=0,
+    )
+    session.add(usd_asset)
+    await session.flush()
+    session.add(AssetValue(
+        id=uuid.uuid4(), asset_id=usd_asset.id,
+        amount=Decimal("100"), date=date_jan, source="manual",
+    ))
+
+    # BRL anchor asset: value in March so that date_mar appears in sorted_dates
+    brl_asset = Asset(
+        id=uuid.uuid4(), user_id=test_user.id, name="House",
+        type="real_estate", currency="BRL", valuation_method="manual",
+        purchase_date=date_mar, purchase_price=Decimal("1000"), position=1,
+    )
+    session.add(brl_asset)
+    await session.flush()
+    session.add(AssetValue(
+        id=uuid.uuid4(), asset_id=brl_asset.id,
+        amount=Decimal("1000"), date=date_mar, source="manual",
+    ))
+
+    await session.commit()
+
+    trend_result = await get_portfolio_trend(session, test_user.id)
+    _, values_at_total = await asset_service.get_asset_values_at(
+        session, test_user.id, as_of_date=date_mar,
+        primary_currency=test_user.primary_currency,
+    )
+
+    # At date_mar: USD 100 @ 6.0 = BRL 600, plus BRL 1000 = 1600
+    trend_at_mar = next(r for r in trend_result["trend"] if r["date"] == date_mar.isoformat())
+    assert trend_at_mar["_total"] == pytest.approx(1600.0, rel=1e-2)
+    assert trend_at_mar["_total"] == pytest.approx(values_at_total, rel=1e-2)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -83,6 +83,28 @@ def test_date_points_monthly():
     assert points[-1] == end
 
 
+def test_date_points_monthly_end_of_month_snapshots():
+    """Monthly points: start date as boundary, then EOM snapshots for each subsequent month."""
+    start = date(2025, 1, 1)
+    end = date(2025, 4, 15)
+    points = _date_points(start, end, "monthly")
+    # start is the Jan boundary; loop begins from Feb, so Jan 31 is not emitted
+    assert points == [
+        date(2025, 1, 1),   # start boundary (Jan reference)
+        date(2025, 2, 28),  # end of Feb
+        date(2025, 3, 31),  # end of Mar
+        date(2025, 4, 15),  # capped at end (Apr 30 → Apr 15)
+    ]
+
+
+def test_date_points_monthly_feb_leap_year():
+    """End-of-month for February respects leap years."""
+    start = date(2024, 1, 1)
+    end = date(2024, 3, 1)
+    points = _date_points(start, end, "monthly")
+    assert date(2024, 2, 29) in points
+
+
 def test_date_points_yearly():
     start = date(2023, 1, 1)
     end = date(2025, 6, 15)

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -78,19 +78,18 @@ def test_date_points_monthly():
     start = date(2025, 1, 1)
     end = date(2025, 6, 15)
     points = _date_points(start, end, "monthly")
-    assert points[0] == start
-    # Last point should be end (June 15), not June 1
-    assert points[-1] == end
+    assert points[0] == date(2025, 1, 31)  # end of first month
+    assert points[-1] == end               # last point capped at end
+    assert len(points) == 6
 
 
 def test_date_points_monthly_end_of_month_snapshots():
-    """Monthly points: start date as boundary, then EOM snapshots for each subsequent month."""
+    """Monthly points: one EOM snapshot per month, last one capped at end."""
     start = date(2025, 1, 1)
     end = date(2025, 4, 15)
     points = _date_points(start, end, "monthly")
-    # start is the Jan boundary; loop begins from Feb, so Jan 31 is not emitted
     assert points == [
-        date(2025, 1, 1),   # start boundary (Jan reference)
+        date(2025, 1, 31),  # end of Jan
         date(2025, 2, 28),  # end of Feb
         date(2025, 3, 31),  # end of Mar
         date(2025, 4, 15),  # capped at end (Apr 30 → Apr 15)
@@ -98,13 +97,15 @@ def test_date_points_monthly_end_of_month_snapshots():
 
 
 def test_date_points_monthly_december_start():
-    """December start must not crash with month=13."""
+    """December start must not crash with month rollover."""
     start = date(2024, 12, 1)
     end = date(2025, 2, 15)
     points = _date_points(start, end, "monthly")
-    assert points[0] == date(2024, 12, 1)
-    assert date(2025, 1, 31) in points
-    assert points[-1] == end
+    assert points == [
+        date(2024, 12, 31),
+        date(2025, 1, 31),
+        date(2025, 2, 15),
+    ]
 
 
 def test_date_points_monthly_feb_leap_year():
@@ -112,7 +113,11 @@ def test_date_points_monthly_feb_leap_year():
     start = date(2024, 1, 1)
     end = date(2024, 3, 1)
     points = _date_points(start, end, "monthly")
-    assert date(2024, 2, 29) in points
+    assert points == [
+        date(2024, 1, 31),
+        date(2024, 2, 29),
+        date(2024, 3, 1),
+    ]
 
 
 def test_date_points_yearly():
@@ -140,14 +145,16 @@ def test_date_points_unknown_interval_defaults_to_monthly():
 
 
 def test_date_points_last_point_replaces_same_period():
-    """When end falls in the same period as the last generated point, replace it."""
+    """End date mid-month caps the last snapshot; no duplicate month labels."""
     start = date(2025, 1, 1)
     end = date(2025, 3, 15)
     points = _date_points(start, end, "monthly")
-    # March 1 and March 15 share "2025-03" label, so March 15 replaces March 1
-    assert points[-1] == end
+    assert points == [
+        date(2025, 1, 31),
+        date(2025, 2, 28),
+        date(2025, 3, 15),  # Mar 31 capped at end
+    ]
     labels = [_format_date_label(p, "monthly") for p in points]
-    # No duplicates
     assert len(labels) == len(set(labels))
 
 

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -97,6 +97,16 @@ def test_date_points_monthly_end_of_month_snapshots():
     ]
 
 
+def test_date_points_monthly_december_start():
+    """December start must not crash with month=13."""
+    start = date(2024, 12, 1)
+    end = date(2025, 2, 15)
+    points = _date_points(start, end, "monthly")
+    assert points[0] == date(2024, 12, 1)
+    assert date(2025, 1, 31) in points
+    assert points[-1] == end
+
+
 def test_date_points_monthly_feb_leap_year():
     """End-of-month for February respects leap years."""
     start = date(2024, 1, 1)


### PR DESCRIPTION
- Dashboard assets widget now reflects the selected month's historical value instead of the current live price; uses the same cutoff date for FX conversion as the reports view, and guards the purchase_price fallback with a purchase_date <= cutoff check.

- Consolidate duplicate asset lookup logic into a single get_asset_values_at() in asset_service, replacing the separate get_total_asset_value() (dashboard) and _asset_value_at() (reports). goal_service updated to use the new function.

- Fix net worth evolution chart one-month offset: monthly snapshots were taken on the 1st of each month (= previous month's closing balance). Now snapshots use the last day of each month, capped at today for the current month.

## What

This should fix bugs https://github.com/securo-finance/securo/issues/197 and https://github.com/securo-finance/securo/issues/199

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
