### PR TITLE
feat: add ignore flag for transactions (closes #200)

### DIFF
--- a/backend/alembic/versions/051_transaction_is_ignored.py
+++ b/backend/alembic/versions/051_transaction_is_ignored.py
@@ -1,0 +1,30 @@
+"""add is_ignored to transactions
+
+Revision ID: 051
+Revises: 050
+Create Date: 2026-05-19
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '051'
+down_revision: Union[str, Sequence[str], None] = '050'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'transactions',
+        sa.Column('is_ignored', sa.Boolean(), nullable=False, server_default='false')
+    )
+    op.create_index('ix_transactions_is_ignored', 'transactions', ['is_ignored'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_transactions_is_ignored', table_name='transactions')
+    op.drop_column('transactions', 'is_ignored')

--- a/backend/app/api/transactions.py
+++ b/backend/app/api/transactions.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import current_active_user
 from app.core.database import get_async_session
 from app.models.user import User
-from app.schemas.transaction import BulkAddToGroupRequest, BulkCategorizeRequest, BulkTagsRequest, CreateCounterpartRequest, LinkTransferRequest, TransactionCreate, TransactionRead, TransactionUpdate, TransferCreate, TransferRead
+from app.schemas.transaction import BulkAddToGroupRequest, BulkCategorizeRequest, BulkDeleteRequest, BulkIgnoreRequest, BulkTagsRequest, BulkUpdateRequest, CreateCounterpartRequest, LinkTransferRequest, TransactionCreate, TransactionRead, TransactionUpdate, TransferCreate, TransferRead
 from app.services import transaction_service
 from app.services.admin_service import get_credit_card_accounting_mode
 
@@ -76,6 +76,7 @@ async def list_transactions(
     limit: int = Query(50, ge=1, le=500),
     include_opening_balance: bool = Query(False),
     exclude_transfers: bool = Query(False),
+    ignored_filter: str = Query("hide"),  # hide | include | only
     tags: Optional[List[str]] = Query(None),
     sort_by: Optional[str] = Query(None, description="Column to sort by (date|amount|description|payee|category|account|type|status). Default: date desc."),
     sort_dir: str = Query("desc", regex="^(asc|desc)$"),
@@ -89,7 +90,7 @@ async def list_transactions(
         category_ids=_merge_id_filters(category_id, category_ids),
         payee_id=payee_id, from_date=from_date, to_date=to_date, page=page, limit=limit,
         include_opening_balance=include_opening_balance, search=q, uncategorized=uncategorized,
-        txn_type=type, exclude_transfers=exclude_transfers,
+        txn_type=type, exclude_transfers=exclude_transfers, ignored_filter=ignored_filter,
         accounting_mode=accounting_mode,
         tags=tags,
         bill_id=bill_id,
@@ -233,6 +234,43 @@ async def bulk_add_to_group(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
+@router.patch("/bulk-ignore")
+async def bulk_ignore(
+    data: BulkIgnoreRequest,
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+):
+    count = await transaction_service.bulk_ignore(
+        session, user.id, data.transaction_ids, data.ignore
+    )
+    return {"updated": count}
+
+
+@router.delete("/bulk-delete")
+async def bulk_delete(
+    data: BulkDeleteRequest,
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+):
+    count = await transaction_service.bulk_delete(session, user.id, data.transaction_ids)
+    return {"deleted": count}
+
+
+@router.patch("/bulk-update")
+async def bulk_update(
+    data: BulkUpdateRequest,
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+):
+    count = await transaction_service.bulk_update(
+        session, user.id, data.transaction_ids,
+        description=data.description,
+        txn_type=data.type,
+        account_id=data.account_id,
+    )
+    return {"updated": count}
+
+
 @router.post("/transfer", response_model=TransferRead, status_code=status.HTTP_201_CREATED)
 async def create_transfer(
     data: TransferCreate,
@@ -362,6 +400,19 @@ async def update_transaction(
         transaction = await transaction_service.update_transaction(session, transaction_id, user.id, data)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    if not transaction:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+    primary_currency = user.primary_currency
+    return _tag_fx_fallback(TransactionRead.model_validate(transaction, from_attributes=True), primary_currency)
+
+
+@router.patch("/{transaction_id}/ignore", response_model=TransactionRead)
+async def toggle_ignore_transaction(
+    transaction_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+):
+    transaction = await transaction_service.toggle_ignore_transaction(session, transaction_id, user.id)
     if not transaction:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
     primary_currency = user.primary_currency

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -28,6 +28,8 @@ class Transaction(Base):
     category_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=True)
     external_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)  # Provider's transaction ID
     description: Mapped[str] = mapped_column(String(500))
+    original_description: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
+    is_ignored: Mapped[bool] = mapped_column(default=False, server_default="false")
     amount: Mapped[Decimal] = mapped_column(Numeric(precision=15, scale=2))
     currency: Mapped[str] = mapped_column(String(3), default="USD")
     date: Mapped[_date] = mapped_column(Date)

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -93,6 +93,7 @@ class TransactionRead(TransactionBase):
     # is_self member at request time. Helps the UI show who paid
     # instead of a generic "shared" badge.
     parent_owner_name: Optional[str] = None
+    is_ignored: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -138,6 +139,22 @@ class CreateCounterpartRequest(BaseModel):
 class BulkTagsRequest(BaseModel):
     transaction_ids: list[uuid.UUID]
     tags: list[str]
+
+
+class BulkDeleteRequest(BaseModel):
+    transaction_ids: list[uuid.UUID]
+
+
+class BulkIgnoreRequest(BaseModel):
+    transaction_ids: list[uuid.UUID]
+    ignore: bool = True
+
+
+class BulkUpdateRequest(BaseModel):
+    transaction_ids: list[uuid.UUID]
+    description: Optional[str] = None
+    type: Optional[str] = None
+    account_id: Optional[uuid.UUID] = None
 
 
 class TransferRead(BaseModel):

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -1070,6 +1070,8 @@ async def sync_connection(
                 )
                 existing_tx = existing.scalar_one_or_none()
                 if existing_tx:
+                    if existing_tx.is_ignored:
+                        continue
                     if existing_tx.status == "pending" and txn_data.status == "posted":
                         existing_tx.status = "posted"
                     # Self-heal bill linkage: a tx that pre-dates the bills
@@ -1097,6 +1099,8 @@ async def sync_connection(
                 # Pass 2: Fuzzy match against manual transactions
                 fuzzy_match = await _fuzzy_match_manual(session, account.id, txn_data)
                 if fuzzy_match:
+                    if fuzzy_match.is_ignored:
+                        continue
                     fuzzy_match.external_id = txn_data.external_id
                     fuzzy_match.source = "sync"
                     fuzzy_match.raw_data = txn_data.raw_data

--- a/backend/app/services/rule_engine.py
+++ b/backend/app/services/rule_engine.py
@@ -112,4 +112,7 @@ def apply_rule_actions(
             if new_tags not in existing:
                 tx.notes = (existing + " " + new_tags).strip() if existing else new_tags
 
+        elif op == "ignore":
+            tx.is_ignored = True
+
     return category_already_set

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -59,6 +59,7 @@ async def get_transactions(
     to_date: Optional[date] = None,
     page: int = 1,
     limit: int = 50,
+    ignored_filter: str = "hide",  # "hide" | "include" | "only"
     include_opening_balance: bool = False,
     search: Optional[str] = None,
     uncategorized: bool = False,
@@ -175,6 +176,13 @@ async def get_transactions(
     # Exclude opening_balance transactions from the normal list unless explicitly requested
     if not include_opening_balance:
         base_query = base_query.where(Transaction.source != "opening_balance")
+
+    # Filter by ignored state: "hide" excludes, "only" restricts, "include" shows all
+    if ignored_filter == "only":
+        base_query = base_query.where(Transaction.is_ignored == True)  # noqa: E712
+    elif ignored_filter == "hide":
+        base_query = base_query.where(Transaction.is_ignored == False)  # noqa: E712
+    # "include" → no filter applied
 
     # Apply filters
     # Multi-id filters take precedence over single-id filters.
@@ -1369,3 +1377,77 @@ async def delete_transaction(
     await session.delete(transaction)
     await session.commit()
     return True
+
+
+async def toggle_ignore_transaction(
+    session: AsyncSession, transaction_id: uuid.UUID, user_id: uuid.UUID
+) -> Optional[Transaction]:
+    transaction = await get_transaction(session, transaction_id, user_id)
+    if not transaction:
+        return None
+    transaction.is_ignored = not transaction.is_ignored
+    await session.commit()
+    await session.refresh(transaction)
+    return transaction
+
+
+async def bulk_ignore(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    transaction_ids: list[uuid.UUID],
+    ignore: bool = True,
+) -> int:
+    result = await session.execute(
+        update(Transaction)
+        .where(
+            Transaction.id.in_(transaction_ids),
+            Transaction.user_id == user_id,
+        )
+        .values(is_ignored=ignore)
+    )
+    await session.commit()
+    return result.rowcount
+
+
+async def bulk_delete(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    transaction_ids: list[uuid.UUID],
+) -> int:
+    result = await session.execute(
+        delete(Transaction).where(
+            Transaction.id.in_(transaction_ids),
+            Transaction.user_id == user_id,
+        )
+    )
+    await session.commit()
+    return result.rowcount
+
+
+async def bulk_update(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    transaction_ids: list[uuid.UUID],
+    description: Optional[str] = None,
+    txn_type: Optional[str] = None,
+    account_id: Optional[uuid.UUID] = None,
+) -> int:
+    values: dict = {}
+    if description is not None:
+        values["description"] = description
+    if txn_type is not None:
+        values["type"] = txn_type
+    if account_id is not None:
+        values["account_id"] = account_id
+    if not values:
+        return 0
+    result = await session.execute(
+        update(Transaction)
+        .where(
+            Transaction.id.in_(transaction_ids),
+            Transaction.user_id == user_id,
+        )
+        .values(**values)
+    )
+    await session.commit()
+    return result.rowcount

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -1,63 +1,89 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
-import { getAccountName } from '@/lib/account-utils'
-import { useTranslation } from 'react-i18next'
-import { useQuery } from '@tanstack/react-query'
-import { useAuth } from '@/contexts/auth-context'
-import { currencies as currenciesApi, transactions as transactionsApi, settings as settingsApi, payees as payeesApi } from '@/lib/api'
-import { cn } from '@/lib/utils'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { DatePickerInput } from '@/components/ui/date-picker-input'
+import { useState, useEffect, useCallback, useRef } from "react";
+import { getAccountName } from "@/lib/account-utils";
+import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/contexts/auth-context";
+import {
+  currencies as currenciesApi,
+  transactions as transactionsApi,
+  settings as settingsApi,
+  payees as payeesApi,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { DatePickerInput } from "@/components/ui/date-picker-input";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogFooter,
-} from '@/components/ui/dialog'
-import { AlertTriangle, ChevronDown, ChevronLeft, Download, Paperclip, Upload, X, FileText, Plus, Unlink } from 'lucide-react'
+} from "@/components/ui/dialog";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronLeft,
+  Download,
+  EyeOff,
+  Eye,
+  Paperclip,
+  Upload,
+  X,
+  FileText,
+  Plus,
+  Unlink,
+} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import { CategorySelect } from '@/components/category-select'
-import { TransactionAttachments } from '@/components/transaction-attachments'
-import type { AttachmentPreview } from '@/components/transaction-attachments'
-import { TransactionSplitsSection } from '@/components/transaction-splits-section'
-import type { Transaction, RecurringTransaction, TransactionSplitsInput, CategoryGroup, Category } from '@/types'
-import { toast } from 'sonner'
+} from "@/components/ui/dropdown-menu";
+import { CategorySelect } from "@/components/category-select";
+import { TransactionAttachments } from "@/components/transaction-attachments";
+import type { AttachmentPreview } from "@/components/transaction-attachments";
+import { TransactionSplitsSection } from "@/components/transaction-splits-section";
+import type {
+  Transaction,
+  RecurringTransaction,
+  TransactionSplitsInput,
+  CategoryGroup,
+  Category,
+} from "@/types";
+import { toast } from "sonner";
 
-export type SaveAction = 'save' | 'saveAndNew' | 'saveAndDuplicate'
+export type SaveAction = "save" | "saveAndNew" | "saveAndDuplicate";
 
 export function extractApiError(error: unknown): string {
   if (
     error &&
-    typeof error === 'object' &&
-    'response' in error &&
+    typeof error === "object" &&
+    "response" in error &&
     error.response &&
-    typeof error.response === 'object' &&
-    'data' in error.response
+    typeof error.response === "object" &&
+    "data" in error.response
   ) {
-    const data = (error.response as { data: unknown }).data
-    if (data && typeof data === 'object' && 'detail' in data) {
-      const detail = (data as { detail: unknown }).detail
-      if (typeof detail === 'string') return detail
+    const data = (error.response as { data: unknown }).data;
+    if (data && typeof data === "object" && "detail" in data) {
+      const detail = (data as { detail: unknown }).detail;
+      if (typeof detail === "string") return detail;
       if (Array.isArray(detail)) {
-        return detail.map((d: { msg?: string; loc?: string[] }) => {
-          const field = d.loc?.slice(-1)[0] ?? ''
-          return `${field}: ${d.msg ?? 'invalid'}`
-        }).join(', ')
+        return detail
+          .map((d: { msg?: string; loc?: string[] }) => {
+            const field = d.loc?.slice(-1)[0] ?? "";
+            return `${field}: ${d.msg ?? "invalid"}`;
+          })
+          .join(", ");
       }
     }
   }
-  return 'An unexpected error occurred'
+  return "An unexpected error occurred";
 }
 
 function isImageType(contentType: string): boolean {
-  return contentType.startsWith('image/')
+  return contentType.startsWith("image/");
 }
 
 export function TransactionDialog({
@@ -70,6 +96,7 @@ export function TransactionDialog({
   recurringMatch,
   onSave,
   onDelete,
+  onIgnore,
   onUnlinkTransfer,
   loading,
   error,
@@ -77,73 +104,93 @@ export function TransactionDialog({
   duplicateDraft = null,
   formResetKey = 0,
 }: {
-  open: boolean
-  onClose: () => void
-  transaction: Transaction | null
-  categories: Category[]
-  categoryGroups: CategoryGroup[]
-  accounts: { id: string; name: string; type?: string }[]
-  recurringMatch?: RecurringTransaction
-  onSave: (data: Partial<Transaction>, recurringData?: { frequency: string; end_date?: string }, pendingFiles?: File[], action?: SaveAction) => void
-  onDelete?: () => void
-  onUnlinkTransfer?: (pairId: string) => void
-  loading: boolean
-  error: string | null
-  isSynced?: boolean
-  duplicateDraft?: Partial<Transaction> | null
-  formResetKey?: number
+  open: boolean;
+  onClose: () => void;
+  transaction: Transaction | null;
+  categories: Category[];
+  categoryGroups: CategoryGroup[];
+  accounts: { id: string; name: string; type?: string }[];
+  recurringMatch?: RecurringTransaction;
+  onSave: (
+    data: Partial<Transaction>,
+    recurringData?: { frequency: string; end_date?: string },
+    pendingFiles?: File[],
+    action?: SaveAction,
+  ) => void;
+  onDelete?: () => void;
+  onIgnore?: () => void;
+  onUnlinkTransfer?: (pairId: string) => void;
+  loading: boolean;
+  error: string | null;
+  isSynced?: boolean;
+  duplicateDraft?: Partial<Transaction> | null;
+  formResetKey?: number;
 }) {
-  const { t } = useTranslation()
-  const [preview, setPreview] = useState<AttachmentPreview | null>(null)
+  const { t } = useTranslation();
+  const [preview, setPreview] = useState<AttachmentPreview | null>(null);
 
-  const handlePreviewChange = useCallback((newPreview: AttachmentPreview | null) => {
-    setPreview(prev => {
-      if (prev?.url) URL.revokeObjectURL(prev.url)
-      return newPreview
-    })
-  }, [])
+  const handlePreviewChange = useCallback(
+    (newPreview: AttachmentPreview | null) => {
+      setPreview((prev) => {
+        if (prev?.url) URL.revokeObjectURL(prev.url);
+        return newPreview;
+      });
+    },
+    [],
+  );
 
   // Clean up preview when dialog closes
   useEffect(() => {
     if (!open) {
-      setPreview(prev => {
-        if (prev?.url) URL.revokeObjectURL(prev.url)
-        return null
-      })
+      setPreview((prev) => {
+        if (prev?.url) URL.revokeObjectURL(prev.url);
+        return null;
+      });
     }
-  }, [open])
+  }, [open]);
 
   const handleDownloadPreview = async () => {
-    if (!preview || !transaction) return
+    if (!preview || !transaction) return;
     try {
-      const url = await transactionsApi.attachments.downloadUrl(transaction.id, preview.attachmentId)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = preview.filename
-      document.body.appendChild(a)
-      a.click()
-      document.body.removeChild(a)
-      URL.revokeObjectURL(url)
+      const url = await transactionsApi.attachments.downloadUrl(
+        transaction.id,
+        preview.attachmentId,
+      );
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = preview.filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
     } catch {
-      toast.error(t('common.error'))
+      toast.error(t("common.error"));
     }
-  }
+  };
 
-  const isEditing = !!transaction
-  const hasPreview = isEditing && !!preview
+  const isEditing = !!transaction;
+  const hasPreview = isEditing && !!preview;
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className={cn(
-        'transition-[max-width] duration-300',
-        hasPreview ? 'sm:max-w-5xl max-w-2xl' : 'sm:max-w-2xl max-w-2xl'
-      )}>
-        <div className={isEditing ? 'sm:flex sm:gap-0 sm:h-[80vh]' : ''}>
+      <DialogContent
+        className={cn(
+          "transition-[max-width] duration-300",
+          hasPreview ? "sm:max-w-5xl max-w-2xl" : "sm:max-w-2xl max-w-2xl",
+        )}
+      >
+        <div className={isEditing ? "sm:flex sm:gap-0 sm:h-[80vh]" : ""}>
           {/* Left column: form */}
-          <div className={isEditing ? 'sm:flex-1 sm:min-w-0 sm:flex sm:flex-col sm:overflow-hidden sm:pr-6' : ''}>
+          <div
+            className={
+              isEditing
+                ? "sm:flex-1 sm:min-w-0 sm:flex sm:flex-col sm:overflow-hidden sm:pr-6"
+                : ""
+            }
+          >
             <DialogHeader className="mb-4">
               <DialogTitle>
-                {transaction ? t('common.edit') : t('transactions.addManual')}
+                {transaction ? t("common.edit") : t("transactions.addManual")}
               </DialogTitle>
             </DialogHeader>
             <TransactionForm
@@ -156,6 +203,7 @@ export function TransactionDialog({
               recurringMatch={recurringMatch}
               onSave={onSave}
               onDelete={onDelete}
+              onIgnore={onIgnore}
               onUnlinkTransfer={onUnlinkTransfer}
               onCancel={onClose}
               loading={loading}
@@ -170,14 +218,14 @@ export function TransactionDialog({
           {/* Desktop: side panel */}
           <div
             className={cn(
-              'hidden sm:flex shrink-0 border-l flex-col overflow-hidden transition-[width] duration-300 ease-in-out',
-              hasPreview ? 'w-[420px]' : 'w-0 border-l-0'
+              "hidden sm:flex shrink-0 border-l flex-col overflow-hidden transition-[width] duration-300 ease-in-out",
+              hasPreview ? "w-[420px]" : "w-0 border-l-0",
             )}
           >
             {preview && (
               <>
                 <div className="flex-1 overflow-hidden">
-                  {preview.contentType === 'application/pdf' ? (
+                  {preview.contentType === "application/pdf" ? (
                     <iframe
                       src={`${preview.url}#toolbar=0&navpanes=0`}
                       title={preview.filename}
@@ -202,7 +250,9 @@ export function TransactionDialog({
                   >
                     <ChevronLeft size={16} />
                   </button>
-                  <span className="flex-1 truncate font-medium">{preview.filename}</span>
+                  <span className="flex-1 truncate font-medium">
+                    {preview.filename}
+                  </span>
                   <button
                     type="button"
                     className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground cursor-pointer"
@@ -221,7 +271,7 @@ export function TransactionDialog({
         {hasPreview && (
           <div className="sm:hidden fixed inset-0 z-[100] bg-background flex flex-col animate-in slide-in-from-right duration-200">
             <div className="flex-1 overflow-hidden">
-              {preview.contentType === 'application/pdf' ? (
+              {preview.contentType === "application/pdf" ? (
                 <iframe
                   src={`${preview.url}#toolbar=0&navpanes=0`}
                   title={preview.filename}
@@ -246,7 +296,9 @@ export function TransactionDialog({
               >
                 <ChevronLeft size={18} />
               </button>
-              <span className="flex-1 truncate font-medium">{preview.filename}</span>
+              <span className="flex-1 truncate font-medium">
+                {preview.filename}
+              </span>
               <button
                 type="button"
                 className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground cursor-pointer"
@@ -260,7 +312,7 @@ export function TransactionDialog({
         )}
       </DialogContent>
     </Dialog>
-  )
+  );
 }
 
 function TransactionForm({
@@ -272,6 +324,7 @@ function TransactionForm({
   recurringMatch,
   onSave,
   onDelete,
+  onIgnore,
   onUnlinkTransfer,
   onCancel,
   loading,
@@ -281,198 +334,229 @@ function TransactionForm({
   activePreviewId,
   hasPreview,
 }: {
-  transaction: Transaction | null
-  duplicateDraft: Partial<Transaction> | null
-  categories: Category[]
-  categoryGroups: CategoryGroup[]
-  accounts: { id: string; name: string; type?: string }[]
-  recurringMatch?: RecurringTransaction
-  onSave: (data: Partial<Transaction>, recurringData?: { frequency: string; end_date?: string }, pendingFiles?: File[], action?: SaveAction) => void
-  onDelete?: () => void
-  onUnlinkTransfer?: (pairId: string) => void
-  onCancel: () => void
-  loading: boolean
-  error: string | null
-  isSynced: boolean
-  onPreviewChange: (preview: AttachmentPreview | null) => void
-  activePreviewId: string | null
-  hasPreview: boolean
+  transaction: Transaction | null;
+  duplicateDraft: Partial<Transaction> | null;
+  categories: Category[];
+  categoryGroups: CategoryGroup[];
+  accounts: { id: string; name: string; type?: string }[];
+  recurringMatch?: RecurringTransaction;
+  onSave: (
+    data: Partial<Transaction>,
+    recurringData?: { frequency: string; end_date?: string },
+    pendingFiles?: File[],
+    action?: SaveAction,
+  ) => void;
+  onDelete?: () => void;
+  onIgnore?: () => void;
+  onUnlinkTransfer?: (pairId: string) => void;
+  onCancel: () => void;
+  loading: boolean;
+  error: string | null;
+  isSynced: boolean;
+  onPreviewChange: (preview: AttachmentPreview | null) => void;
+  activePreviewId: string | null;
+  hasPreview: boolean;
 }) {
-  const { t, i18n } = useTranslation()
-  const { user } = useAuth()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
-  const locale = i18n.language === 'en' ? 'en-US' : i18n.language
+  const { t, i18n } = useTranslation();
+  const { user } = useAuth();
+  const userCurrency = user?.preferences?.currency_display ?? "USD";
+  const locale = i18n.language === "en" ? "en-US" : i18n.language;
   const { data: supportedCurrencies } = useQuery({
-    queryKey: ['currencies'],
+    queryKey: ["currencies"],
     queryFn: currenciesApi.list,
     staleTime: Infinity,
-  })
+  });
   const { data: payeesList } = useQuery({
-    queryKey: ['payees'],
+    queryKey: ["payees"],
     queryFn: payeesApi.list,
-  })
-  const seed = transaction ?? duplicateDraft
-  const [description, setDescription] = useState(seed?.description ?? '')
-  const [amount, setAmount] = useState(seed?.amount?.toString() ?? '')
-  const [date, setDate] = useState(seed?.date ?? new Date().toISOString().split('T')[0])
-  const [type, setType] = useState<'debit' | 'credit'>(seed?.type ?? 'debit')
-  const [currency, setCurrency] = useState(seed?.currency ?? userCurrency)
-  const [categoryId, setCategoryId] = useState(seed?.category_id ?? '')
-  const [payeeId, setPayeeId] = useState(seed?.payee_id ?? '')
-  const [accountId, setAccountId] = useState(seed?.account_id ?? accounts[0]?.id ?? '')
-  const [notes, setNotes] = useState(seed?.notes ?? '')
+  });
+  const seed = transaction ?? duplicateDraft;
+  const [description, setDescription] = useState(seed?.description ?? "");
+  const [amount, setAmount] = useState(seed?.amount?.toString() ?? "");
+  const [date, setDate] = useState(
+    seed?.date ?? new Date().toISOString().split("T")[0],
+  );
+  const [type, setType] = useState<"debit" | "credit">(seed?.type ?? "debit");
+  const [currency, setCurrency] = useState(seed?.currency ?? userCurrency);
+  const [categoryId, setCategoryId] = useState(seed?.category_id ?? "");
+  const [payeeId, setPayeeId] = useState(seed?.payee_id ?? "");
+  const [accountId, setAccountId] = useState(
+    seed?.account_id ?? accounts[0]?.id ?? "",
+  );
+  const [notes, setNotes] = useState(seed?.notes ?? "");
   // Manual CC bucketing override (issue #92). Empty = auto. Visible only
   // when the selected account is a credit card.
-  const [effectiveBillDate, setEffectiveBillDate] = useState(seed?.effective_bill_date ?? '')
+  const [effectiveBillDate, setEffectiveBillDate] = useState(
+    seed?.effective_bill_date ?? "",
+  );
   const [convertedAmount, setConvertedAmount] = useState(
-    seed?.amount_primary != null ? seed.amount_primary.toString() : ''
-  )
+    seed?.amount_primary != null ? seed.amount_primary.toString() : "",
+  );
   const [fxRate, setFxRate] = useState(
-    seed?.fx_rate_used != null ? seed.fx_rate_used.toString() : ''
-  )
-  const [isRecurring, setIsRecurring] = useState(false)
-  const [frequency, setFrequency] = useState<'monthly' | 'weekly' | 'yearly'>('monthly')
-  const [endDate, setEndDate] = useState('')
+    seed?.fx_rate_used != null ? seed.fx_rate_used.toString() : "",
+  );
+  const [isRecurring, setIsRecurring] = useState(false);
+  const [frequency, setFrequency] = useState<"monthly" | "weekly" | "yearly">(
+    "monthly",
+  );
+  const [endDate, setEndDate] = useState("");
   // Optional split-with-group payload. `null` = leave splits as-is on
   // update, or no splits on create. The dedicated section component
   // owns its own UI state and surfaces a normalized payload here.
   // Seeded from the transaction's existing splits so the edit dialog
   // round-trips them rather than appearing empty.
-  const [splitsValid, setSplitsValid] = useState(true)
+  const [splitsValid, setSplitsValid] = useState(true);
   const [splits, setSplits] = useState<TransactionSplitsInput | null>(() => {
-    const existing = (seed as Transaction | null | undefined)?.splits
-    if (!existing || existing.length === 0) return null
+    const existing = (seed as Transaction | null | undefined)?.splits;
+    if (!existing || existing.length === 0) return null;
     return {
-      share_type: (existing[0].share_type as TransactionSplitsInput['share_type']) ?? 'equal',
+      share_type:
+        (existing[0].share_type as TransactionSplitsInput["share_type"]) ??
+        "equal",
       splits: existing.map((s) => ({
         group_member_id: s.group_member_id,
         share_amount: s.share_amount,
         share_pct: s.share_pct,
       })),
-    }
-  })
+    };
+  });
   // Captured once at mount so we know whether to send an explicit clear
   // payload when the user toggles split off on a previously-split tx.
   const [hadInitialSplits] = useState<boolean>(() => {
-    const existing = (seed as Transaction | null | undefined)?.splits
-    return !!(existing && existing.length > 0)
-  })
-  const isCreating = !transaction
-  const showConversion = currency !== userCurrency && !isSynced
-  const [pendingFiles, setPendingFiles] = useState<File[]>([])
-  const [pendingDragOver, setPendingDragOver] = useState(false)
-  const pendingFileInputRef = useRef<HTMLInputElement>(null)
-  const pendingActionRef = useRef<SaveAction>('save')
-  const formRef = useRef<HTMLFormElement>(null)
+    const existing = (seed as Transaction | null | undefined)?.splits;
+    return !!(existing && existing.length > 0);
+  });
+  const isCreating = !transaction;
+  const showConversion = currency !== userCurrency && !isSynced;
+  const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+  const [pendingDragOver, setPendingDragOver] = useState(false);
+  const pendingFileInputRef = useRef<HTMLInputElement>(null);
+  const pendingActionRef = useRef<SaveAction>("save");
+  const formRef = useRef<HTMLFormElement>(null);
 
   const triggerSubmit = (action: SaveAction) => {
-    pendingActionRef.current = action
-    formRef.current?.requestSubmit()
-  }
-  const showSaveVariants = isCreating && !isSynced
+    pendingActionRef.current = action;
+    formRef.current?.requestSubmit();
+  };
+  const showSaveVariants = isCreating && !isSynced;
 
   const { data: attachmentSettings } = useQuery({
-    queryKey: ['settings', 'attachments'],
+    queryKey: ["settings", "attachments"],
     queryFn: () => settingsApi.attachments(),
     staleTime: 5 * 60 * 1000,
     enabled: isCreating,
-  })
-  const allowedExtensions = attachmentSettings?.allowed_extensions ?? ['jpg', 'jpeg', 'png', 'webp', 'gif', 'heic', 'pdf']
-  const maxFileSize = (attachmentSettings?.max_file_size_mb ?? 10) * 1024 * 1024
-  const maxAttachments = attachmentSettings?.max_attachments_per_transaction ?? 10
+  });
+  const allowedExtensions = attachmentSettings?.allowed_extensions ?? [
+    "jpg",
+    "jpeg",
+    "png",
+    "webp",
+    "gif",
+    "heic",
+    "pdf",
+  ];
+  const maxFileSize =
+    (attachmentSettings?.max_file_size_mb ?? 10) * 1024 * 1024;
+  const maxAttachments =
+    attachmentSettings?.max_attachments_per_transaction ?? 10;
 
-  const addPendingFiles = useCallback((files: FileList | File[]) => {
-    const fileArray = Array.from(files)
-    setPendingFiles(prev => {
-      let current = prev.length
-      const next = [...prev]
-      for (const file of fileArray) {
-        if (current >= maxAttachments) {
-          toast.error(t('transactions.attachmentMaxReached'))
-          break
+  const addPendingFiles = useCallback(
+    (files: FileList | File[]) => {
+      const fileArray = Array.from(files);
+      setPendingFiles((prev) => {
+        let current = prev.length;
+        const next = [...prev];
+        for (const file of fileArray) {
+          if (current >= maxAttachments) {
+            toast.error(t("transactions.attachmentMaxReached"));
+            break;
+          }
+          const ext = file.name.includes(".")
+            ? file.name.split(".").pop()!.toLowerCase()
+            : "";
+          if (!allowedExtensions.includes(ext)) {
+            toast.error(t("transactions.attachmentTypeNotAllowed"));
+            continue;
+          }
+          if (file.size > maxFileSize) {
+            toast.error(t("transactions.attachmentTooLarge"));
+            continue;
+          }
+          next.push(file);
+          current++;
         }
-        const ext = file.name.includes('.') ? file.name.split('.').pop()!.toLowerCase() : ''
-        if (!allowedExtensions.includes(ext)) {
-          toast.error(t('transactions.attachmentTypeNotAllowed'))
-          continue
-        }
-        if (file.size > maxFileSize) {
-          toast.error(t('transactions.attachmentTooLarge'))
-          continue
-        }
-        next.push(file)
-        current++
-      }
-      return next
-    })
-  }, [maxAttachments, allowedExtensions, maxFileSize, t])
+        return next;
+      });
+    },
+    [maxAttachments, allowedExtensions, maxFileSize, t],
+  );
 
   const removePendingFile = (index: number) => {
-    setPendingFiles(prev => prev.filter((_, i) => i !== index))
-  }
+    setPendingFiles((prev) => prev.filter((_, i) => i !== index));
+  };
 
   const handleConvertedAmountChange = (val: string) => {
-    setConvertedAmount(val)
-    const numVal = parseFloat(val)
-    const numAmount = parseFloat(amount)
+    setConvertedAmount(val);
+    const numVal = parseFloat(val);
+    const numAmount = parseFloat(amount);
     if (numVal && numAmount) {
-      setFxRate((numVal / numAmount).toString())
+      setFxRate((numVal / numAmount).toString());
     } else if (!val) {
-      setFxRate('')
+      setFxRate("");
     }
-  }
+  };
 
   const handleFxRateChange = (val: string) => {
-    setFxRate(val)
-    const numRate = parseFloat(val)
-    const numAmount = parseFloat(amount)
+    setFxRate(val);
+    const numRate = parseFloat(val);
+    const numAmount = parseFloat(amount);
     if (numRate && numAmount) {
-      setConvertedAmount((numAmount * numRate).toFixed(2))
+      setConvertedAmount((numAmount * numRate).toFixed(2));
     } else if (!val) {
-      setConvertedAmount('')
+      setConvertedAmount("");
     }
-  }
+  };
 
   const handleAmountChange = (val: string) => {
-    setAmount(val)
-    const numAmount = parseFloat(val)
-    const numRate = parseFloat(fxRate)
+    setAmount(val);
+    const numAmount = parseFloat(val);
+    const numRate = parseFloat(fxRate);
     if (numRate && numAmount) {
-      setConvertedAmount((numAmount * numRate).toFixed(2))
+      setConvertedAmount((numAmount * numRate).toFixed(2));
     }
-  }
+  };
 
   const handleCurrencyChange = (val: string) => {
-    setCurrency(val)
+    setCurrency(val);
     if (val === userCurrency) {
-      setConvertedAmount('')
-      setFxRate('')
+      setConvertedAmount("");
+      setFxRate("");
     }
-  }
+  };
 
   return (
     <form
       ref={formRef}
       onSubmit={(e) => {
-        e.preventDefault()
-        const action = pendingActionRef.current
-        pendingActionRef.current = 'save'
-        const fxFields: Partial<Transaction> = {}
+        e.preventDefault();
+        const action = pendingActionRef.current;
+        pendingActionRef.current = "save";
+        const fxFields: Partial<Transaction> = {};
         if (showConversion && convertedAmount) {
-          fxFields.amount_primary = parseFloat(convertedAmount)
+          fxFields.amount_primary = parseFloat(convertedAmount);
         }
         if (showConversion && fxRate) {
-          fxFields.fx_rate_used = parseFloat(fxRate)
+          fxFields.fx_rate_used = parseFloat(fxRate);
         }
         // Active CC account ⇒ surface effective_bill_date in the payload
         // (sent both for synced and manual edits since the user can hand-
         // correct the bucketing on either; null clears the override back to
         // auto bucketing).
-        const selectedAcc = accounts.find(a => a.id === accountId)
-        const isCcSelected = selectedAcc?.type === 'credit_card'
+        const selectedAcc = accounts.find((a) => a.id === accountId);
+        const isCcSelected = selectedAcc?.type === "credit_card";
         const overridePayload: Partial<Transaction> = isCcSelected
           ? { effective_bill_date: effectiveBillDate || null }
-          : {}
+          : {};
         // Splits ride along on the same payload — the backend treats a
         // missing `splits` field as untouched and a present payload as
         // full replacement. To clear existing splits when the user
@@ -480,17 +564,17 @@ function TransactionForm({
         const splitsPayload: { splits?: TransactionSplitsInput } = splits
           ? { splits }
           : hadInitialSplits
-            ? { splits: { share_type: 'equal', splits: [] } }
-            : {}
+            ? { splits: { share_type: "equal", splits: [] } }
+            : {};
         const txData = isSynced
-          ? {
+          ? ({
               category_id: categoryId || null,
               payee_id: payeeId || null,
               notes: notes.trim() || null,
               ...overridePayload,
               ...splitsPayload,
-            } as Partial<Transaction>
-          : {
+            } as Partial<Transaction>)
+          : ({
               description,
               amount: parseFloat(amount),
               date,
@@ -503,340 +587,450 @@ function TransactionForm({
               ...fxFields,
               ...overridePayload,
               ...splitsPayload,
-            } as Partial<Transaction>
-        const recurringData = isCreating && isRecurring
-          ? { frequency, end_date: endDate || undefined }
-          : undefined
-        onSave(txData, recurringData, isCreating && pendingFiles.length > 0 ? pendingFiles : undefined, action)
+            } as Partial<Transaction>);
+        const recurringData =
+          isCreating && isRecurring
+            ? { frequency, end_date: endDate || undefined }
+            : undefined;
+        onSave(
+          txData,
+          recurringData,
+          isCreating && pendingFiles.length > 0 ? pendingFiles : undefined,
+          action,
+        );
       }}
       className={cn(
-        'flex flex-col',
-        !isCreating ? 'flex-1 min-h-0' : 'max-h-[85vh]',
-        hasPreview && 'mt-4'
+        "flex flex-col",
+        !isCreating ? "flex-1 min-h-0" : "max-h-[85vh]",
+        hasPreview && "mt-4",
       )}
     >
       <div className="space-y-4 overflow-y-auto flex-1 min-h-0 pb-2">
-      {error && (
-        <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md">
-          {error}
-        </div>
-      )}
-      {isSynced && (
-        <div className="flex items-center gap-2 p-3 text-sm bg-amber-50 border border-amber-200 rounded-md text-amber-700">
-          {t('transactions.syncedInfo')}
-        </div>
-      )}
-      {!!transaction?.transfer_pair_id && (
-        <div className="p-3 text-sm bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-md text-blue-700 dark:text-blue-300 space-y-2">
-          <div className="flex items-start justify-between gap-3">
-            <div className="space-y-1 min-w-0">
-              <p>{t('transactions.transferInfo')}</p>
-              <p className="text-xs text-blue-500 dark:text-blue-400">{t('transactions.transferTooltip')}</p>
-            </div>
-            {onUnlinkTransfer && transaction?.transfer_pair_id && (
-              <button
-                type="button"
-                disabled={loading}
-                onClick={() => {
-                  if (transaction?.transfer_pair_id) {
-                    onUnlinkTransfer(transaction.transfer_pair_id)
-                  }
-                }}
-                className="shrink-0 inline-flex items-center gap-1.5 rounded-md border border-blue-200 dark:border-blue-800 bg-white/60 dark:bg-blue-900/40 px-2.5 py-1.5 text-xs font-medium text-blue-700 dark:text-blue-200 hover:bg-white dark:hover:bg-blue-900/70 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                title={t('transactions.unlinkTransferConfirm')}
-              >
-                <Unlink size={12} />
-                {t('transactions.unlinkTransfer')}
-              </button>
-            )}
-          </div>
-        </div>
-      )}
-      {recurringMatch && (
-        <div className="flex items-center gap-2 p-3 text-sm bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-md">
-          <span>{t('transactions.recurringInfo', {
-            frequency: t(`recurring.${recurringMatch.frequency}`),
-            next: new Date(recurringMatch.next_occurrence).toLocaleDateString(locale),
-          })}</span>
-        </div>
-      )}
-      <div className="space-y-2">
-        <Label>{t('transactions.description')}</Label>
-        <Input
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          required
-          disabled={isSynced}
-        />
-        {isSynced && transaction?.payee && transaction.payee !== transaction.description && (
-          <p className="text-xs text-muted-foreground">{transaction.payee}</p>
-        )}
-      </div>
-      <div className="grid grid-cols-3 gap-4">
-        <div className="space-y-2">
-          <Label>{t('transactions.amount')}</Label>
-          <Input
-            type="number"
-            step="0.01"
-            value={amount}
-            onChange={(e) => handleAmountChange(e.target.value)}
-            required
-            disabled={isSynced}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label>{t('transactions.currency')}</Label>
-          <select
-            className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background h-9 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
-            value={currency}
-            onChange={(e) => handleCurrencyChange(e.target.value)}
-            disabled={isSynced}
-          >
-            {(supportedCurrencies ?? [{ code: userCurrency, symbol: userCurrency, name: userCurrency, flag: '' }]).map((c) => (
-              <option key={c.code} value={c.code}>{c.flag} {c.name}</option>
-            ))}
-          </select>
-        </div>
-        <div className="space-y-2">
-          <Label>{t('transactions.date')}</Label>
-          <DatePickerInput
-            value={date}
-            onChange={setDate}
-            disabled={isSynced}
-            className="w-full justify-start"
-          />
-        </div>
-      </div>
-      {showConversion && (
-        <div className="border border-border rounded-md p-3 space-y-2">
-          {transaction?.fx_fallback && (
-            <div className="flex items-start gap-2 p-2 rounded-md bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-400">
-              <AlertTriangle size={14} className="mt-0.5 shrink-0" />
-              <span className="text-xs">{t('transactions.fxFallbackBanner')}</span>
-            </div>
-          )}
-          <div>
-            <span className="text-sm font-medium">{t('transactions.conversion')}</span>
-            <span className="text-xs text-muted-foreground ml-2">({t('transactions.conversionHint')})</span>
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-1">
-              <Label className="text-xs">{t('transactions.convertedAmount', { currency: userCurrency })}</Label>
-              <Input
-                type="number"
-                step="0.01"
-                value={convertedAmount}
-                onChange={(e) => handleConvertedAmountChange(e.target.value)}
-                placeholder={t('transactions.autoCalculated')}
-              />
-            </div>
-            <div className="space-y-1">
-              <Label className="text-xs">{t('transactions.exchangeRate')}</Label>
-              <Input
-                type="number"
-                step="0.0001"
-                value={fxRate}
-                onChange={(e) => handleFxRateChange(e.target.value)}
-                placeholder={t('transactions.autoCalculated')}
-              />
-            </div>
-          </div>
-        </div>
-      )}
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label>{t('transactions.type')}</Label>
-          <select
-            className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
-            value={type}
-            onChange={(e) => setType(e.target.value as 'debit' | 'credit')}
-            disabled={isSynced}
-          >
-            <option value="debit">{t('transactions.expense')}</option>
-            <option value="credit">{t('transactions.income')}</option>
-          </select>
-        </div>
-        <div className="space-y-2">
-          <Label>{t('transactions.category')}</Label>
-          <CategorySelect
-            value={categoryId}
-            onChange={setCategoryId}
-            categories={categories}
-            groups={categoryGroups}
-            allowNone={true}
-          />
-        </div>
-      </div>
-      <div className={cn("grid gap-4", isSynced ? "grid-cols-1" : "grid-cols-2")}>
-        <div className="space-y-2">
-          <Label>{t('payees.payee')}</Label>
-          <select
-            className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
-            value={payeeId}
-            onChange={(e) => setPayeeId(e.target.value)}
-          >
-            <option value="">{t('payees.noPayee')}</option>
-            {(payeesList ?? []).map((p) => (
-              <option key={p.id} value={p.id}>{p.name}</option>
-            ))}
-          </select>
-          {isSynced && transaction?.payee && (
-            <p className="text-xs text-muted-foreground">{t('payees.rawPayee')}: {transaction.payee}</p>
-          )}
-        </div>
-        {!isSynced && (
-          <div className="space-y-2">
-            <Label>{t('transactions.account')}</Label>
-            <select
-              className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
-              value={accountId}
-              onChange={(e) => setAccountId(e.target.value)}
-              required
-            >
-              {accounts.map((acc) => (
-                <option key={acc.id} value={acc.id}>{getAccountName(acc)}</option>
-              ))}
-            </select>
+        {error && (
+          <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md">
+            {error}
           </div>
         )}
-      </div>
-
-      <div className="space-y-2">
-        <Label>{t('transactions.notes')} <span className="text-muted-foreground font-normal text-xs">({t('transactions.notesHint')})</span></Label>
-        <textarea
-          className="w-full border border-input rounded-md px-3 py-2 text-sm bg-background resize-none focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-0"
-          rows={2}
-          value={notes}
-          onChange={(e) => setNotes(e.target.value)}
-          placeholder={t('transactions.notesPlaceholder')}
-        />
-      </div>
-
-      {/* Manual bill-cycle override (issue #92). CC accounts only. Empty
-          input = use auto bucketing (Pluggy bill_id when available, cycle
-          math otherwise). Setting the date forces this tx into the bill
-          whose due_date matches. */}
-      {(() => {
-        const selectedAcc = accounts.find(a => a.id === accountId)
-        if (selectedAcc?.type !== 'credit_card') return null
-        return (
-          <div className="space-y-2">
-            <Label>
-              {t('transactions.effectiveBillDate', 'Data efetiva da fatura')}{' '}
-              <span className="text-muted-foreground font-normal text-xs">
-                ({t('transactions.effectiveBillDateHint', 'manual, sobrescreve o ciclo automático')})
-              </span>
-            </Label>
-            <div className="inline-flex items-center gap-1">
-              <DatePickerInput
-                value={effectiveBillDate}
-                onChange={setEffectiveBillDate}
-                placeholder={t('transactions.effectiveBillDatePlaceholder', 'Vencimento da fatura (opcional)')}
-              />
-              {effectiveBillDate && (
+        {isSynced && (
+          <div className="flex items-center gap-2 p-3 text-sm bg-amber-50 border border-amber-200 rounded-md text-amber-700">
+            {t("transactions.syncedInfo")}
+          </div>
+        )}
+        {!!transaction?.transfer_pair_id && (
+          <div className="p-3 text-sm bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-md text-blue-700 dark:text-blue-300 space-y-2">
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1 min-w-0">
+                <p>{t("transactions.transferInfo")}</p>
+                <p className="text-xs text-blue-500 dark:text-blue-400">
+                  {t("transactions.transferTooltip")}
+                </p>
+              </div>
+              {onUnlinkTransfer && transaction?.transfer_pair_id && (
                 <button
                   type="button"
-                  className="h-9 w-9 inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
-                  onClick={() => setEffectiveBillDate('')}
-                  title={t('transactions.clearOverride', 'Remover sobrescrição')}
+                  disabled={loading}
+                  onClick={() => {
+                    if (transaction?.transfer_pair_id) {
+                      onUnlinkTransfer(transaction.transfer_pair_id);
+                    }
+                  }}
+                  className="shrink-0 inline-flex items-center gap-1.5 rounded-md border border-blue-200 dark:border-blue-800 bg-white/60 dark:bg-blue-900/40 px-2.5 py-1.5 text-xs font-medium text-blue-700 dark:text-blue-200 hover:bg-white dark:hover:bg-blue-900/70 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  title={t("transactions.unlinkTransferConfirm")}
                 >
-                  <X className="h-4 w-4" />
+                  <Unlink size={12} />
+                  {t("transactions.unlinkTransfer")}
                 </button>
               )}
             </div>
           </div>
-        )
-      })()}
-
-      {/* A settlement-sourced transaction *is* the movement clearing a
-          group debt; splitting it would create circular accounting
-          (the share would settle a debt that this debit is already
-          settling). Hide the section entirely in that case. */}
-      {transaction?.source !== 'settlement' && (
-        <TransactionSplitsSection
-          amount={parseFloat(amount) || 0}
-          currency={currency}
-          value={splits}
-          onChange={setSplits}
-          onValidityChange={setSplitsValid}
-        />
-      )}
-
-      {!isCreating && transaction ? (
-        <TransactionAttachments
-          transactionId={transaction.id}
-          onPreviewChange={onPreviewChange}
-          activePreviewId={activePreviewId}
-        />
-      ) : isCreating && (
-        <PendingAttachmentsSection
-          files={pendingFiles}
-          dragOver={pendingDragOver}
-          maxAttachments={maxAttachments}
-          allowedExtensions={allowedExtensions}
-          fileInputRef={pendingFileInputRef}
-          onDragOver={() => setPendingDragOver(true)}
-          onDragLeave={() => setPendingDragOver(false)}
-          onDrop={(e) => { e.preventDefault(); setPendingDragOver(false); if (e.dataTransfer.files?.length) addPendingFiles(e.dataTransfer.files) }}
-          onFileChange={(e) => { if (e.target.files?.length) { addPendingFiles(e.target.files); e.target.value = '' } }}
-          onRemove={removePendingFile}
-        />
-      )}
-
-      {/* Recurring toggle — only shown when creating non-synced */}
-      {isCreating && !isSynced && (
-        <div className="space-y-3 border rounded-md p-3">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={isRecurring}
-              onChange={(e) => setIsRecurring(e.target.checked)}
-              className="rounded border-gray-300"
+        )}
+        {recurringMatch && (
+          <div className="flex items-center gap-2 p-3 text-sm bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-md">
+            <span>
+              {t("transactions.recurringInfo", {
+                frequency: t(`recurring.${recurringMatch.frequency}`),
+                next: new Date(
+                  recurringMatch.next_occurrence,
+                ).toLocaleDateString(locale),
+              })}
+            </span>
+          </div>
+        )}
+        <div className="space-y-2">
+          <Label>{t("transactions.description")}</Label>
+          <Input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            required
+            disabled={isSynced}
+          />
+          {isSynced &&
+            transaction?.payee &&
+            transaction.payee !== transaction.description && (
+              <p className="text-xs text-muted-foreground">
+                {transaction.payee}
+              </p>
+            )}
+        </div>
+        <div className="grid grid-cols-3 gap-4">
+          <div className="space-y-2">
+            <Label>{t("transactions.amount")}</Label>
+            <Input
+              type="number"
+              step="0.01"
+              value={amount}
+              onChange={(e) => handleAmountChange(e.target.value)}
+              required
+              disabled={isSynced}
             />
-            <span className="text-sm font-medium">{t('transactions.makeRecurring')}</span>
-          </label>
-          {isRecurring && (
-            <div className="grid grid-cols-2 gap-4 pt-1">
-              <div className="space-y-2">
-                <Label>{t('recurring.frequency')}</Label>
-                <select
-                  className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
-                  value={frequency}
-                  onChange={(e) => setFrequency(e.target.value as 'monthly' | 'weekly' | 'yearly')}
-                >
-                  <option value="monthly">{t('recurring.monthly')}</option>
-                  <option value="weekly">{t('recurring.weekly')}</option>
-                  <option value="yearly">{t('recurring.yearly')}</option>
-                </select>
+          </div>
+          <div className="space-y-2">
+            <Label>{t("transactions.currency")}</Label>
+            <select
+              className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background h-9 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
+              value={currency}
+              onChange={(e) => handleCurrencyChange(e.target.value)}
+              disabled={isSynced}
+            >
+              {(
+                supportedCurrencies ?? [
+                  {
+                    code: userCurrency,
+                    symbol: userCurrency,
+                    name: userCurrency,
+                    flag: "",
+                  },
+                ]
+              ).map((c) => (
+                <option key={c.code} value={c.code}>
+                  {c.flag} {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label>{t("transactions.date")}</Label>
+            <DatePickerInput
+              value={date}
+              onChange={setDate}
+              disabled={isSynced}
+              className="w-full justify-start"
+            />
+          </div>
+        </div>
+        {showConversion && (
+          <div className="border border-border rounded-md p-3 space-y-2">
+            {transaction?.fx_fallback && (
+              <div className="flex items-start gap-2 p-2 rounded-md bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-400">
+                <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                <span className="text-xs">
+                  {t("transactions.fxFallbackBanner")}
+                </span>
               </div>
-              <div className="space-y-2">
-                <Label>{t('recurring.endDate')}</Label>
-                <DatePickerInput
-                  value={endDate}
-                  onChange={setEndDate}
-                  placeholder={t('recurring.endDate')}
-                  className="w-full justify-start"
+            )}
+            <div>
+              <span className="text-sm font-medium">
+                {t("transactions.conversion")}
+              </span>
+              <span className="text-xs text-muted-foreground ml-2">
+                ({t("transactions.conversionHint")})
+              </span>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Label className="text-xs">
+                  {t("transactions.convertedAmount", {
+                    currency: userCurrency,
+                  })}
+                </Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={convertedAmount}
+                  onChange={(e) => handleConvertedAmountChange(e.target.value)}
+                  placeholder={t("transactions.autoCalculated")}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">
+                  {t("transactions.exchangeRate")}
+                </Label>
+                <Input
+                  type="number"
+                  step="0.0001"
+                  value={fxRate}
+                  onChange={(e) => handleFxRateChange(e.target.value)}
+                  placeholder={t("transactions.autoCalculated")}
                 />
               </div>
             </div>
+          </div>
+        )}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label>{t("transactions.type")}</Label>
+            <select
+              className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
+              value={type}
+              onChange={(e) => setType(e.target.value as "debit" | "credit")}
+              disabled={isSynced}
+            >
+              <option value="debit">{t("transactions.expense")}</option>
+              <option value="credit">{t("transactions.income")}</option>
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label>{t("transactions.category")}</Label>
+            <CategorySelect
+              value={categoryId}
+              onChange={setCategoryId}
+              categories={categories}
+              groups={categoryGroups}
+              allowNone={true}
+            />
+          </div>
+        </div>
+        <div
+          className={cn("grid gap-4", isSynced ? "grid-cols-1" : "grid-cols-2")}
+        >
+          <div className="space-y-2">
+            <Label>{t("payees.payee")}</Label>
+            <select
+              className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
+              value={payeeId}
+              onChange={(e) => setPayeeId(e.target.value)}
+            >
+              <option value="">{t("payees.noPayee")}</option>
+              {(payeesList ?? []).map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+            {isSynced && transaction?.payee && (
+              <p className="text-xs text-muted-foreground">
+                {t("payees.rawPayee")}: {transaction.payee}
+              </p>
+            )}
+          </div>
+          {!isSynced && (
+            <div className="space-y-2">
+              <Label>{t("transactions.account")}</Label>
+              <select
+                className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
+                value={accountId}
+                onChange={(e) => setAccountId(e.target.value)}
+                required
+              >
+                {accounts.map((acc) => (
+                  <option key={acc.id} value={acc.id}>
+                    {getAccountName(acc)}
+                  </option>
+                ))}
+              </select>
+            </div>
           )}
         </div>
-      )}
 
+        <div className="space-y-2">
+          <Label>
+            {t("transactions.notes")}{" "}
+            <span className="text-muted-foreground font-normal text-xs">
+              ({t("transactions.notesHint")})
+            </span>
+          </Label>
+          <textarea
+            className="w-full border border-input rounded-md px-3 py-2 text-sm bg-background resize-none focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-0"
+            rows={2}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder={t("transactions.notesPlaceholder")}
+          />
+        </div>
+
+        {/* Manual bill-cycle override (issue #92). CC accounts only. Empty
+          input = use auto bucketing (Pluggy bill_id when available, cycle
+          math otherwise). Setting the date forces this tx into the bill
+          whose due_date matches. */}
+        {(() => {
+          const selectedAcc = accounts.find((a) => a.id === accountId);
+          if (selectedAcc?.type !== "credit_card") return null;
+          return (
+            <div className="space-y-2">
+              <Label>
+                {t("transactions.effectiveBillDate", "Data efetiva da fatura")}{" "}
+                <span className="text-muted-foreground font-normal text-xs">
+                  (
+                  {t(
+                    "transactions.effectiveBillDateHint",
+                    "manual, sobrescreve o ciclo automático",
+                  )}
+                  )
+                </span>
+              </Label>
+              <div className="inline-flex items-center gap-1">
+                <DatePickerInput
+                  value={effectiveBillDate}
+                  onChange={setEffectiveBillDate}
+                  placeholder={t(
+                    "transactions.effectiveBillDatePlaceholder",
+                    "Vencimento da fatura (opcional)",
+                  )}
+                />
+                {effectiveBillDate && (
+                  <button
+                    type="button"
+                    className="h-9 w-9 inline-flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
+                    onClick={() => setEffectiveBillDate("")}
+                    title={t(
+                      "transactions.clearOverride",
+                      "Remover sobrescrição",
+                    )}
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })()}
+
+        {/* A settlement-sourced transaction *is* the movement clearing a
+          group debt; splitting it would create circular accounting
+          (the share would settle a debt that this debit is already
+          settling). Hide the section entirely in that case. */}
+        {transaction?.source !== "settlement" && (
+          <TransactionSplitsSection
+            amount={parseFloat(amount) || 0}
+            currency={currency}
+            value={splits}
+            onChange={setSplits}
+            onValidityChange={setSplitsValid}
+          />
+        )}
+
+        {!isCreating && transaction ? (
+          <TransactionAttachments
+            transactionId={transaction.id}
+            onPreviewChange={onPreviewChange}
+            activePreviewId={activePreviewId}
+          />
+        ) : (
+          isCreating && (
+            <PendingAttachmentsSection
+              files={pendingFiles}
+              dragOver={pendingDragOver}
+              maxAttachments={maxAttachments}
+              allowedExtensions={allowedExtensions}
+              fileInputRef={pendingFileInputRef}
+              onDragOver={() => setPendingDragOver(true)}
+              onDragLeave={() => setPendingDragOver(false)}
+              onDrop={(e) => {
+                e.preventDefault();
+                setPendingDragOver(false);
+                if (e.dataTransfer.files?.length)
+                  addPendingFiles(e.dataTransfer.files);
+              }}
+              onFileChange={(e) => {
+                if (e.target.files?.length) {
+                  addPendingFiles(e.target.files);
+                  e.target.value = "";
+                }
+              }}
+              onRemove={removePendingFile}
+            />
+          )
+        )}
+
+        {/* Recurring toggle — only shown when creating non-synced */}
+        {isCreating && !isSynced && (
+          <div className="space-y-3 border rounded-md p-3">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={isRecurring}
+                onChange={(e) => setIsRecurring(e.target.checked)}
+                className="rounded border-gray-300"
+              />
+              <span className="text-sm font-medium">
+                {t("transactions.makeRecurring")}
+              </span>
+            </label>
+            {isRecurring && (
+              <div className="grid grid-cols-2 gap-4 pt-1">
+                <div className="space-y-2">
+                  <Label>{t("recurring.frequency")}</Label>
+                  <select
+                    className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
+                    value={frequency}
+                    onChange={(e) =>
+                      setFrequency(
+                        e.target.value as "monthly" | "weekly" | "yearly",
+                      )
+                    }
+                  >
+                    <option value="monthly">{t("recurring.monthly")}</option>
+                    <option value="weekly">{t("recurring.weekly")}</option>
+                    <option value="yearly">{t("recurring.yearly")}</option>
+                  </select>
+                </div>
+                <div className="space-y-2">
+                  <Label>{t("recurring.endDate")}</Label>
+                  <DatePickerInput
+                    value={endDate}
+                    onChange={setEndDate}
+                    placeholder={t("recurring.endDate")}
+                    className="w-full justify-start"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
-      <DialogFooter className={cn(
-        'shrink-0 border-t pt-4 mt-2',
-        onDelete ? 'flex justify-between sm:justify-between' : ''
-      )}>
-        {onDelete && (
-          <Button type="button" variant="destructive" onClick={onDelete} disabled={loading}>
-            {t('common.delete')}
-          </Button>
+      <DialogFooter
+        className={cn(
+          "shrink-0 border-t pt-4 mt-2",
+          onDelete || onIgnore ? "flex justify-between sm:justify-between" : "",
         )}
+      >
+        <div className="flex gap-2">
+          {onDelete && (
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={onDelete}
+              disabled={loading}
+            >
+              {t("common.delete")}
+            </Button>
+          )}
+          {onIgnore && transaction && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onIgnore}
+              disabled={loading}
+              className="gap-1.5 text-muted-foreground"
+            >
+              {transaction.is_ignored ? (
+                <>
+                  <Eye size={14} />
+                  Desfazer ignorar
+                </>
+              ) : (
+                <>
+                  <EyeOff size={14} />
+                  Ignorar
+                </>
+              )}
+            </Button>
+          )}
+        </div>
         <div className="flex gap-2">
           <Button type="button" variant="outline" onClick={onCancel}>
-            {t('common.cancel')}
+            {t("common.cancel")}
           </Button>
           {showSaveVariants ? (
             <div className="inline-flex">
@@ -845,44 +1039,48 @@ function TransactionForm({
                 disabled={loading || !splitsValid}
                 className="rounded-r-none"
               >
-                {loading ? t('common.loading') : t('common.save')}
+                {loading ? t("common.loading") : t("common.save")}
               </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
                     type="button"
                     disabled={loading || !splitsValid}
-                    aria-label={t('transactions.moreSaveOptions')}
+                    aria-label={t("transactions.moreSaveOptions")}
                     className="rounded-l-none border-l border-l-primary-foreground/20 px-2 has-[>svg]:px-2"
                   >
                     <ChevronDown />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuItem onSelect={() => triggerSubmit('saveAndNew')}>
-                    {t('transactions.saveAndNew')}
+                  <DropdownMenuItem
+                    onSelect={() => triggerSubmit("saveAndNew")}
+                  >
+                    {t("transactions.saveAndNew")}
                   </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => triggerSubmit('saveAndDuplicate')}>
-                    {t('transactions.saveAndDuplicate')}
+                  <DropdownMenuItem
+                    onSelect={() => triggerSubmit("saveAndDuplicate")}
+                  >
+                    {t("transactions.saveAndDuplicate")}
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
           ) : (
             <Button type="submit" disabled={loading || !splitsValid}>
-              {loading ? t('common.loading') : t('common.save')}
+              {loading ? t("common.loading") : t("common.save")}
             </Button>
           )}
         </div>
       </DialogFooter>
     </form>
-  )
+  );
 }
 
 function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function PendingAttachmentsSection({
@@ -897,28 +1095,30 @@ function PendingAttachmentsSection({
   onFileChange,
   onRemove,
 }: {
-  files: File[]
-  dragOver: boolean
-  maxAttachments: number
-  allowedExtensions: string[]
-  fileInputRef: React.RefObject<HTMLInputElement | null>
-  onDragOver: () => void
-  onDragLeave: () => void
-  onDrop: (e: React.DragEvent) => void
-  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void
-  onRemove: (index: number) => void
+  files: File[];
+  dragOver: boolean;
+  maxAttachments: number;
+  allowedExtensions: string[];
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  onDragOver: () => void;
+  onDragLeave: () => void;
+  onDrop: (e: React.DragEvent) => void;
+  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onRemove: (index: number) => void;
 }) {
-  const { t } = useTranslation()
-  const hasFiles = files.length > 0
-  const atMax = files.length >= maxAttachments
+  const { t } = useTranslation();
+  const hasFiles = files.length > 0;
+  const atMax = files.length >= maxAttachments;
 
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-2 text-sm font-medium">
         <Paperclip size={14} />
-        {t('transactions.attachments')}
+        {t("transactions.attachments")}
         {hasFiles && (
-          <span className="text-xs text-muted-foreground font-normal">({files.length})</span>
+          <span className="text-xs text-muted-foreground font-normal">
+            ({files.length})
+          </span>
         )}
       </div>
 
@@ -926,9 +1126,11 @@ function PendingAttachmentsSection({
         <>
           <div className="grid grid-cols-3 gap-2">
             {files.map((file, index) => {
-              const isImg = file.type.startsWith('image/')
-              const isPdf = file.type === 'application/pdf'
-              const ext = file.name.includes('.') ? file.name.split('.').pop()!.toUpperCase() : 'FILE'
+              const isImg = file.type.startsWith("image/");
+              const isPdf = file.type === "application/pdf";
+              const ext = file.name.includes(".")
+                ? file.name.split(".").pop()!.toUpperCase()
+                : "FILE";
 
               return (
                 <div
@@ -941,14 +1143,25 @@ function PendingAttachmentsSection({
                         src={URL.createObjectURL(file)}
                         alt={file.name}
                         className="w-full h-full object-cover"
-                        onLoad={(e) => URL.revokeObjectURL((e.target as HTMLImageElement).src)}
+                        onLoad={(e) =>
+                          URL.revokeObjectURL(
+                            (e.target as HTMLImageElement).src,
+                          )
+                        }
                       />
                     ) : (
                       <div className="flex flex-col items-center gap-2">
-                        <div className={`w-12 h-14 rounded-lg flex items-center justify-center ${
-                          isPdf ? 'bg-red-500/10' : 'bg-muted'
-                        }`}>
-                          <FileText size={24} className={isPdf ? 'text-red-500' : 'text-muted-foreground'} />
+                        <div
+                          className={`w-12 h-14 rounded-lg flex items-center justify-center ${
+                            isPdf ? "bg-red-500/10" : "bg-muted"
+                          }`}
+                        >
+                          <FileText
+                            size={24}
+                            className={
+                              isPdf ? "text-red-500" : "text-muted-foreground"
+                            }
+                          />
                         </div>
                         <span className="text-[10px] font-semibold tracking-widest text-muted-foreground/70 uppercase">
                           {ext}
@@ -964,7 +1177,7 @@ function PendingAttachmentsSection({
                         type="button"
                         className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 cursor-pointer transition-colors"
                         onClick={() => onRemove(index)}
-                        title={t('common.delete')}
+                        title={t("common.delete")}
                       >
                         <X size={14} />
                       </button>
@@ -972,7 +1185,10 @@ function PendingAttachmentsSection({
                   </div>
 
                   <div className="px-3 py-2.5 bg-card">
-                    <p className="text-[12px] font-medium truncate leading-tight" title={file.name}>
+                    <p
+                      className="text-[12px] font-medium truncate leading-tight"
+                      title={file.name}
+                    >
                       {file.name}
                     </p>
                     <p className="text-[10px] text-muted-foreground mt-1 leading-tight">
@@ -980,7 +1196,7 @@ function PendingAttachmentsSection({
                     </p>
                   </div>
                 </div>
-              )
+              );
             })}
           </div>
 
@@ -989,25 +1205,35 @@ function PendingAttachmentsSection({
               type="button"
               className={`w-full mt-2 rounded-lg border-2 border-dashed py-3 flex items-center justify-center gap-2 cursor-pointer transition-all duration-200 ${
                 dragOver
-                  ? 'border-primary bg-primary/5'
-                  : 'border-border hover:border-muted-foreground/40 hover:bg-muted/30'
+                  ? "border-primary bg-primary/5"
+                  : "border-border hover:border-muted-foreground/40 hover:bg-muted/30"
               }`}
-              onDragOver={(e) => { e.preventDefault(); onDragOver() }}
+              onDragOver={(e) => {
+                e.preventDefault();
+                onDragOver();
+              }}
               onDragLeave={onDragLeave}
               onDrop={onDrop}
               onClick={() => fileInputRef.current?.click()}
             >
               <Plus size={14} className="text-muted-foreground" />
-              <span className="text-xs text-muted-foreground">{t('transactions.attachmentsUpload')}</span>
+              <span className="text-xs text-muted-foreground">
+                {t("transactions.attachmentsUpload")}
+              </span>
             </button>
           )}
         </>
       ) : (
         <div
           className={`rounded-xl border-2 border-dashed py-6 px-4 text-center transition-all cursor-pointer ${
-            dragOver ? 'border-primary bg-primary/5' : 'border-border hover:border-muted-foreground/40'
+            dragOver
+              ? "border-primary bg-primary/5"
+              : "border-border hover:border-muted-foreground/40"
           }`}
-          onDragOver={(e) => { e.preventDefault(); onDragOver() }}
+          onDragOver={(e) => {
+            e.preventDefault();
+            onDragOver();
+          }}
           onDragLeave={onDragLeave}
           onDrop={onDrop}
           onClick={() => fileInputRef.current?.click()}
@@ -1016,7 +1242,9 @@ function PendingAttachmentsSection({
             <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center">
               <Upload size={14} className="text-muted-foreground" />
             </div>
-            <span className="text-xs text-muted-foreground">{t('transactions.attachmentsUpload')}</span>
+            <span className="text-xs text-muted-foreground">
+              {t("transactions.attachmentsUpload")}
+            </span>
           </div>
         </div>
       )}
@@ -1025,10 +1253,10 @@ function PendingAttachmentsSection({
         ref={fileInputRef}
         type="file"
         multiple
-        accept={allowedExtensions.map(ext => `.${ext}`).join(',')}
+        accept={allowedExtensions.map((ext) => `.${ext}`).join(",")}
         onChange={onFileChange}
         className="hidden"
       />
     </div>
-  )
+  );
 }

--- a/frontend/src/components/transactions-filter-bar.tsx
+++ b/frontend/src/components/transactions-filter-bar.tsx
@@ -1,12 +1,13 @@
-import { useMemo, useRef, useState } from 'react'
-import { getAccountName } from '@/lib/account-utils'
-import { useTranslation } from 'react-i18next'
-import { format, startOfMonth, startOfYear, subDays } from 'date-fns'
+import { useMemo, useRef, useState } from "react";
+import { getAccountName } from "@/lib/account-utils";
+import { useTranslation } from "react-i18next";
+import { format, startOfMonth, startOfYear, subDays } from "date-fns";
 import {
   ArrowUpDown,
   Calendar as CalendarIcon,
   Check,
   ChevronRight,
+  EyeOff,
   ListFilter,
   Search,
   Store,
@@ -14,8 +15,8 @@ import {
   Users,
   Wallet,
   X,
-} from 'lucide-react'
-import { ptBR, enUS } from 'date-fns/locale'
+} from "lucide-react";
+import { ptBR, enUS } from "date-fns/locale";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -29,51 +30,53 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
+} from "@/components/ui/dropdown-menu";
 import {
   Popover,
   PopoverAnchor,
   PopoverContent,
-} from '@/components/ui/popover'
-import { Calendar } from '@/components/ui/calendar'
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
-import { CategoryFilterContent } from '@/components/category-filter-content'
-import type { Account, Category, CategoryGroup, Group, Payee } from '@/types'
+} from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { CategoryFilterContent } from "@/components/category-filter-content";
+import type { Account, Category, CategoryGroup, Group, Payee } from "@/types";
 
 interface TransactionsFilterBarProps {
-  searchInput: string
-  onSearchChange: (value: string) => void
-  onSearchSubmit?: (value: string) => void
-  filterAccountIds: string[]
-  onAccountIdsChange: (value: string[]) => void
-  filterCategoryIds: string[]
-  onCategoryIdsChange: (value: string[]) => void
-  filterUncategorized: boolean
-  onUncategorizedChange: (value: boolean) => void
-  filterPayee: string
-  onPayeeChange: (value: string) => void
-  filterGroupId: string
-  onGroupIdChange: (value: string) => void
-  filterType: string
-  onTypeChange: (value: string) => void
-  filterFrom: string
-  filterTo: string
-  onDateRangeChange: (from: string, to: string) => void
-  onClearAll: () => void
-  accounts: Account[]
-  categories: Category[]
-  categoryGroups: CategoryGroup[]
-  payees: Payee[]
-  groups: Group[]
+  searchInput: string;
+  onSearchChange: (value: string) => void;
+  onSearchSubmit?: (value: string) => void;
+  filterAccountIds: string[];
+  onAccountIdsChange: (value: string[]) => void;
+  filterCategoryIds: string[];
+  onCategoryIdsChange: (value: string[]) => void;
+  filterUncategorized: boolean;
+  onUncategorizedChange: (value: boolean) => void;
+  filterPayee: string;
+  onPayeeChange: (value: string) => void;
+  filterGroupId: string;
+  onGroupIdChange: (value: string) => void;
+  filterType: string;
+  onTypeChange: (value: string) => void;
+  ignoredFilter: "hide" | "include" | "only";
+  onIgnoredFilterChange: (value: "hide" | "include" | "only") => void;
+  filterFrom: string;
+  filterTo: string;
+  onDateRangeChange: (from: string, to: string) => void;
+  onClearAll: () => void;
+  accounts: Account[];
+  categories: Category[];
+  categoryGroups: CategoryGroup[];
+  payees: Payee[];
+  groups: Group[];
 }
 
 function toISODate(d: Date): string {
-  return format(d, 'yyyy-MM-dd')
+  return format(d, "yyyy-MM-dd");
 }
 
 function toggleInArray(arr: string[], id: string): string[] {
-  return arr.includes(id) ? arr.filter((x) => x !== id) : [...arr, id]
+  return arr.includes(id) ? arr.filter((x) => x !== id) : [...arr, id];
 }
 
 export function TransactionsFilterBar({
@@ -92,6 +95,8 @@ export function TransactionsFilterBar({
   onGroupIdChange,
   filterType,
   onTypeChange,
+  ignoredFilter,
+  onIgnoredFilterChange,
   filterFrom,
   filterTo,
   onDateRangeChange,
@@ -102,68 +107,68 @@ export function TransactionsFilterBar({
   payees,
   groups,
 }: TransactionsFilterBarProps) {
-  const { t, i18n } = useTranslation()
-  const locale = i18n.language === 'en' ? 'en-US' : i18n.language
-  const dateFnsLocale = i18n.language === 'pt-BR' ? ptBR : enUS
-  const [menuOpen, setMenuOpen] = useState(false)
-  const [accountSubOpen, setAccountSubOpen] = useState(false)
-  const [categorySubOpen, setCategorySubOpen] = useState(false)
-  const keepAccountSubOpenRef = useRef(false)
-  const keepCategorySubOpenRef = useRef(false)
-  const [dateCustomOpen, setDateCustomOpen] = useState(false)
-  const [draftFrom, setDraftFrom] = useState<string>(filterFrom)
-  const [draftTo, setDraftTo] = useState<string>(filterTo)
-  const searchRef = useRef<HTMLInputElement>(null)
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language === "en" ? "en-US" : i18n.language;
+  const dateFnsLocale = i18n.language === "pt-BR" ? ptBR : enUS;
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [accountSubOpen, setAccountSubOpen] = useState(false);
+  const [categorySubOpen, setCategorySubOpen] = useState(false);
+  const keepAccountSubOpenRef = useRef(false);
+  const keepCategorySubOpenRef = useRef(false);
+  const [dateCustomOpen, setDateCustomOpen] = useState(false);
+  const [draftFrom, setDraftFrom] = useState<string>(filterFrom);
+  const [draftTo, setDraftTo] = useState<string>(filterTo);
+  const searchRef = useRef<HTMLInputElement>(null);
 
   // When a CheckRow is clicked inside a submenu, Radix tries to close the submenu
   // even if we preventDefault in onSelect. We intercept the close request so the
   // submenu stays open and users can toggle several rows in a row.
   const handleAccountSubOpenChange = (open: boolean) => {
     if (!open && keepAccountSubOpenRef.current) {
-      keepAccountSubOpenRef.current = false
-      return
+      keepAccountSubOpenRef.current = false;
+      return;
     }
-    setAccountSubOpen(open)
-  }
+    setAccountSubOpen(open);
+  };
   const handleCategorySubOpenChange = (open: boolean) => {
     if (!open && keepCategorySubOpenRef.current) {
-      keepCategorySubOpenRef.current = false
-      return
+      keepCategorySubOpenRef.current = false;
+      return;
     }
-    setCategorySubOpen(open)
-  }
+    setCategorySubOpen(open);
+  };
   // When the root menu closes, make sure submenus close too so a fresh open starts clean.
   const handleMenuOpenChange = (open: boolean) => {
-    setMenuOpen(open)
+    setMenuOpen(open);
     if (!open) {
-      setAccountSubOpen(false)
-      setCategorySubOpen(false)
-      keepAccountSubOpenRef.current = false
-      keepCategorySubOpenRef.current = false
+      setAccountSubOpen(false);
+      setCategorySubOpen(false);
+      keepAccountSubOpenRef.current = false;
+      keepCategorySubOpenRef.current = false;
     }
-  }
+  };
 
   const accountById = useMemo(() => {
-    const map = new Map<string, Account>()
-    accounts.forEach((a) => map.set(a.id, a))
-    return map
-  }, [accounts])
+    const map = new Map<string, Account>();
+    accounts.forEach((a) => map.set(a.id, a));
+    return map;
+  }, [accounts]);
 
   const categoryById = useMemo(() => {
-    const map = new Map<string, Category>()
-    categories.forEach((c) => map.set(c.id, c))
-    return map
-  }, [categories])
+    const map = new Map<string, Category>();
+    categories.forEach((c) => map.set(c.id, c));
+    return map;
+  }, [categories]);
 
   const selectedPayee = useMemo(
     () => payees.find((p) => p.id === filterPayee),
     [payees, filterPayee],
-  )
+  );
 
   const selectedGroup = useMemo(
     () => groups.find((g) => g.id === filterGroupId),
     [groups, filterGroupId],
-  )
+  );
 
   const hasAnyFilter =
     filterAccountIds.length > 0 ||
@@ -174,584 +179,695 @@ export function TransactionsFilterBar({
     !!filterType ||
     !!filterFrom ||
     !!filterTo ||
-    searchInput.trim().length > 0
+    searchInput.trim().length > 0;
 
   const typeLabel =
-    filterType === 'credit'
-      ? t('transactions.income')
-      : filterType === 'debit'
-        ? t('transactions.expense')
-        : ''
+    filterType === "credit"
+      ? t("transactions.income")
+      : filterType === "debit"
+        ? t("transactions.expense")
+        : "";
 
   const dateLabel = useMemo(() => {
-    if (!filterFrom && !filterTo) return null
+    if (!filterFrom && !filterTo) return null;
     const fmt = (iso: string) =>
-      new Date(iso + 'T00:00:00').toLocaleDateString(locale, {
-        day: '2-digit',
-        month: 'short',
-      })
-    if (filterFrom && filterTo) return `${fmt(filterFrom)} — ${fmt(filterTo)}`
-    if (filterFrom) return `≥ ${fmt(filterFrom)}`
-    return `≤ ${fmt(filterTo)}`
-  }, [filterFrom, filterTo, locale])
+      new Date(iso + "T00:00:00").toLocaleDateString(locale, {
+        day: "2-digit",
+        month: "short",
+      });
+    if (filterFrom && filterTo) return `${fmt(filterFrom)} — ${fmt(filterTo)}`;
+    if (filterFrom) return `≥ ${fmt(filterFrom)}`;
+    return `≤ ${fmt(filterTo)}`;
+  }, [filterFrom, filterTo, locale]);
 
   const datePresets = useMemo(() => {
-    const today = new Date()
+    const today = new Date();
     return [
       {
-        key: 'today',
-        label: t('transactions.filtersBar.datePresets.today'),
+        key: "today",
+        label: t("transactions.filtersBar.datePresets.today"),
         from: toISODate(today),
         to: toISODate(today),
       },
       {
-        key: 'last7',
-        label: t('transactions.filtersBar.datePresets.last7'),
+        key: "last7",
+        label: t("transactions.filtersBar.datePresets.last7"),
         from: toISODate(subDays(today, 6)),
         to: toISODate(today),
       },
       {
-        key: 'last30',
-        label: t('transactions.filtersBar.datePresets.last30'),
+        key: "last30",
+        label: t("transactions.filtersBar.datePresets.last30"),
         from: toISODate(subDays(today, 29)),
         to: toISODate(today),
       },
       {
-        key: 'thisMonth',
-        label: t('transactions.filtersBar.datePresets.thisMonth'),
+        key: "thisMonth",
+        label: t("transactions.filtersBar.datePresets.thisMonth"),
         from: toISODate(startOfMonth(today)),
         to: toISODate(today),
       },
       {
-        key: 'last90',
-        label: t('transactions.filtersBar.datePresets.last90'),
+        key: "last90",
+        label: t("transactions.filtersBar.datePresets.last90"),
         from: toISODate(subDays(today, 89)),
         to: toISODate(today),
       },
       {
-        key: 'thisYear',
-        label: t('transactions.filtersBar.datePresets.thisYear'),
+        key: "thisYear",
+        label: t("transactions.filtersBar.datePresets.thisYear"),
         from: toISODate(startOfYear(today)),
         to: toISODate(today),
       },
-    ]
-  }, [t])
+    ];
+  }, [t]);
 
   const openCustomRange = () => {
-    setDraftFrom(filterFrom)
-    setDraftTo(filterTo)
-    setMenuOpen(false)
+    setDraftFrom(filterFrom);
+    setDraftTo(filterTo);
+    setMenuOpen(false);
     // Wait for the dropdown to finish closing before showing the popover
     // so focus and portal state settle correctly.
-    setTimeout(() => setDateCustomOpen(true), 80)
-  }
+    setTimeout(() => setDateCustomOpen(true), 80);
+  };
 
   const accountSummary =
     filterAccountIds.length > 1
-      ? t('transactions.filtersBar.nSelected', { count: filterAccountIds.length })
+      ? t("transactions.filtersBar.nSelected", {
+          count: filterAccountIds.length,
+        })
       : filterAccountIds.length === 1
-        ? (getAccountName(accountById.get(filterAccountIds[0]) ?? { name: '', display_name: null }))
-        : ''
+        ? getAccountName(
+            accountById.get(filterAccountIds[0]) ?? {
+              name: "",
+              display_name: null,
+            },
+          )
+        : "";
 
   const categorySummary = (() => {
-    const total = filterCategoryIds.length + (filterUncategorized ? 1 : 0)
+    const total = filterCategoryIds.length + (filterUncategorized ? 1 : 0);
     if (total > 1)
-      return t('transactions.filtersBar.nSelected', { count: total })
-    if (filterUncategorized) return t('transactions.uncategorized')
+      return t("transactions.filtersBar.nSelected", { count: total });
+    if (filterUncategorized) return t("transactions.uncategorized");
     if (filterCategoryIds.length === 1)
-      return categoryById.get(filterCategoryIds[0])?.name ?? ''
-    return ''
-  })()
+      return categoryById.get(filterCategoryIds[0])?.name ?? "";
+    return "";
+  })();
 
   return (
     <div className="mb-4">
-      <Popover open={dateCustomOpen} onOpenChange={setDateCustomOpen} modal={true}>
-      <PopoverAnchor asChild>
-      <div
-        className={cn(
-          'group/filterbar rounded-xl border border-border bg-card shadow-sm transition-colors',
-          'focus-within:border-primary/40 focus-within:ring-[3px] focus-within:ring-primary/10',
-        )}
+      <Popover
+        open={dateCustomOpen}
+        onOpenChange={setDateCustomOpen}
+        modal={true}
       >
-        {/* Top row: search input + controls */}
-        <div className="flex items-center gap-1.5 px-2 py-1.5">
-        {/* Search input — splits committed `#tag` tokens into inline chips,
+        <PopoverAnchor asChild>
+          <div
+            className={cn(
+              "group/filterbar rounded-xl border border-border bg-card shadow-sm transition-colors",
+              "focus-within:border-primary/40 focus-within:ring-[3px] focus-within:ring-primary/10",
+            )}
+          >
+            {/* Top row: search input + controls */}
+            <div className="flex items-center gap-1.5 px-2 py-1.5">
+              {/* Search input — splits committed `#tag` tokens into inline chips,
             keeping free text as plain typing. Comma or space commits a token. */}
-        <SearchWithTagChips
-          inputRef={searchRef}
-          value={searchInput}
-          placeholder={t('transactions.searchPlaceholder')}
-          onChange={onSearchChange}
-          onSubmit={onSearchSubmit}
-        />
+              <SearchWithTagChips
+                inputRef={searchRef}
+                value={searchInput}
+                placeholder={t("transactions.searchPlaceholder")}
+                onChange={onSearchChange}
+                onSubmit={onSearchSubmit}
+              />
 
-        {/* Right-side controls */}
-        <div className="ml-auto flex shrink-0 items-center gap-1 pl-1">
-          {hasAnyFilter && (
-            <button
-              type="button"
-              onClick={onClearAll}
-              className="hidden h-7 items-center rounded-md px-2 text-[11.5px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground md:inline-flex"
-            >
-              {t('transactions.clearFilters')}
-            </button>
-          )}
-
-          <DropdownMenu open={menuOpen} onOpenChange={handleMenuOpenChange}>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                aria-label={t('transactions.filtersBar.filters')}
-                className={cn(
-                  'inline-flex h-8 items-center gap-1.5 rounded-md border border-border/80 bg-background px-2.5 text-[12px] font-medium text-muted-foreground transition-colors',
-                  'hover:bg-muted hover:text-foreground',
-                  menuOpen && 'bg-muted text-foreground',
-                  hasAnyFilter && 'border-primary/30 text-primary hover:text-primary',
-                )}
-              >
-                <ListFilter size={13} />
-                <span className="hidden sm:inline">
-                  {t('transactions.filtersBar.filters')}
-                </span>
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              sideOffset={6}
-              className="w-[240px] p-1"
-            >
-              <DropdownMenuLabel className="px-2 py-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
-                {t('transactions.filtersBar.filterBy')}
-              </DropdownMenuLabel>
-              <DropdownMenuGroup>
-                {/* Account submenu (multi) */}
-                <DropdownMenuSub
-                  open={accountSubOpen}
-                  onOpenChange={handleAccountSubOpenChange}
-                >
-                  <DropdownMenuSubTrigger className="gap-2 text-[13px]">
-                    <Wallet size={14} className="text-muted-foreground" />
-                    <span className="flex-1">{t('transactions.account')}</span>
-                    {accountSummary && (
-                      <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
-                        {accountSummary}
-                      </span>
-                    )}
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuPortal>
-                    <DropdownMenuSubContent
-                      sideOffset={8}
-                      className="max-h-[320px] w-[240px] overflow-y-auto p-1"
-                    >
-                      {accounts.length === 0 ? (
-                        <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
-                          {t('transactions.filtersBar.noOptions')}
-                        </div>
-                      ) : (
-                        accounts.map((a) => (
-                          <DropdownMenuCheckboxItem
-                            key={a.id}
-                            checked={filterAccountIds.includes(a.id)}
-                            onSelect={(e) => {
-                              e.preventDefault()
-                              keepAccountSubOpenRef.current = true
-                              onAccountIdsChange(
-                                toggleInArray(filterAccountIds, a.id),
-                              )
-                            }}
-                            className="gap-2 rounded-sm py-1.5 text-[13px]"
-                          >
-                            <span className="min-w-0 flex-1 truncate text-left">
-                              {getAccountName(a)}
-                            </span>
-                            {a.currency && (
-                              <span className="text-[10.5px] uppercase tracking-wide text-muted-foreground/70">
-                                {a.currency}
-                              </span>
-                            )}
-                          </DropdownMenuCheckboxItem>
-                        ))
-                      )}
-                      {filterAccountIds.length > 0 && (
-                        <>
-                          <div className="my-1 h-px bg-border/60" />
-                          <DropdownMenuItem
-                            onSelect={(e) => {
-                              e.preventDefault()
-                              keepAccountSubOpenRef.current = true
-                              onAccountIdsChange([])
-                            }}
-                            className="gap-2 rounded-sm px-2 py-1.5 text-[12px] text-muted-foreground"
-                          >
-                            <X size={12} />
-                            {t('transactions.filtersBar.clearSelection')}
-                          </DropdownMenuItem>
-                        </>
-                      )}
-                    </DropdownMenuSubContent>
-                  </DropdownMenuPortal>
-                </DropdownMenuSub>
-
-                {/* Category submenu (multi) */}
-                <DropdownMenuSub
-                  open={categorySubOpen}
-                  onOpenChange={handleCategorySubOpenChange}
-                >
-                  <DropdownMenuSubTrigger className="gap-2 text-[13px]">
-                    <Tag size={14} className="text-muted-foreground" />
-                    <span className="flex-1">{t('transactions.category')}</span>
-                    {categorySummary && (
-                      <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
-                        {categorySummary}
-                      </span>
-                    )}
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuPortal>
-                    <DropdownMenuSubContent
-                      sideOffset={8}
-                      className="max-h-[320px] w-[240px] overflow-y-auto p-1"
-                    >
-                      <CategoryFilterContent
-                        categoryIds={filterCategoryIds}
-                        onCategoryIdsChange={onCategoryIdsChange}
-                        filterUncategorized={filterUncategorized}
-                        onUncategorizedChange={onUncategorizedChange}
-                        categories={categories}
-                        groups={categoryGroups}
-                        onKeepOpen={() => { keepCategorySubOpenRef.current = true }}
-                      />
-                    </DropdownMenuSubContent>
-                  </DropdownMenuPortal>
-                </DropdownMenuSub>
-
-                {/* Payee submenu (single) */}
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger className="gap-2 text-[13px]">
-                    <Store size={14} className="text-muted-foreground" />
-                    <span className="flex-1">{t('payees.payee')}</span>
-                    {selectedPayee && (
-                      <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
-                        {selectedPayee.name}
-                      </span>
-                    )}
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuPortal>
-                    <DropdownMenuSubContent
-                      sideOffset={8}
-                      className="max-h-[320px] w-[240px] overflow-y-auto p-1"
-                    >
-                      <DropdownMenuItem
-                        onSelect={() => onPayeeChange('')}
-                        className={cn(
-                          'gap-2 rounded-sm px-2 py-1.5 text-[13px]',
-                          !filterPayee && 'bg-primary/5',
-                        )}
-                      >
-                        <span className="size-2.5 shrink-0" />
-                        <span className="min-w-0 flex-1 truncate text-left">
-                          {t('transactions.all')}
-                        </span>
-                        {!filterPayee && <Check size={13} className="text-primary" />}
-                      </DropdownMenuItem>
-                      <div className="my-1 h-px bg-border/60" />
-                      {payees.length === 0 ? (
-                        <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
-                          {t('transactions.filtersBar.noOptions')}
-                        </div>
-                      ) : (
-                        payees.map((p) => (
-                          <DropdownMenuItem
-                            key={p.id}
-                            onSelect={() => onPayeeChange(p.id)}
-                            className={cn(
-                              'gap-2 rounded-sm px-2 py-1.5 text-[13px]',
-                              filterPayee === p.id && 'bg-primary/5',
-                            )}
-                          >
-                            <span className="size-2.5 shrink-0" />
-                            <span className="min-w-0 flex-1 truncate text-left">
-                              {p.name}
-                            </span>
-                            {filterPayee === p.id && (
-                              <Check size={13} className="text-primary" />
-                            )}
-                          </DropdownMenuItem>
-                        ))
-                      )}
-                    </DropdownMenuSubContent>
-                  </DropdownMenuPortal>
-                </DropdownMenuSub>
-
-                {/* Group submenu (single) */}
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger className="gap-2 text-[13px]">
-                    <Users size={14} className="text-muted-foreground" />
-                    <span className="flex-1">{t('splitGroups.group')}</span>
-                    {selectedGroup && (
-                      <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
-                        {selectedGroup.name}
-                      </span>
-                    )}
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuPortal>
-                    <DropdownMenuSubContent
-                      sideOffset={8}
-                      className="max-h-[320px] w-[240px] overflow-y-auto p-1"
-                    >
-                      <DropdownMenuItem
-                        onSelect={() => onGroupIdChange('')}
-                        className={cn(
-                          'gap-2 rounded-sm px-2 py-1.5 text-[13px]',
-                          !filterGroupId && 'bg-primary/5',
-                        )}
-                      >
-                        <span className="size-2.5 shrink-0" />
-                        <span className="min-w-0 flex-1 truncate text-left">
-                          {t('transactions.all')}
-                        </span>
-                        {!filterGroupId && <Check size={13} className="text-primary" />}
-                      </DropdownMenuItem>
-                      <div className="my-1 h-px bg-border/60" />
-                      {groups.length === 0 ? (
-                        <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
-                          {t('transactions.filtersBar.noOptions')}
-                        </div>
-                      ) : (
-                        groups.map((g) => (
-                          <DropdownMenuItem
-                            key={g.id}
-                            onSelect={() => onGroupIdChange(g.id)}
-                            className={cn(
-                              'gap-2 rounded-sm px-2 py-1.5 text-[13px]',
-                              filterGroupId === g.id && 'bg-primary/5',
-                            )}
-                          >
-                            <span className="size-2.5 shrink-0" />
-                            <span className="min-w-0 flex-1 truncate text-left">
-                              {g.name}
-                            </span>
-                            {filterGroupId === g.id && (
-                              <Check size={13} className="text-primary" />
-                            )}
-                          </DropdownMenuItem>
-                        ))
-                      )}
-                    </DropdownMenuSubContent>
-                  </DropdownMenuPortal>
-                </DropdownMenuSub>
-
-                {/* Type submenu (single — income vs expense) */}
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger className="gap-2 text-[13px]">
-                    <ArrowUpDown size={14} className="text-muted-foreground" />
-                    <span className="flex-1">{t('transactions.type')}</span>
-                    {typeLabel && (
-                      <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
-                        {typeLabel}
-                      </span>
-                    )}
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuPortal>
-                    <DropdownMenuSubContent
-                      sideOffset={8}
-                      className="w-[200px] p-1"
-                    >
-                      {[
-                        { value: '', label: t('transactions.all') },
-                        { value: 'credit', label: t('transactions.income') },
-                        { value: 'debit', label: t('transactions.expense') },
-                      ].map((opt) => (
-                        <DropdownMenuItem
-                          key={opt.value || 'all'}
-                          onSelect={() => onTypeChange(opt.value)}
-                          className={cn(
-                            'gap-2 rounded-sm px-2 py-1.5 text-[13px]',
-                            filterType === opt.value && 'bg-primary/5',
-                          )}
-                        >
-                          <span className="size-2.5 shrink-0" />
-                          <span className="min-w-0 flex-1 truncate text-left">
-                            {opt.label}
-                          </span>
-                          {filterType === opt.value && (
-                            <Check size={13} className="text-primary" />
-                          )}
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuSubContent>
-                  </DropdownMenuPortal>
-                </DropdownMenuSub>
-
-                {/* Date range submenu with presets */}
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger className="gap-2 text-[13px]">
-                    <CalendarIcon size={14} className="text-muted-foreground" />
-                    <span className="flex-1">
-                      {t('transactions.filtersBar.date')}
-                    </span>
-                    {dateLabel && (
-                      <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
-                        {dateLabel}
-                      </span>
-                    )}
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuPortal>
-                    <DropdownMenuSubContent
-                      sideOffset={8}
-                      className="w-[220px] p-1"
-                    >
-                      <DropdownMenuItem
-                        onSelect={() => onDateRangeChange('', '')}
-                        className={cn(
-                          'gap-2 rounded-sm px-2 py-1.5 text-[13px]',
-                          !filterFrom && !filterTo && 'bg-primary/5',
-                        )}
-                      >
-                        <span className="size-2.5 shrink-0" />
-                        <span className="min-w-0 flex-1 truncate text-left">
-                          {t('transactions.all')}
-                        </span>
-                        {!filterFrom && !filterTo && (
-                          <Check size={13} className="text-primary" />
-                        )}
-                      </DropdownMenuItem>
-                      <div className="my-1 h-px bg-border/60" />
-                      {datePresets.map((preset) => {
-                        const active =
-                          filterFrom === preset.from && filterTo === preset.to
-                        return (
-                          <DropdownMenuItem
-                            key={preset.key}
-                            onSelect={() =>
-                              onDateRangeChange(preset.from, preset.to)
-                            }
-                            className={cn(
-                              'gap-2 rounded-sm px-2 py-1.5 text-[13px]',
-                              active && 'bg-primary/5',
-                            )}
-                          >
-                            <span className="size-2.5 shrink-0" />
-                            <span className="min-w-0 flex-1 truncate text-left">
-                              {preset.label}
-                            </span>
-                            {active && <Check size={13} className="text-primary" />}
-                          </DropdownMenuItem>
-                        )
-                      })}
-                      <div className="my-1 h-px bg-border/60" />
-                      <DropdownMenuItem
-                        onSelect={openCustomRange}
-                        className="justify-between rounded-sm px-2 py-1.5 text-[13px]"
-                      >
-                        <span>{t('transactions.filtersBar.customRange')}</span>
-                        <ChevronRight
-                          size={13}
-                          className="text-muted-foreground/60"
-                        />
-                      </DropdownMenuItem>
-                    </DropdownMenuSubContent>
-                  </DropdownMenuPortal>
-                </DropdownMenuSub>
-              </DropdownMenuGroup>
-
-              {hasAnyFilter && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onSelect={() => {
-                      onClearAll()
-                      setMenuOpen(false)
-                    }}
-                    className="gap-2 rounded-sm px-2 py-1.5 text-[12.5px] text-muted-foreground"
+              {/* Right-side controls */}
+              <div className="ml-auto flex shrink-0 items-center gap-1 pl-1">
+                {hasAnyFilter && (
+                  <button
+                    type="button"
+                    onClick={onClearAll}
+                    className="hidden h-7 items-center rounded-md px-2 text-[11.5px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground md:inline-flex"
                   >
-                    <X size={13} />
-                    {t('transactions.clearFilters')}
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-        </div>
+                    {t("transactions.clearFilters")}
+                  </button>
+                )}
 
-        {/* Bottom row: active filter chips (only when any are set) */}
-        {(filterAccountIds.length > 0 ||
-          filterCategoryIds.length > 0 ||
-          filterUncategorized ||
-          !!selectedPayee ||
-          !!typeLabel ||
-          !!dateLabel) && (
-          <div className="flex flex-wrap items-center gap-1 border-t border-border/60 px-2 py-1.5">
-            {filterAccountIds.map((id) => {
-              const account = accountById.get(id)
-              if (!account) return null
-              return (
-                <FilterChip
-                  key={`acc-${id}`}
-                  icon={<Wallet size={12} />}
-                  label={t('transactions.account')}
-                  value={getAccountName(account)}
-                  onRemove={() =>
-                    onAccountIdsChange(filterAccountIds.filter((x) => x !== id))
-                  }
-                />
-              )
-            })}
-            {filterCategoryIds.map((id) => {
-              const cat = categoryById.get(id)
-              if (!cat) return null
-              return (
-                <FilterChip
-                  key={`cat-${id}`}
-                  icon={<Tag size={12} />}
-                  label={t('transactions.category')}
-                  value={cat.name}
-                  tint={cat.color ?? undefined}
-                  onRemove={() =>
-                    onCategoryIdsChange(
-                      filterCategoryIds.filter((x) => x !== id),
-                    )
-                  }
-                />
-              )
-            })}
-            {filterUncategorized && (
-              <FilterChip
-                icon={<Tag size={12} />}
-                label={t('transactions.category')}
-                value={t('transactions.uncategorized')}
-                onRemove={() => onUncategorizedChange(false)}
-              />
-            )}
-            {selectedPayee && (
-              <FilterChip
-                icon={<Store size={12} />}
-                label={t('payees.payee')}
-                value={selectedPayee.name}
-                onRemove={() => onPayeeChange('')}
-              />
-            )}
-            {typeLabel && (
-              <FilterChip
-                icon={<ArrowUpDown size={12} />}
-                label={t('transactions.type')}
-                value={typeLabel}
-                onRemove={() => onTypeChange('')}
-              />
-            )}
-            {dateLabel && (
-              <FilterChip
-                icon={<CalendarIcon size={12} />}
-                label={t('transactions.filtersBar.date')}
-                value={dateLabel}
-                onRemove={() => onDateRangeChange('', '')}
-              />
+                <DropdownMenu
+                  open={menuOpen}
+                  onOpenChange={handleMenuOpenChange}
+                >
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={t("transactions.filtersBar.filters")}
+                      className={cn(
+                        "inline-flex h-8 items-center gap-1.5 rounded-md border border-border/80 bg-background px-2.5 text-[12px] font-medium text-muted-foreground transition-colors",
+                        "hover:bg-muted hover:text-foreground",
+                        menuOpen && "bg-muted text-foreground",
+                        hasAnyFilter &&
+                          "border-primary/30 text-primary hover:text-primary",
+                      )}
+                    >
+                      <ListFilter size={13} />
+                      <span className="hidden sm:inline">
+                        {t("transactions.filtersBar.filters")}
+                      </span>
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    align="end"
+                    sideOffset={6}
+                    className="w-[240px] p-1"
+                  >
+                    <DropdownMenuLabel className="px-2 py-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
+                      {t("transactions.filtersBar.filterBy")}
+                    </DropdownMenuLabel>
+                    <DropdownMenuGroup>
+                      {/* Account submenu (multi) */}
+                      <DropdownMenuSub
+                        open={accountSubOpen}
+                        onOpenChange={handleAccountSubOpenChange}
+                      >
+                        <DropdownMenuSubTrigger className="gap-2 text-[13px]">
+                          <Wallet size={14} className="text-muted-foreground" />
+                          <span className="flex-1">
+                            {t("transactions.account")}
+                          </span>
+                          {accountSummary && (
+                            <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
+                              {accountSummary}
+                            </span>
+                          )}
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent
+                            sideOffset={8}
+                            className="max-h-[320px] w-[240px] overflow-y-auto p-1"
+                          >
+                            {accounts.length === 0 ? (
+                              <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
+                                {t("transactions.filtersBar.noOptions")}
+                              </div>
+                            ) : (
+                              accounts.map((a) => (
+                                <DropdownMenuCheckboxItem
+                                  key={a.id}
+                                  checked={filterAccountIds.includes(a.id)}
+                                  onSelect={(e) => {
+                                    e.preventDefault();
+                                    keepAccountSubOpenRef.current = true;
+                                    onAccountIdsChange(
+                                      toggleInArray(filterAccountIds, a.id),
+                                    );
+                                  }}
+                                  className="gap-2 rounded-sm py-1.5 text-[13px]"
+                                >
+                                  <span className="min-w-0 flex-1 truncate text-left">
+                                    {getAccountName(a)}
+                                  </span>
+                                  {a.currency && (
+                                    <span className="text-[10.5px] uppercase tracking-wide text-muted-foreground/70">
+                                      {a.currency}
+                                    </span>
+                                  )}
+                                </DropdownMenuCheckboxItem>
+                              ))
+                            )}
+                            {filterAccountIds.length > 0 && (
+                              <>
+                                <div className="my-1 h-px bg-border/60" />
+                                <DropdownMenuItem
+                                  onSelect={(e) => {
+                                    e.preventDefault();
+                                    keepAccountSubOpenRef.current = true;
+                                    onAccountIdsChange([]);
+                                  }}
+                                  className="gap-2 rounded-sm px-2 py-1.5 text-[12px] text-muted-foreground"
+                                >
+                                  <X size={12} />
+                                  {t("transactions.filtersBar.clearSelection")}
+                                </DropdownMenuItem>
+                              </>
+                            )}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+
+                      {/* Category submenu (multi) */}
+                      <DropdownMenuSub
+                        open={categorySubOpen}
+                        onOpenChange={handleCategorySubOpenChange}
+                      >
+                        <DropdownMenuSubTrigger className="gap-2 text-[13px]">
+                          <Tag size={14} className="text-muted-foreground" />
+                          <span className="flex-1">
+                            {t("transactions.category")}
+                          </span>
+                          {categorySummary && (
+                            <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
+                              {categorySummary}
+                            </span>
+                          )}
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent
+                            sideOffset={8}
+                            className="max-h-[320px] w-[240px] overflow-y-auto p-1"
+                          >
+                            <CategoryFilterContent
+                              categoryIds={filterCategoryIds}
+                              onCategoryIdsChange={onCategoryIdsChange}
+                              filterUncategorized={filterUncategorized}
+                              onUncategorizedChange={onUncategorizedChange}
+                              categories={categories}
+                              groups={categoryGroups}
+                              onKeepOpen={() => {
+                                keepCategorySubOpenRef.current = true;
+                              }}
+                            />
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+
+                      {/* Payee submenu (single) */}
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger className="gap-2 text-[13px]">
+                          <Store size={14} className="text-muted-foreground" />
+                          <span className="flex-1">{t("payees.payee")}</span>
+                          {selectedPayee && (
+                            <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
+                              {selectedPayee.name}
+                            </span>
+                          )}
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent
+                            sideOffset={8}
+                            className="max-h-[320px] w-[240px] overflow-y-auto p-1"
+                          >
+                            <DropdownMenuItem
+                              onSelect={() => onPayeeChange("")}
+                              className={cn(
+                                "gap-2 rounded-sm px-2 py-1.5 text-[13px]",
+                                !filterPayee && "bg-primary/5",
+                              )}
+                            >
+                              <span className="size-2.5 shrink-0" />
+                              <span className="min-w-0 flex-1 truncate text-left">
+                                {t("transactions.all")}
+                              </span>
+                              {!filterPayee && (
+                                <Check size={13} className="text-primary" />
+                              )}
+                            </DropdownMenuItem>
+                            <div className="my-1 h-px bg-border/60" />
+                            {payees.length === 0 ? (
+                              <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
+                                {t("transactions.filtersBar.noOptions")}
+                              </div>
+                            ) : (
+                              payees.map((p) => (
+                                <DropdownMenuItem
+                                  key={p.id}
+                                  onSelect={() => onPayeeChange(p.id)}
+                                  className={cn(
+                                    "gap-2 rounded-sm px-2 py-1.5 text-[13px]",
+                                    filterPayee === p.id && "bg-primary/5",
+                                  )}
+                                >
+                                  <span className="size-2.5 shrink-0" />
+                                  <span className="min-w-0 flex-1 truncate text-left">
+                                    {p.name}
+                                  </span>
+                                  {filterPayee === p.id && (
+                                    <Check size={13} className="text-primary" />
+                                  )}
+                                </DropdownMenuItem>
+                              ))
+                            )}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+
+                      {/* Group submenu (single) */}
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger className="gap-2 text-[13px]">
+                          <Users size={14} className="text-muted-foreground" />
+                          <span className="flex-1">
+                            {t("splitGroups.group")}
+                          </span>
+                          {selectedGroup && (
+                            <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
+                              {selectedGroup.name}
+                            </span>
+                          )}
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent
+                            sideOffset={8}
+                            className="max-h-[320px] w-[240px] overflow-y-auto p-1"
+                          >
+                            <DropdownMenuItem
+                              onSelect={() => onGroupIdChange("")}
+                              className={cn(
+                                "gap-2 rounded-sm px-2 py-1.5 text-[13px]",
+                                !filterGroupId && "bg-primary/5",
+                              )}
+                            >
+                              <span className="size-2.5 shrink-0" />
+                              <span className="min-w-0 flex-1 truncate text-left">
+                                {t("transactions.all")}
+                              </span>
+                              {!filterGroupId && (
+                                <Check size={13} className="text-primary" />
+                              )}
+                            </DropdownMenuItem>
+                            <div className="my-1 h-px bg-border/60" />
+                            {groups.length === 0 ? (
+                              <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
+                                {t("transactions.filtersBar.noOptions")}
+                              </div>
+                            ) : (
+                              groups.map((g) => (
+                                <DropdownMenuItem
+                                  key={g.id}
+                                  onSelect={() => onGroupIdChange(g.id)}
+                                  className={cn(
+                                    "gap-2 rounded-sm px-2 py-1.5 text-[13px]",
+                                    filterGroupId === g.id && "bg-primary/5",
+                                  )}
+                                >
+                                  <span className="size-2.5 shrink-0" />
+                                  <span className="min-w-0 flex-1 truncate text-left">
+                                    {g.name}
+                                  </span>
+                                  {filterGroupId === g.id && (
+                                    <Check size={13} className="text-primary" />
+                                  )}
+                                </DropdownMenuItem>
+                              ))
+                            )}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+
+                      {/* Type submenu (single — income vs expense) */}
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger className="gap-2 text-[13px]">
+                          <ArrowUpDown
+                            size={14}
+                            className="text-muted-foreground"
+                          />
+                          <span className="flex-1">
+                            {t("transactions.type")}
+                          </span>
+                          {typeLabel && (
+                            <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
+                              {typeLabel}
+                            </span>
+                          )}
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent
+                            sideOffset={8}
+                            className="w-[200px] p-1"
+                          >
+                            {[
+                              { value: "", label: t("transactions.all") },
+                              {
+                                value: "credit",
+                                label: t("transactions.income"),
+                              },
+                              {
+                                value: "debit",
+                                label: t("transactions.expense"),
+                              },
+                            ].map((opt) => (
+                              <DropdownMenuItem
+                                key={opt.value || "all"}
+                                onSelect={() => onTypeChange(opt.value)}
+                                className={cn(
+                                  "gap-2 rounded-sm px-2 py-1.5 text-[13px]",
+                                  filterType === opt.value && "bg-primary/5",
+                                )}
+                              >
+                                <span className="size-2.5 shrink-0" />
+                                <span className="min-w-0 flex-1 truncate text-left">
+                                  {opt.label}
+                                </span>
+                                {filterType === opt.value && (
+                                  <Check size={13} className="text-primary" />
+                                )}
+                              </DropdownMenuItem>
+                            ))}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+
+                      {/* Ignored filter submenu */}
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger className="gap-2 text-[13px]">
+                          <EyeOff size={14} className="text-muted-foreground" />
+                          <span className="flex-1">Ignoradas</span>
+                          {ignoredFilter !== "include" && (
+                            <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
+                              {ignoredFilter === "only"
+                                ? "Só ignoradas"
+                                : "Ocultas"}
+                            </span>
+                          )}
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent
+                            sideOffset={8}
+                            className="w-[200px] p-1"
+                          >
+                            {(["hide", "include", "only"] as const).map(
+                              (val) => {
+                                const label =
+                                  val === "hide"
+                                    ? "Ocultar ignoradas"
+                                    : val === "include"
+                                      ? "Mostrar todas"
+                                      : "Só ignoradas";
+                                return (
+                                  <DropdownMenuItem
+                                    key={val}
+                                    onSelect={() => onIgnoredFilterChange(val)}
+                                    className={cn(
+                                      "gap-2 rounded-sm px-2 py-1.5 text-[13px]",
+                                      ignoredFilter === val && "bg-primary/5",
+                                    )}
+                                  >
+                                    <span className="size-2.5 shrink-0" />
+                                    <span className="min-w-0 flex-1 truncate text-left">
+                                      {label}
+                                    </span>
+                                    {ignoredFilter === val && (
+                                      <Check
+                                        size={13}
+                                        className="text-primary"
+                                      />
+                                    )}
+                                  </DropdownMenuItem>
+                                );
+                              },
+                            )}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+
+                      {/* Date range submenu with presets */}
+                      <DropdownMenuSub>
+                        <DropdownMenuSubTrigger className="gap-2 text-[13px]">
+                          <CalendarIcon
+                            size={14}
+                            className="text-muted-foreground"
+                          />
+                          <span className="flex-1">
+                            {t("transactions.filtersBar.date")}
+                          </span>
+                          {dateLabel && (
+                            <span className="max-w-[90px] truncate text-[11px] text-muted-foreground">
+                              {dateLabel}
+                            </span>
+                          )}
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent
+                            sideOffset={8}
+                            className="w-[220px] p-1"
+                          >
+                            <DropdownMenuItem
+                              onSelect={() => onDateRangeChange("", "")}
+                              className={cn(
+                                "gap-2 rounded-sm px-2 py-1.5 text-[13px]",
+                                !filterFrom && !filterTo && "bg-primary/5",
+                              )}
+                            >
+                              <span className="size-2.5 shrink-0" />
+                              <span className="min-w-0 flex-1 truncate text-left">
+                                {t("transactions.all")}
+                              </span>
+                              {!filterFrom && !filterTo && (
+                                <Check size={13} className="text-primary" />
+                              )}
+                            </DropdownMenuItem>
+                            <div className="my-1 h-px bg-border/60" />
+                            {datePresets.map((preset) => {
+                              const active =
+                                filterFrom === preset.from &&
+                                filterTo === preset.to;
+                              return (
+                                <DropdownMenuItem
+                                  key={preset.key}
+                                  onSelect={() =>
+                                    onDateRangeChange(preset.from, preset.to)
+                                  }
+                                  className={cn(
+                                    "gap-2 rounded-sm px-2 py-1.5 text-[13px]",
+                                    active && "bg-primary/5",
+                                  )}
+                                >
+                                  <span className="size-2.5 shrink-0" />
+                                  <span className="min-w-0 flex-1 truncate text-left">
+                                    {preset.label}
+                                  </span>
+                                  {active && (
+                                    <Check size={13} className="text-primary" />
+                                  )}
+                                </DropdownMenuItem>
+                              );
+                            })}
+                            <div className="my-1 h-px bg-border/60" />
+                            <DropdownMenuItem
+                              onSelect={openCustomRange}
+                              className="justify-between rounded-sm px-2 py-1.5 text-[13px]"
+                            >
+                              <span>
+                                {t("transactions.filtersBar.customRange")}
+                              </span>
+                              <ChevronRight
+                                size={13}
+                                className="text-muted-foreground/60"
+                              />
+                            </DropdownMenuItem>
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+                    </DropdownMenuGroup>
+
+                    {hasAnyFilter && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onSelect={() => {
+                            onClearAll();
+                            setMenuOpen(false);
+                          }}
+                          className="gap-2 rounded-sm px-2 py-1.5 text-[12.5px] text-muted-foreground"
+                        >
+                          <X size={13} />
+                          {t("transactions.clearFilters")}
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+
+            {/* Bottom row: active filter chips (only when any are set) */}
+            {(filterAccountIds.length > 0 ||
+              filterCategoryIds.length > 0 ||
+              filterUncategorized ||
+              !!selectedPayee ||
+              !!typeLabel ||
+              !!dateLabel ||
+              ignoredFilter !== "include") && (
+              <div className="flex flex-wrap items-center gap-1 border-t border-border/60 px-2 py-1.5">
+                {filterAccountIds.map((id) => {
+                  const account = accountById.get(id);
+                  if (!account) return null;
+                  return (
+                    <FilterChip
+                      key={`acc-${id}`}
+                      icon={<Wallet size={12} />}
+                      label={t("transactions.account")}
+                      value={getAccountName(account)}
+                      onRemove={() =>
+                        onAccountIdsChange(
+                          filterAccountIds.filter((x) => x !== id),
+                        )
+                      }
+                    />
+                  );
+                })}
+                {filterCategoryIds.map((id) => {
+                  const cat = categoryById.get(id);
+                  if (!cat) return null;
+                  return (
+                    <FilterChip
+                      key={`cat-${id}`}
+                      icon={<Tag size={12} />}
+                      label={t("transactions.category")}
+                      value={cat.name}
+                      tint={cat.color ?? undefined}
+                      onRemove={() =>
+                        onCategoryIdsChange(
+                          filterCategoryIds.filter((x) => x !== id),
+                        )
+                      }
+                    />
+                  );
+                })}
+                {filterUncategorized && (
+                  <FilterChip
+                    icon={<Tag size={12} />}
+                    label={t("transactions.category")}
+                    value={t("transactions.uncategorized")}
+                    onRemove={() => onUncategorizedChange(false)}
+                  />
+                )}
+                {selectedPayee && (
+                  <FilterChip
+                    icon={<Store size={12} />}
+                    label={t("payees.payee")}
+                    value={selectedPayee.name}
+                    onRemove={() => onPayeeChange("")}
+                  />
+                )}
+                {typeLabel && (
+                  <FilterChip
+                    icon={<ArrowUpDown size={12} />}
+                    label={t("transactions.type")}
+                    value={typeLabel}
+                    onRemove={() => onTypeChange("")}
+                  />
+                )}
+                {dateLabel && (
+                  <FilterChip
+                    icon={<CalendarIcon size={12} />}
+                    label={t("transactions.filtersBar.date")}
+                    value={dateLabel}
+                    onRemove={() => onDateRangeChange("", "")}
+                  />
+                )}
+                {ignoredFilter !== "include" && (
+                  <FilterChip
+                    icon={<EyeOff size={12} />}
+                    label="Ignoradas"
+                    value={
+                      ignoredFilter === "only" ? "Só ignoradas" : "Ocultas"
+                    }
+                    onRemove={() => onIgnoredFilterChange("include")}
+                  />
+                )}
+              </div>
             )}
           </div>
-        )}
-      </div>
-
-      </PopoverAnchor>
+        </PopoverAnchor>
         {/* Custom range popover — anchored to the filter bar above */}
         <PopoverContent
           align="end"
@@ -761,43 +877,45 @@ export function TransactionsFilterBar({
         >
           <div className="border-b border-border/70 px-4 py-3">
             <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              {t('transactions.filtersBar.customRange')}
+              {t("transactions.filtersBar.customRange")}
             </p>
             <p className="mt-0.5 text-[11px] text-muted-foreground/70">
               {draftFrom || draftTo
                 ? formatRange(draftFrom, draftTo, locale)
-                : t('transactions.filtersBar.pickRange')}
+                : t("transactions.filtersBar.pickRange")}
             </p>
           </div>
           <div className="flex flex-col gap-4 p-3 sm:flex-row sm:gap-0">
             <div className="sm:border-r sm:border-border/60 sm:pr-2">
               <p className="px-2 pb-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/80">
-                {t('transactions.filtersBar.fromLabel')}
+                {t("transactions.filtersBar.fromLabel")}
               </p>
               <Calendar
-                selected={draftFrom ? new Date(draftFrom + 'T00:00:00') : undefined}
+                selected={
+                  draftFrom ? new Date(draftFrom + "T00:00:00") : undefined
+                }
                 defaultMonth={
-                  draftFrom ? new Date(draftFrom + 'T00:00:00') : new Date()
+                  draftFrom ? new Date(draftFrom + "T00:00:00") : new Date()
                 }
                 locale={dateFnsLocale}
-                onSelect={(d) => setDraftFrom(d ? toISODate(d) : '')}
+                onSelect={(d) => setDraftFrom(d ? toISODate(d) : "")}
               />
             </div>
             <div className="sm:pl-2">
               <p className="px-2 pb-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/80">
-                {t('transactions.filtersBar.toLabel')}
+                {t("transactions.filtersBar.toLabel")}
               </p>
               <Calendar
-                selected={draftTo ? new Date(draftTo + 'T00:00:00') : undefined}
+                selected={draftTo ? new Date(draftTo + "T00:00:00") : undefined}
                 defaultMonth={
                   draftTo
-                    ? new Date(draftTo + 'T00:00:00')
+                    ? new Date(draftTo + "T00:00:00")
                     : draftFrom
-                      ? new Date(draftFrom + 'T00:00:00')
+                      ? new Date(draftFrom + "T00:00:00")
                       : new Date()
                 }
                 locale={dateFnsLocale}
-                onSelect={(d) => setDraftTo(d ? toISODate(d) : '')}
+                onSelect={(d) => setDraftTo(d ? toISODate(d) : "")}
               />
             </div>
           </div>
@@ -805,12 +923,12 @@ export function TransactionsFilterBar({
             <button
               type="button"
               onClick={() => {
-                setDraftFrom('')
-                setDraftTo('')
+                setDraftFrom("");
+                setDraftTo("");
               }}
               className="text-[12px] font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
-              {t('transactions.filtersBar.reset')}
+              {t("transactions.filtersBar.reset")}
             </button>
             <div className="flex items-center gap-2">
               <Button
@@ -819,7 +937,7 @@ export function TransactionsFilterBar({
                 size="sm"
                 onClick={() => setDateCustomOpen(false)}
               >
-                {t('transactions.filtersBar.cancel')}
+                {t("transactions.filtersBar.cancel")}
               </Button>
               <Button
                 type="button"
@@ -827,44 +945,44 @@ export function TransactionsFilterBar({
                 disabled={!draftFrom && !draftTo}
                 onClick={() => {
                   // Normalize: if user only picked one of the two, mirror it.
-                  const from = draftFrom || draftTo
-                  const to = draftTo || draftFrom
+                  const from = draftFrom || draftTo;
+                  const to = draftTo || draftFrom;
                   if (from && to && from > to) {
-                    onDateRangeChange(to, from)
+                    onDateRangeChange(to, from);
                   } else {
-                    onDateRangeChange(from, to)
+                    onDateRangeChange(from, to);
                   }
-                  setDateCustomOpen(false)
+                  setDateCustomOpen(false);
                 }}
               >
-                {t('transactions.filtersBar.apply')}
+                {t("transactions.filtersBar.apply")}
               </Button>
             </div>
           </div>
         </PopoverContent>
       </Popover>
     </div>
-  )
+  );
 }
 
 function formatRange(from: string, to: string, locale: string): string {
   const fmt = (iso: string) =>
-    new Date(iso + 'T00:00:00').toLocaleDateString(locale, {
-      day: '2-digit',
-      month: 'short',
-      year: 'numeric',
-    })
-  if (from && to) return `${fmt(from)} — ${fmt(to)}`
-  if (from) return `≥ ${fmt(from)}`
-  return `≤ ${fmt(to)}`
+    new Date(iso + "T00:00:00").toLocaleDateString(locale, {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+  if (from && to) return `${fmt(from)} — ${fmt(to)}`;
+  if (from) return `≥ ${fmt(from)}`;
+  return `≤ ${fmt(to)}`;
 }
 
 interface FilterChipProps {
-  icon: React.ReactNode
-  label: string
-  value: string
-  tint?: string
-  onRemove: () => void
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  tint?: string;
+  onRemove: () => void;
 }
 
 function FilterChip({ icon, label, value, tint, onRemove }: FilterChipProps) {
@@ -873,7 +991,11 @@ function FilterChip({ icon, label, value, tint, onRemove }: FilterChipProps) {
       type="button"
       onClick={onRemove}
       className="group inline-flex h-7 shrink-0 items-center gap-1.5 rounded-full border border-border/80 bg-muted/50 pl-2 pr-1.5 text-[11.5px] text-foreground transition-colors hover:border-destructive/40 hover:bg-destructive/5"
-      style={tint ? { borderColor: `${tint}55`, backgroundColor: `${tint}12` } : undefined}
+      style={
+        tint
+          ? { borderColor: `${tint}55`, backgroundColor: `${tint}12` }
+          : undefined
+      }
     >
       <span
         className="flex items-center text-muted-foreground group-hover:text-destructive"
@@ -889,7 +1011,7 @@ function FilterChip({ icon, label, value, tint, onRemove }: FilterChipProps) {
         <X size={11} />
       </span>
     </button>
-  )
+  );
 }
 
 // Search input with inline `#tag` chips. Free text is a normal input;
@@ -902,55 +1024,60 @@ function SearchWithTagChips({
   onChange,
   onSubmit,
 }: {
-  inputRef: React.RefObject<HTMLInputElement | null>
-  value: string
-  placeholder?: string
-  onChange: (value: string) => void
-  onSubmit?: (value: string) => void
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  value: string;
+  placeholder?: string;
+  onChange: (value: string) => void;
+  onSubmit?: (value: string) => void;
 }) {
   // Split into leading `#tag` chips (terminated by whitespace) + free text.
   // We only treat a `#tag` as a chip when it has a trailing whitespace —
   // otherwise the user is still typing it.
   const [chips, freeText] = (() => {
-    const parts: string[] = []
-    let rest = value
+    const parts: string[] = [];
+    let rest = value;
     while (true) {
-      const m = rest.match(/^(#\S+)\s+/)
-      if (!m) break
-      parts.push(m[1])
-      rest = rest.slice(m[0].length)
+      const m = rest.match(/^(#\S+)\s+/);
+      if (!m) break;
+      parts.push(m[1]);
+      rest = rest.slice(m[0].length);
     }
-    return [parts, rest] as const
-  })()
+    return [parts, rest] as const;
+  })();
 
   const rebuild = (nextChips: string[], nextFreeText: string): string => {
-    const head = nextChips.length ? nextChips.join(' ') + ' ' : ''
-    return head + nextFreeText
-  }
+    const head = nextChips.length ? nextChips.join(" ") + " " : "";
+    return head + nextFreeText;
+  };
 
   const removeChipAt = (index: number) => {
-    const next = [...chips]
-    next.splice(index, 1)
-    onChange(rebuild(next, freeText))
-    inputRef.current?.focus()
-  }
+    const next = [...chips];
+    next.splice(index, 1);
+    onChange(rebuild(next, freeText));
+    inputRef.current?.focus();
+  };
 
-  const commitTrailingTagInFreeText = (text: string): { newChips: string[]; rest: string } | null => {
+  const commitTrailingTagInFreeText = (
+    text: string,
+  ): { newChips: string[]; rest: string } | null => {
     // Match a `#tag` that ends the string (just typed before comma/space/Enter).
-    const m = text.match(/^(.*?)(\s|^)(#\S+)$/)
-    if (!m) return null
-    const before = (m[1] + m[2]).trimEnd()
-    const tag = m[3]
-    const newChips = [...chips, tag]
-    return { newChips, rest: before }
-  }
+    const m = text.match(/^(.*?)(\s|^)(#\S+)$/);
+    if (!m) return null;
+    const before = (m[1] + m[2]).trimEnd();
+    const tag = m[3];
+    const newChips = [...chips, tag];
+    return { newChips, rest: before };
+  };
 
   return (
     <div
       className="relative flex min-w-0 flex-1 flex-wrap items-center gap-1 px-2.5 py-1 min-h-9 cursor-text"
       onClick={() => inputRef.current?.focus()}
     >
-      <Search size={15} className="pointer-events-none shrink-0 text-muted-foreground/70" />
+      <Search
+        size={15}
+        className="pointer-events-none shrink-0 text-muted-foreground/70"
+      />
       {chips.map((tag, i) => (
         <span
           key={`${tag}-${i}`}
@@ -961,8 +1088,8 @@ function SearchWithTagChips({
             type="button"
             tabIndex={-1}
             onClick={(e) => {
-              e.stopPropagation()
-              removeChipAt(i)
+              e.stopPropagation();
+              removeChipAt(i);
             }}
             className="text-primary/60 hover:text-primary"
           >
@@ -976,47 +1103,51 @@ function SearchWithTagChips({
         placeholder={chips.length === 0 ? placeholder : undefined}
         value={freeText}
         onChange={(e) => {
-          const next = e.target.value
+          const next = e.target.value;
           // Comma right after a `#tag` token commits it. Other commas stay
           // as literal characters in the free-text search.
-          if (next.endsWith(',')) {
-            const beforeComma = next.slice(0, -1)
-            const result = commitTrailingTagInFreeText(beforeComma)
+          if (next.endsWith(",")) {
+            const beforeComma = next.slice(0, -1);
+            const result = commitTrailingTagInFreeText(beforeComma);
             if (result) {
-              const submitValue = rebuild(result.newChips, result.rest)
-              if (onSubmit) onSubmit(submitValue)
-              else onChange(submitValue)
-              return
+              const submitValue = rebuild(result.newChips, result.rest);
+              if (onSubmit) onSubmit(submitValue);
+              else onChange(submitValue);
+              return;
             }
           }
-          onChange(rebuild(chips, next))
+          onChange(rebuild(chips, next));
         }}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' && onSubmit) {
-            e.preventDefault()
+          if (e.key === "Enter" && onSubmit) {
+            e.preventDefault();
             // Promote a still-being-typed `#tag` at the end to a chip too.
-            const result = commitTrailingTagInFreeText(freeText)
+            const result = commitTrailingTagInFreeText(freeText);
             const submitValue = result
               ? rebuild(result.newChips, result.rest)
-              : rebuild(chips, freeText)
-            onSubmit(submitValue)
-          } else if (e.key === 'Backspace' && freeText === '' && chips.length > 0) {
-            e.preventDefault()
-            removeChipAt(chips.length - 1)
-          } else if (e.key === ' ') {
+              : rebuild(chips, freeText);
+            onSubmit(submitValue);
+          } else if (
+            e.key === "Backspace" &&
+            freeText === "" &&
+            chips.length > 0
+          ) {
+            e.preventDefault();
+            removeChipAt(chips.length - 1);
+          } else if (e.key === " ") {
             // Space after a `#tag` commits it; space inside free text is
             // a normal whitespace.
-            const result = commitTrailingTagInFreeText(freeText)
+            const result = commitTrailingTagInFreeText(freeText);
             if (result) {
-              e.preventDefault()
-              const submitValue = rebuild(result.newChips, result.rest)
-              if (onSubmit) onSubmit(submitValue)
-              else onChange(submitValue)
+              e.preventDefault();
+              const submitValue = rebuild(result.newChips, result.rest);
+              if (onSubmit) onSubmit(submitValue);
+              else onChange(submitValue);
             }
           }
         }}
         className="min-w-[80px] flex-1 border-0 bg-transparent text-[13.5px] outline-none placeholder:text-muted-foreground"
       />
     </div>
-  )
+  );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios from "axios";
 import type {
   User,
   AdminUser,
@@ -41,354 +41,491 @@ import type {
   GroupSettlement,
   GroupBalances,
   TransactionSplitsInput,
-} from '@/types'
+} from "@/types";
 
 const api = axios.create({
-  baseURL: '/api',
-})
+  baseURL: "/api",
+});
 
 // Add auth token to requests
 api.interceptors.request.use((config) => {
-  const token = localStorage.getItem('token')
+  const token = localStorage.getItem("token");
   if (token) {
-    config.headers.Authorization = `Bearer ${token}`
+    config.headers.Authorization = `Bearer ${token}`;
   }
-  return config
-})
+  return config;
+});
 
 // Handle auth errors
 api.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      localStorage.removeItem('token')
-      window.location.href = '/login'
+      localStorage.removeItem("token");
+      window.location.href = "/login";
     }
-    return Promise.reject(error)
-  }
-)
+    return Promise.reject(error);
+  },
+);
 
 // Setup
 export const setup = {
   status: async (): Promise<{ has_users: boolean }> => {
-    const { data } = await api.get('/setup/status')
-    return data
+    const { data } = await api.get("/setup/status");
+    return data;
   },
-  createAdmin: async (email: string, password: string, currency = 'USD', name = '', language = 'en'): Promise<{ access_token: string }> => {
-    const { data } = await api.post('/setup/create-admin', { email, password, currency, name, language })
-    return data
+  createAdmin: async (
+    email: string,
+    password: string,
+    currency = "USD",
+    name = "",
+    language = "en",
+  ): Promise<{ access_token: string }> => {
+    const { data } = await api.post("/setup/create-admin", {
+      email,
+      password,
+      currency,
+      name,
+      language,
+    });
+    return data;
   },
-}
+};
 
 // Auth
 export const auth = {
   login: async (email: string, password: string) => {
-    const formData = new URLSearchParams()
-    formData.append('username', email)
-    formData.append('password', password)
-    const { data } = await api.post('/auth/login', formData, {
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    })
-    return data
+    const formData = new URLSearchParams();
+    formData.append("username", email);
+    formData.append("password", password);
+    const { data } = await api.post("/auth/login", formData, {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+    return data;
   },
-  register: async (email: string, password: string, preferences?: Record<string, string>) => {
-    const { data } = await api.post('/auth/register', { email, password, preferences })
-    return data
+  register: async (
+    email: string,
+    password: string,
+    preferences?: Record<string, string>,
+  ) => {
+    const { data } = await api.post("/auth/register", {
+      email,
+      password,
+      preferences,
+    });
+    return data;
   },
   me: async (): Promise<User> => {
-    const { data } = await api.get('/users/me')
-    return data
+    const { data } = await api.get("/users/me");
+    return data;
   },
   updateMe: async (updates: Partial<User>): Promise<User> => {
-    const { data } = await api.patch('/users/me', updates)
-    return data
+    const { data } = await api.patch("/users/me", updates);
+    return data;
   },
   changePassword: async (password: string): Promise<User> => {
-    const { data } = await api.patch('/users/me', { password })
-    return data
+    const { data } = await api.patch("/users/me", { password });
+    return data;
   },
   setup2fa: async (): Promise<{ secret: string; otpauth_uri: string }> => {
-    const { data } = await api.post('/auth/2fa/setup')
-    return data
+    const { data } = await api.post("/auth/2fa/setup");
+    return data;
   },
   enable2fa: async (code: string): Promise<void> => {
-    await api.post('/auth/2fa/enable', { code })
+    await api.post("/auth/2fa/enable", { code });
   },
   disable2fa: async (password: string, code: string): Promise<void> => {
-    await api.post('/auth/2fa/disable', { password, code })
+    await api.post("/auth/2fa/disable", { password, code });
   },
-  verify2fa: async (tempToken: string, code: string): Promise<{ access_token: string; token_type: string }> => {
-    const { data } = await api.post('/auth/2fa/verify', { temp_token: tempToken, code })
-    return data
+  verify2fa: async (
+    tempToken: string,
+    code: string,
+  ): Promise<{ access_token: string; token_type: string }> => {
+    const { data } = await api.post("/auth/2fa/verify", {
+      temp_token: tempToken,
+      code,
+    });
+    return data;
   },
-}
+};
 
 // Categories
 export const categories = {
   list: async (): Promise<Category[]> => {
-    const { data } = await api.get('/categories')
-    return data
+    const { data } = await api.get("/categories");
+    return data;
   },
   create: async (category: Partial<Category>): Promise<Category> => {
-    const { data } = await api.post('/categories', category)
-    return data
+    const { data } = await api.post("/categories", category);
+    return data;
   },
-  update: async (id: string, category: Partial<Category>): Promise<Category> => {
-    const { data } = await api.patch(`/categories/${id}`, category)
-    return data
+  update: async (
+    id: string,
+    category: Partial<Category>,
+  ): Promise<Category> => {
+    const { data } = await api.patch(`/categories/${id}`, category);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/categories/${id}`)
+    await api.delete(`/categories/${id}`);
   },
-}
+};
 
 // Category Groups
 export const categoryGroups = {
   list: async (): Promise<CategoryGroup[]> => {
-    const { data } = await api.get('/category-groups')
-    return data
+    const { data } = await api.get("/category-groups");
+    return data;
   },
   create: async (group: Partial<CategoryGroup>): Promise<CategoryGroup> => {
-    const { data } = await api.post('/category-groups', group)
-    return data
+    const { data } = await api.post("/category-groups", group);
+    return data;
   },
-  update: async (id: string, group: Partial<CategoryGroup>): Promise<CategoryGroup> => {
-    const { data } = await api.patch(`/category-groups/${id}`, group)
-    return data
+  update: async (
+    id: string,
+    group: Partial<CategoryGroup>,
+  ): Promise<CategoryGroup> => {
+    const { data } = await api.patch(`/category-groups/${id}`, group);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/category-groups/${id}`)
+    await api.delete(`/category-groups/${id}`);
   },
-}
+};
 
 // Bank Connections
 export const connections = {
   list: async (): Promise<BankConnection[]> => {
-    const { data } = await api.get('/connections')
-    return data
+    const { data } = await api.get("/connections");
+    return data;
   },
-  getProviders: async (): Promise<{ name: string; display_name: string; description: string; flow_type: string; configured: boolean }[]> => {
-    const { data } = await api.get('/connections/providers')
-    return data.providers
+  getProviders: async (): Promise<
+    {
+      name: string;
+      display_name: string;
+      description: string;
+      flow_type: string;
+      configured: boolean;
+    }[]
+  > => {
+    const { data } = await api.get("/connections/providers");
+    return data.providers;
   },
-  getConnectToken: async (provider = 'pluggy'): Promise<string> => {
-    const { data } = await api.post('/connections/connect-token', { provider })
-    return data.access_token
+  getConnectToken: async (provider = "pluggy"): Promise<string> => {
+    const { data } = await api.post("/connections/connect-token", { provider });
+    return data.access_token;
   },
   getOAuthUrl: async (provider: string): Promise<string> => {
-    const { data } = await api.post('/connections/oauth/url', { provider })
-    return data.url
+    const { data } = await api.post("/connections/oauth/url", { provider });
+    return data.url;
   },
-  handleCallback: async (code: string, provider: string): Promise<BankConnection> => {
-    const { data } = await api.post('/connections/oauth/callback', { code, provider })
-    return data
+  handleCallback: async (
+    code: string,
+    provider: string,
+  ): Promise<BankConnection> => {
+    const { data } = await api.post("/connections/oauth/callback", {
+      code,
+      provider,
+    });
+    return data;
   },
   sync: async (id: string): Promise<BankConnection> => {
-    const { data } = await api.post(`/connections/${id}/sync`)
-    return data
+    const { data } = await api.post(`/connections/${id}/sync`);
+    return data;
   },
   getReconnectToken: async (connectionId: string): Promise<string> => {
-    const { data } = await api.post(`/connections/${connectionId}/reconnect-token`)
-    return data.access_token
+    const { data } = await api.post(
+      `/connections/${connectionId}/reconnect-token`,
+    );
+    return data.access_token;
   },
-  updateSettings: async (id: string, settings: Partial<ConnectionSettings>): Promise<BankConnection> => {
-    const { data } = await api.patch(`/connections/${id}/settings`, settings)
-    return data
+  updateSettings: async (
+    id: string,
+    settings: Partial<ConnectionSettings>,
+  ): Promise<BankConnection> => {
+    const { data } = await api.patch(`/connections/${id}/settings`, settings);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/connections/${id}`)
+    await api.delete(`/connections/${id}`);
   },
-}
+};
 
 // Accounts
 export const accounts = {
   list: async (includeClosed = false): Promise<Account[]> => {
-    const { data } = await api.get('/accounts', { params: { include_closed: includeClosed } })
-    return data
+    const { data } = await api.get("/accounts", {
+      params: { include_closed: includeClosed },
+    });
+    return data;
   },
   get: async (id: string): Promise<Account> => {
-    const { data } = await api.get(`/accounts/${id}`)
-    return data
+    const { data } = await api.get(`/accounts/${id}`);
+    return data;
   },
   create: async (account: {
-    name: string
-    type: string
-    balance?: number
-    balance_date?: string
-    currency?: string
-    credit_limit?: number | null
-    statement_close_day?: number | null
-    payment_due_day?: number | null
+    name: string;
+    type: string;
+    balance?: number;
+    balance_date?: string;
+    currency?: string;
+    credit_limit?: number | null;
+    statement_close_day?: number | null;
+    payment_due_day?: number | null;
   }): Promise<Account> => {
-    const { data } = await api.post('/accounts', account)
-    return data
+    const { data } = await api.post("/accounts", account);
+    return data;
   },
   update: async (id: string, account: Partial<Account>): Promise<Account> => {
-    const { data } = await api.patch(`/accounts/${id}`, account)
-    return data
+    const { data } = await api.patch(`/accounts/${id}`, account);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/accounts/${id}`)
+    await api.delete(`/accounts/${id}`);
   },
-  summary: async (id: string, from?: string, to?: string, billId?: string, unbilledOnly?: boolean): Promise<AccountSummary> => {
-    const { data } = await api.get(`/accounts/${id}/summary`, { params: { from, to, bill_id: billId, unbilled_only: unbilledOnly || undefined } })
-    return data
+  summary: async (
+    id: string,
+    from?: string,
+    to?: string,
+    billId?: string,
+    unbilledOnly?: boolean,
+  ): Promise<AccountSummary> => {
+    const { data } = await api.get(`/accounts/${id}/summary`, {
+      params: {
+        from,
+        to,
+        bill_id: billId,
+        unbilled_only: unbilledOnly || undefined,
+      },
+    });
+    return data;
   },
-  balanceHistory: async (id: string, from?: string, to?: string): Promise<{ date: string; balance: number; balance_primary?: number }[]> => {
-    const { data } = await api.get(`/accounts/${id}/balance-history`, { params: { from, to } })
-    return data
+  balanceHistory: async (
+    id: string,
+    from?: string,
+    to?: string,
+  ): Promise<{ date: string; balance: number; balance_primary?: number }[]> => {
+    const { data } = await api.get(`/accounts/${id}/balance-history`, {
+      params: { from, to },
+    });
+    return data;
   },
   bills: async (id: string, limit = 24): Promise<CreditCardBill[]> => {
-    const { data } = await api.get(`/accounts/${id}/bills`, { params: { limit } })
-    return data
+    const { data } = await api.get(`/accounts/${id}/bills`, {
+      params: { limit },
+    });
+    return data;
   },
   close: async (id: string): Promise<Account> => {
-    const { data } = await api.post(`/accounts/${id}/close`)
-    return data
+    const { data } = await api.post(`/accounts/${id}/close`);
+    return data;
   },
   reopen: async (id: string): Promise<Account> => {
-    const { data } = await api.post(`/accounts/${id}/reopen`)
-    return data
+    const { data } = await api.post(`/accounts/${id}/reopen`);
+    return data;
   },
-}
+};
 
 // Transactions
 export const transactions = {
   list: async (params?: {
-    account_id?: string
-    account_ids?: string[]
-    category_id?: string
-    category_ids?: string[]
-    payee_id?: string
-    uncategorized?: boolean
-    type?: string
-    from?: string
-    to?: string
-    bill_id?: string
-    group_id?: string
-    unbilled_only?: boolean
-    q?: string
-    page?: number
-    limit?: number
-    include_opening_balance?: boolean
-    exclude_transfers?: boolean
-    tags?: string[]
-    sort_by?: string
-    sort_dir?: 'asc' | 'desc'
+    account_id?: string;
+    account_ids?: string[];
+    category_id?: string;
+    category_ids?: string[];
+    payee_id?: string;
+    uncategorized?: boolean;
+    type?: string;
+    from?: string;
+    to?: string;
+    bill_id?: string;
+    group_id?: string;
+    unbilled_only?: boolean;
+    q?: string;
+    page?: number;
+    limit?: number;
+    include_opening_balance?: boolean;
+    exclude_transfers?: boolean;
+    tags?: string[];
+    sort_by?: string;
+    sort_dir?: "asc" | "desc";
+    ignored_filter?: "hide" | "include" | "only";
   }): Promise<PaginatedTransactions> => {
-    const { data } = await api.get('/transactions', {
+    const { data } = await api.get("/transactions", {
       params,
       paramsSerializer: { indexes: null },
-    })
-    return data
+    });
+    return data;
   },
   get: async (id: string): Promise<Transaction> => {
-    const { data } = await api.get(`/transactions/${id}`)
-    return data
+    const { data } = await api.get(`/transactions/${id}`);
+    return data;
   },
   create: async (transaction: Partial<Transaction>): Promise<Transaction> => {
-    const { data } = await api.post('/transactions', transaction)
-    return data
+    const { data } = await api.post("/transactions", transaction);
+    return data;
   },
   update: async (
     id: string,
     transaction: Partial<Transaction> & { apply_to_transfer_pair?: boolean },
   ): Promise<Transaction> => {
-    const { data } = await api.patch(`/transactions/${id}`, transaction)
-    return data
+    const { data } = await api.patch(`/transactions/${id}`, transaction);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/transactions/${id}`)
+    await api.delete(`/transactions/${id}`);
   },
   createTransfer: async (transfer: {
-    from_account_id: string
-    to_account_id: string
-    amount: number
-    date: string
-    description: string
-    notes?: string
-    fx_rate?: number
-  }): Promise<{ debit: Transaction; credit: Transaction; transfer_pair_id: string }> => {
-    const { data } = await api.post('/transactions/transfer', transfer)
-    return data
+    from_account_id: string;
+    to_account_id: string;
+    amount: number;
+    date: string;
+    description: string;
+    notes?: string;
+    fx_rate?: number;
+  }): Promise<{
+    debit: Transaction;
+    credit: Transaction;
+    transfer_pair_id: string;
+  }> => {
+    const { data } = await api.post("/transactions/transfer", transfer);
+    return data;
   },
-  bulkCategorize: async (transactionIds: string[], categoryId: string | null): Promise<{ updated: number }> => {
-    const { data } = await api.patch('/transactions/bulk-categorize', {
+  bulkCategorize: async (
+    transactionIds: string[],
+    categoryId: string | null,
+  ): Promise<{ updated: number }> => {
+    const { data } = await api.patch("/transactions/bulk-categorize", {
       transaction_ids: transactionIds,
       category_id: categoryId,
-    })
-    return data
+    });
+    return data;
   },
-  bulkAddTags: async (transactionIds: string[], tags: string[]): Promise<{ updated: number }> => {
-    const { data } = await api.patch('/transactions/bulk-add-tags', {
+  bulkAddTags: async (
+    transactionIds: string[],
+    tags: string[],
+  ): Promise<{ updated: number }> => {
+    const { data } = await api.patch("/transactions/bulk-add-tags", {
       transaction_ids: transactionIds,
       tags,
-    })
-    return data
+    });
+    return data;
   },
-  bulkRemoveTags: async (transactionIds: string[], tags: string[]): Promise<{ updated: number }> => {
-    const { data } = await api.patch('/transactions/bulk-remove-tags', {
+  bulkRemoveTags: async (
+    transactionIds: string[],
+    tags: string[],
+  ): Promise<{ updated: number }> => {
+    const { data } = await api.patch("/transactions/bulk-remove-tags", {
       transaction_ids: transactionIds,
       tags,
-    })
-    return data
+    });
+    return data;
   },
   bulkAddToGroup: async (
     transactionIds: string[],
     groupId: string,
     options?: {
-      share_type?: 'equal' | 'percent'
-      member_splits?: { group_member_id: string; share_pct?: number }[]
+      share_type?: "equal" | "percent";
+      member_splits?: { group_member_id: string; share_pct?: number }[];
     },
   ): Promise<{ updated: number; skipped: number }> => {
-    const { data } = await api.patch('/transactions/bulk-add-to-group', {
+    const { data } = await api.patch("/transactions/bulk-add-to-group", {
       transaction_ids: transactionIds,
       group_id: groupId,
       ...(options?.share_type ? { share_type: options.share_type } : {}),
-      ...(options?.member_splits ? { member_splits: options.member_splits } : {}),
-    })
-    return data
+      ...(options?.member_splits
+        ? { member_splits: options.member_splits }
+        : {}),
+    });
+    return data;
   },
-  linkTransfer: async (transactionIds: string[]): Promise<{ debit: Transaction; credit: Transaction; transfer_pair_id: string }> => {
-    const { data } = await api.post('/transactions/link-transfer', {
+  ignore: async (transactionId: string): Promise<Transaction> => {
+    const { data } = await api.patch(`/transactions/${transactionId}/ignore`);
+    return data;
+  },
+  bulkIgnore: async (
+    transactionIds: string[],
+    ignore: boolean,
+  ): Promise<{ updated: number }> => {
+    const { data } = await api.patch("/transactions/bulk-ignore", {
       transaction_ids: transactionIds,
-    })
-    return data
+      ignore,
+    });
+    return data;
+  },
+  linkTransfer: async (
+    transactionIds: string[],
+  ): Promise<{
+    debit: Transaction;
+    credit: Transaction;
+    transfer_pair_id: string;
+  }> => {
+    const { data } = await api.post("/transactions/link-transfer", {
+      transaction_ids: transactionIds,
+    });
+    return data;
   },
   createTransferCounterpart: async (
     transactionId: string,
     toAccountId: string,
-  ): Promise<{ debit: Transaction; credit: Transaction; transfer_pair_id: string }> => {
-    const { data } = await api.post(`/transactions/${transactionId}/create-counterpart`, {
-      to_account_id: toAccountId,
-    })
-    return data
+  ): Promise<{
+    debit: Transaction;
+    credit: Transaction;
+    transfer_pair_id: string;
+  }> => {
+    const { data } = await api.post(
+      `/transactions/${transactionId}/create-counterpart`,
+      {
+        to_account_id: toAccountId,
+      },
+    );
+    return data;
   },
-  transferCandidates: async (transactionId: string, params?: { limit?: number; window_days?: number }): Promise<Transaction[]> => {
-    const { data } = await api.get(`/transactions/${transactionId}/transfer-candidates`, { params })
-    return data
+  transferCandidates: async (
+    transactionId: string,
+    params?: { limit?: number; window_days?: number },
+  ): Promise<Transaction[]> => {
+    const { data } = await api.get(
+      `/transactions/${transactionId}/transfer-candidates`,
+      { params },
+    );
+    return data;
   },
   unlinkTransfer: async (pairId: string): Promise<void> => {
-    await api.delete(`/connections/transfers/${pairId}`)
+    await api.delete(`/connections/transfers/${pairId}`);
   },
-  previewImport: async (file: File, options?: {
-    date_format?: string
-    flip_amount?: boolean
-    inflow_column?: string
-    outflow_column?: string
-    column_mapping?: Record<string, string>
-  }): Promise<{ transactions: ImportPreviewTransaction[]; detected_format: string; csv_columns?: string[]; parse_error?: string | null }> => {
-    const formData = new FormData()
-    formData.append('file', file)
-    if (options?.date_format) formData.append('date_format', options.date_format)
-    if (options?.flip_amount) formData.append('flip_amount', 'true')
-    if (options?.inflow_column) formData.append('inflow_column', options.inflow_column)
-    if (options?.outflow_column) formData.append('outflow_column', options.outflow_column)
-    if (options?.column_mapping && Object.keys(options.column_mapping).length > 0) {
-      formData.append('column_mapping', JSON.stringify(options.column_mapping))
+  previewImport: async (
+    file: File,
+    options?: {
+      date_format?: string;
+      flip_amount?: boolean;
+      inflow_column?: string;
+      outflow_column?: string;
+      column_mapping?: Record<string, string>;
+    },
+  ): Promise<{
+    transactions: ImportPreviewTransaction[];
+    detected_format: string;
+    csv_columns?: string[];
+    parse_error?: string | null;
+  }> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    if (options?.date_format)
+      formData.append("date_format", options.date_format);
+    if (options?.flip_amount) formData.append("flip_amount", "true");
+    if (options?.inflow_column)
+      formData.append("inflow_column", options.inflow_column);
+    if (options?.outflow_column)
+      formData.append("outflow_column", options.outflow_column);
+    if (
+      options?.column_mapping &&
+      Object.keys(options.column_mapping).length > 0
+    ) {
+      formData.append("column_mapping", JSON.stringify(options.column_mapping));
     }
-    const { data } = await api.post('/transactions/import/preview', formData)
-    return data
+    const { data } = await api.post("/transactions/import/preview", formData);
+    return data;
   },
   import: async (
     account_id: string,
@@ -396,787 +533,1026 @@ export const transactions = {
     filename: string,
     detected_format: string,
     options?: { detect_duplicates?: boolean },
-  ): Promise<{ imported: number; skipped: number; excluded: number; import_log_id: string }> => {
+  ): Promise<{
+    imported: number;
+    skipped: number;
+    excluded: number;
+    import_log_id: string;
+  }> => {
     const payload: {
-      account_id: string
-      transactions: ImportPreviewTransaction[]
-      filename: string
-      detected_format: string
-      detect_duplicates?: boolean
-    } = { account_id, transactions, filename, detected_format }
+      account_id: string;
+      transactions: ImportPreviewTransaction[];
+      filename: string;
+      detected_format: string;
+      detect_duplicates?: boolean;
+    } = { account_id, transactions, filename, detected_format };
 
-    if (typeof options?.detect_duplicates === 'boolean') {
-      payload.detect_duplicates = options.detect_duplicates
+    if (typeof options?.detect_duplicates === "boolean") {
+      payload.detect_duplicates = options.detect_duplicates;
     }
 
-    const { data } = await api.post('/transactions/import', payload)
-    return data
+    const { data } = await api.post("/transactions/import", payload);
+    return data;
   },
   export: async (params?: {
-    account_id?: string
-    account_ids?: string[]
-    category_id?: string
-    category_ids?: string[]
-    uncategorized?: boolean
-    type?: string
-    from?: string
-    to?: string
-    q?: string
-    transaction_ids?: string[]
+    account_id?: string;
+    account_ids?: string[];
+    category_id?: string;
+    category_ids?: string[];
+    uncategorized?: boolean;
+    type?: string;
+    from?: string;
+    to?: string;
+    q?: string;
+    transaction_ids?: string[];
   }): Promise<void> => {
-    const { data } = await api.get('/transactions/export', {
+    const { data } = await api.get("/transactions/export", {
       params,
-      responseType: 'blob',
+      responseType: "blob",
       paramsSerializer: { indexes: null },
-    })
-    const blob = new Blob([data], { type: 'text/csv;charset=utf-8;' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `transactions-${new Date().toISOString().slice(0, 10)}.csv`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
+    });
+    const blob = new Blob([data], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `transactions-${new Date().toISOString().slice(0, 10)}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
   },
   attachments: {
     list: async (transactionId: string): Promise<Attachment[]> => {
-      const { data } = await api.get(`/transactions/${transactionId}/attachments`)
-      return data
+      const { data } = await api.get(
+        `/transactions/${transactionId}/attachments`,
+      );
+      return data;
     },
     upload: async (transactionId: string, file: File): Promise<Attachment> => {
-      const formData = new FormData()
-      formData.append('file', file)
-      const { data } = await api.post(`/transactions/${transactionId}/attachments`, formData)
-      return data
+      const formData = new FormData();
+      formData.append("file", file);
+      const { data } = await api.post(
+        `/transactions/${transactionId}/attachments`,
+        formData,
+      );
+      return data;
     },
-    downloadUrl: async (transactionId: string, attachmentId: string): Promise<string> => {
-      const { data } = await api.get(`/transactions/${transactionId}/attachments/${attachmentId}`, {
-        responseType: 'blob',
-      })
-      return URL.createObjectURL(data)
+    downloadUrl: async (
+      transactionId: string,
+      attachmentId: string,
+    ): Promise<string> => {
+      const { data } = await api.get(
+        `/transactions/${transactionId}/attachments/${attachmentId}`,
+        {
+          responseType: "blob",
+        },
+      );
+      return URL.createObjectURL(data);
     },
-    rename: async (transactionId: string, attachmentId: string, filename: string): Promise<Attachment> => {
-      const { data } = await api.patch(`/transactions/${transactionId}/attachments/${attachmentId}`, { filename })
-      return data
+    rename: async (
+      transactionId: string,
+      attachmentId: string,
+      filename: string,
+    ): Promise<Attachment> => {
+      const { data } = await api.patch(
+        `/transactions/${transactionId}/attachments/${attachmentId}`,
+        { filename },
+      );
+      return data;
     },
-    delete: async (transactionId: string, attachmentId: string): Promise<void> => {
-      await api.delete(`/transactions/${transactionId}/attachments/${attachmentId}`)
+    delete: async (
+      transactionId: string,
+      attachmentId: string,
+    ): Promise<void> => {
+      await api.delete(
+        `/transactions/${transactionId}/attachments/${attachmentId}`,
+      );
     },
   },
-}
+};
 
 // Payees
 export const payees = {
   list: async (): Promise<Payee[]> => {
-    const { data } = await api.get('/payees')
-    return data
+    const { data } = await api.get("/payees");
+    return data;
   },
   get: async (id: string): Promise<Payee> => {
-    const { data } = await api.get(`/payees/${id}`)
-    return data
+    const { data } = await api.get(`/payees/${id}`);
+    return data;
   },
-  summary: async (id: string, from?: string, to?: string): Promise<PayeeSummary> => {
-    const { data } = await api.get(`/payees/${id}/summary`, { params: { from, to } })
-    return data
+  summary: async (
+    id: string,
+    from?: string,
+    to?: string,
+  ): Promise<PayeeSummary> => {
+    const { data } = await api.get(`/payees/${id}/summary`, {
+      params: { from, to },
+    });
+    return data;
   },
-  create: async (payee: { name: string; type?: string; notes?: string }): Promise<Payee> => {
-    const { data } = await api.post('/payees', payee)
-    return data
+  create: async (payee: {
+    name: string;
+    type?: string;
+    notes?: string;
+  }): Promise<Payee> => {
+    const { data } = await api.post("/payees", payee);
+    return data;
   },
   update: async (id: string, payee: Partial<Payee>): Promise<Payee> => {
-    const { data } = await api.patch(`/payees/${id}`, payee)
-    return data
+    const { data } = await api.patch(`/payees/${id}`, payee);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/payees/${id}`)
+    await api.delete(`/payees/${id}`);
   },
-  merge: async (targetId: string, sourceIds: string[]): Promise<{ merged: number; transactions_reassigned: number }> => {
-    const { data } = await api.post('/payees/merge', { target_id: targetId, source_ids: sourceIds })
-    return data
+  merge: async (
+    targetId: string,
+    sourceIds: string[],
+  ): Promise<{ merged: number; transactions_reassigned: number }> => {
+    const { data } = await api.post("/payees/merge", {
+      target_id: targetId,
+      source_ids: sourceIds,
+    });
+    return data;
   },
-}
+};
 
 // Groups (split transactions)
 export interface GroupCreatePayload {
-  name: string
-  kind?: GroupKind
-  default_currency?: string
-  icon?: string
-  color?: string
-  notes?: string | null
+  name: string;
+  kind?: GroupKind;
+  default_currency?: string;
+  icon?: string;
+  color?: string;
+  notes?: string | null;
 }
 
 export interface GroupMemberPayload {
-  name: string
-  linked_user_id?: string | null
-  email?: string | null
-  is_self?: boolean
+  name: string;
+  linked_user_id?: string | null;
+  email?: string | null;
+  is_self?: boolean;
 }
 
 export interface GroupSettlementPayload {
-  from_member_id: string
-  to_member_id: string
-  amount: number
-  currency: string
-  date: string
-  transaction_id?: string | null
-  notes?: string | null
+  from_member_id: string;
+  to_member_id: string;
+  amount: number;
+  currency: string;
+  date: string;
+  transaction_id?: string | null;
+  notes?: string | null;
   // When provided, the backend creates a debit transaction on this
   // account and links it via transaction_id. Mutually exclusive with
   // passing transaction_id directly.
-  account_id?: string | null
-  description?: string | null
+  account_id?: string | null;
+  description?: string | null;
 }
 
 export const groups = {
   list: async (includeArchived = false): Promise<Group[]> => {
-    const { data } = await api.get('/groups', { params: { include_archived: includeArchived } })
-    return data
+    const { data } = await api.get("/groups", {
+      params: { include_archived: includeArchived },
+    });
+    return data;
   },
   get: async (id: string): Promise<Group> => {
-    const { data } = await api.get(`/groups/${id}`)
-    return data
+    const { data } = await api.get(`/groups/${id}`);
+    return data;
   },
   create: async (payload: GroupCreatePayload): Promise<Group> => {
-    const { data } = await api.post('/groups', payload)
-    return data
+    const { data } = await api.post("/groups", payload);
+    return data;
   },
-  update: async (id: string, payload: Partial<GroupCreatePayload> & { is_archived?: boolean }): Promise<Group> => {
-    const { data } = await api.patch(`/groups/${id}`, payload)
-    return data
+  update: async (
+    id: string,
+    payload: Partial<GroupCreatePayload> & { is_archived?: boolean },
+  ): Promise<Group> => {
+    const { data } = await api.patch(`/groups/${id}`, payload);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/groups/${id}`)
+    await api.delete(`/groups/${id}`);
   },
   members: {
     list: async (groupId: string): Promise<GroupMember[]> => {
-      const { data } = await api.get(`/groups/${groupId}/members`)
-      return data
+      const { data } = await api.get(`/groups/${groupId}/members`);
+      return data;
     },
-    create: async (groupId: string, payload: GroupMemberPayload): Promise<GroupMember> => {
-      const { data } = await api.post(`/groups/${groupId}/members`, payload)
-      return data
+    create: async (
+      groupId: string,
+      payload: GroupMemberPayload,
+    ): Promise<GroupMember> => {
+      const { data } = await api.post(`/groups/${groupId}/members`, payload);
+      return data;
     },
-    update: async (groupId: string, memberId: string, payload: Partial<GroupMemberPayload>): Promise<GroupMember> => {
-      const { data } = await api.patch(`/groups/${groupId}/members/${memberId}`, payload)
-      return data
+    update: async (
+      groupId: string,
+      memberId: string,
+      payload: Partial<GroupMemberPayload>,
+    ): Promise<GroupMember> => {
+      const { data } = await api.patch(
+        `/groups/${groupId}/members/${memberId}`,
+        payload,
+      );
+      return data;
     },
     delete: async (groupId: string, memberId: string): Promise<void> => {
-      await api.delete(`/groups/${groupId}/members/${memberId}`)
+      await api.delete(`/groups/${groupId}/members/${memberId}`);
     },
   },
   settlements: {
     list: async (groupId: string): Promise<GroupSettlement[]> => {
-      const { data } = await api.get(`/groups/${groupId}/settlements`)
-      return data
+      const { data } = await api.get(`/groups/${groupId}/settlements`);
+      return data;
     },
-    create: async (groupId: string, payload: GroupSettlementPayload): Promise<GroupSettlement> => {
-      const { data } = await api.post(`/groups/${groupId}/settlements`, payload)
-      return data
+    create: async (
+      groupId: string,
+      payload: GroupSettlementPayload,
+    ): Promise<GroupSettlement> => {
+      const { data } = await api.post(
+        `/groups/${groupId}/settlements`,
+        payload,
+      );
+      return data;
     },
-    update: async (groupId: string, settlementId: string, payload: Partial<GroupSettlementPayload>): Promise<GroupSettlement> => {
-      const { data } = await api.patch(`/groups/${groupId}/settlements/${settlementId}`, payload)
-      return data
+    update: async (
+      groupId: string,
+      settlementId: string,
+      payload: Partial<GroupSettlementPayload>,
+    ): Promise<GroupSettlement> => {
+      const { data } = await api.patch(
+        `/groups/${groupId}/settlements/${settlementId}`,
+        payload,
+      );
+      return data;
     },
     delete: async (groupId: string, settlementId: string): Promise<void> => {
-      await api.delete(`/groups/${groupId}/settlements/${settlementId}`)
+      await api.delete(`/groups/${groupId}/settlements/${settlementId}`);
     },
   },
   balances: async (groupId: string): Promise<GroupBalances> => {
-    const { data } = await api.get(`/groups/${groupId}/balances`)
-    return data
+    const { data } = await api.get(`/groups/${groupId}/balances`);
+    return data;
   },
   transactions: async (groupId: string, limit = 20): Promise<Transaction[]> => {
     const { data } = await api.get(`/groups/${groupId}/transactions`, {
       params: { limit },
-    })
-    return data
+    });
+    return data;
   },
-}
+};
 
 // Helper re-export so transaction-creation forms have a typed entry point.
-export type { TransactionSplitsInput }
+export type { TransactionSplitsInput };
 
 // User lookup: exact-match resolution for linking group members to
 // existing Securo users. Returns null on miss (404).
 export interface UserLookupResult {
-  id: string
-  email: string
+  id: string;
+  email: string;
 }
 
 export const users = {
   lookupByEmail: async (email: string): Promise<UserLookupResult | null> => {
     try {
-      const { data } = await api.get('/users/lookup', { params: { email } })
-      return data
+      const { data } = await api.get("/users/lookup", { params: { email } });
+      return data;
     } catch (err: unknown) {
-      const status = (err as { response?: { status?: number } })?.response?.status
-      if (status === 404) return null
-      throw err
+      const status = (err as { response?: { status?: number } })?.response
+        ?.status;
+      if (status === 404) return null;
+      throw err;
     }
   },
   directory: async (): Promise<UserLookupResult[]> => {
-    const { data } = await api.get('/users/directory')
-    return data
+    const { data } = await api.get("/users/directory");
+    return data;
   },
-}
-
+};
 
 // Categorization Rules
 export const rules = {
   list: async (): Promise<Rule[]> => {
-    const { data } = await api.get('/rules')
-    return data
+    const { data } = await api.get("/rules");
+    return data;
   },
-  create: async (rule: Omit<Rule, 'id' | 'user_id'>): Promise<Rule> => {
-    const { data } = await api.post('/rules', rule)
-    return data
+  create: async (rule: Omit<Rule, "id" | "user_id">): Promise<Rule> => {
+    const { data } = await api.post("/rules", rule);
+    return data;
   },
   update: async (id: string, rule: Partial<Rule>): Promise<Rule> => {
-    const { data } = await api.patch(`/rules/${id}`, rule)
-    return data
+    const { data } = await api.patch(`/rules/${id}`, rule);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/rules/${id}`)
+    await api.delete(`/rules/${id}`);
   },
   applyAll: async (): Promise<{ applied: number }> => {
-    const { data } = await api.post('/rules/apply-all')
-    return data
+    const { data } = await api.post("/rules/apply-all");
+    return data;
   },
-  packs: async (): Promise<{ code: string; name: string; flag: string; rule_count: number; installed: boolean }[]> => {
-    const { data } = await api.get('/rules/packs')
-    return data
+  packs: async (): Promise<
+    {
+      code: string;
+      name: string;
+      flag: string;
+      rule_count: number;
+      installed: boolean;
+    }[]
+  > => {
+    const { data } = await api.get("/rules/packs");
+    return data;
   },
   installPack: async (
     packCode: string,
     createMissingCategories = false,
-  ): Promise<{ installed: number; unresolved: number; categories_created: number }> => {
+  ): Promise<{
+    installed: number;
+    unresolved: number;
+    categories_created: number;
+  }> => {
     const { data } = await api.post(`/rules/packs/${packCode}/install`, null, {
       params: { create_missing_categories: createMissingCategories },
-    })
-    return data
+    });
+    return data;
   },
-}
+};
 
 // Recurring Transactions
 export const recurring = {
   list: async (): Promise<RecurringTransaction[]> => {
-    const { data } = await api.get('/recurring-transactions')
-    return data
+    const { data } = await api.get("/recurring-transactions");
+    return data;
   },
-  create: async (rt: Partial<RecurringTransaction>): Promise<RecurringTransaction> => {
-    const { data } = await api.post('/recurring-transactions', rt)
-    return data
+  create: async (
+    rt: Partial<RecurringTransaction>,
+  ): Promise<RecurringTransaction> => {
+    const { data } = await api.post("/recurring-transactions", rt);
+    return data;
   },
-  update: async (id: string, rt: Partial<RecurringTransaction>): Promise<RecurringTransaction> => {
-    const { data } = await api.patch(`/recurring-transactions/${id}`, rt)
-    return data
+  update: async (
+    id: string,
+    rt: Partial<RecurringTransaction>,
+  ): Promise<RecurringTransaction> => {
+    const { data } = await api.patch(`/recurring-transactions/${id}`, rt);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/recurring-transactions/${id}`)
+    await api.delete(`/recurring-transactions/${id}`);
   },
   generate: async (): Promise<{ generated: number }> => {
-    const { data } = await api.post('/recurring-transactions/generate')
-    return data
+    const { data } = await api.post("/recurring-transactions/generate");
+    return data;
   },
-}
+};
 
 // Budgets
 export const budgets = {
   list: async (month?: string): Promise<Budget[]> => {
-    const { data } = await api.get('/budgets', { params: { month } })
-    return data
+    const { data } = await api.get("/budgets", { params: { month } });
+    return data;
   },
-  create: async (budget: { category_id: string; amount: number; month: string; is_recurring?: boolean }): Promise<Budget> => {
-    const { data } = await api.post('/budgets', budget)
-    return data
+  create: async (budget: {
+    category_id: string;
+    amount: number;
+    month: string;
+    is_recurring?: boolean;
+  }): Promise<Budget> => {
+    const { data } = await api.post("/budgets", budget);
+    return data;
   },
   update: async (id: string, budget: { amount?: number }): Promise<Budget> => {
-    const { data } = await api.patch(`/budgets/${id}`, budget)
-    return data
+    const { data } = await api.patch(`/budgets/${id}`, budget);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/budgets/${id}`)
+    await api.delete(`/budgets/${id}`);
   },
   comparison: async (month?: string): Promise<BudgetVsActual[]> => {
-    const { data } = await api.get('/budgets/comparison', { params: { month } })
-    return data
+    const { data } = await api.get("/budgets/comparison", {
+      params: { month },
+    });
+    return data;
   },
-}
+};
 
 // Goals
 export const goals = {
   list: async (status?: string): Promise<Goal[]> => {
-    const { data } = await api.get('/goals', { params: { status } })
-    return data
+    const { data } = await api.get("/goals", { params: { status } });
+    return data;
   },
   get: async (id: string): Promise<Goal> => {
-    const { data } = await api.get(`/goals/${id}`)
-    return data
+    const { data } = await api.get(`/goals/${id}`);
+    return data;
   },
   create: async (goal: Partial<Goal>): Promise<Goal> => {
-    const { data } = await api.post('/goals', goal)
-    return data
+    const { data } = await api.post("/goals", goal);
+    return data;
   },
   update: async (id: string, goal: Partial<Goal>): Promise<Goal> => {
-    const { data } = await api.patch(`/goals/${id}`, goal)
-    return data
+    const { data } = await api.patch(`/goals/${id}`, goal);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/goals/${id}`)
+    await api.delete(`/goals/${id}`);
   },
   summary: async (limit = 3): Promise<GoalSummary[]> => {
-    const { data } = await api.get('/goals/summary', { params: { limit } })
-    return data
+    const { data } = await api.get("/goals/summary", { params: { limit } });
+    return data;
   },
-}
+};
 
 // Dashboard
 export const dashboard = {
-  summary: async (month?: string, balanceDate?: string): Promise<DashboardSummary> => {
-    const { data } = await api.get('/dashboard/summary', { params: { month, balance_date: balanceDate } })
-    return data
+  summary: async (
+    month?: string,
+    balanceDate?: string,
+  ): Promise<DashboardSummary> => {
+    const { data } = await api.get("/dashboard/summary", {
+      params: { month, balance_date: balanceDate },
+    });
+    return data;
   },
   spendingByCategory: async (month?: string): Promise<SpendingByCategory[]> => {
-    const { data } = await api.get('/dashboard/spending-by-category', { params: { month } })
-    return data
+    const { data } = await api.get("/dashboard/spending-by-category", {
+      params: { month },
+    });
+    return data;
   },
   monthlyTrend: async (months = 6): Promise<MonthlyTrend[]> => {
-    const { data } = await api.get('/dashboard/monthly-trend', { params: { months } })
-    return data
+    const { data } = await api.get("/dashboard/monthly-trend", {
+      params: { months },
+    });
+    return data;
   },
-  projectedTransactions: async (month?: string): Promise<ProjectedTransaction[]> => {
-    const { data } = await api.get('/dashboard/projected-transactions', { params: { month } })
-    return data
+  projectedTransactions: async (
+    month?: string,
+  ): Promise<ProjectedTransaction[]> => {
+    const { data } = await api.get("/dashboard/projected-transactions", {
+      params: { month },
+    });
+    return data;
   },
   balanceHistory: async (month?: string): Promise<BalanceHistory> => {
-    const { data } = await api.get('/dashboard/balance-history', { params: { month } })
-    return data
+    const { data } = await api.get("/dashboard/balance-history", {
+      params: { month },
+    });
+    return data;
   },
-}
+};
 
 // Assets
 export const assets = {
   list: async (includeArchived = false): Promise<Asset[]> => {
-    const { data } = await api.get('/assets', { params: { include_archived: includeArchived } })
-    return data
+    const { data } = await api.get("/assets", {
+      params: { include_archived: includeArchived },
+    });
+    return data;
   },
   get: async (id: string): Promise<Asset> => {
-    const { data } = await api.get(`/assets/${id}`)
-    return data
+    const { data } = await api.get(`/assets/${id}`);
+    return data;
   },
-  create: async (asset: Partial<Asset> & { name: string; type: string; current_value?: number }): Promise<Asset> => {
-    const { data } = await api.post('/assets', asset)
-    return data
+  create: async (
+    asset: Partial<Asset> & {
+      name: string;
+      type: string;
+      current_value?: number;
+    },
+  ): Promise<Asset> => {
+    const { data } = await api.post("/assets", asset);
+    return data;
   },
-  update: async (id: string, asset: Partial<Asset>, opts?: { regenerateGrowth?: boolean }): Promise<Asset> => {
+  update: async (
+    id: string,
+    asset: Partial<Asset>,
+    opts?: { regenerateGrowth?: boolean },
+  ): Promise<Asset> => {
     const { data } = await api.patch(`/assets/${id}`, asset, {
       params: opts?.regenerateGrowth ? { regenerate_growth: true } : undefined,
-    })
-    return data
+    });
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/assets/${id}`)
+    await api.delete(`/assets/${id}`);
   },
   values: async (id: string): Promise<AssetValue[]> => {
-    const { data } = await api.get(`/assets/${id}/values`)
-    return data
+    const { data } = await api.get(`/assets/${id}/values`);
+    return data;
   },
-  valueTrend: async (id: string, months = 12): Promise<{ date: string; amount: number }[]> => {
-    const { data } = await api.get(`/assets/${id}/value-trend`, { params: { months } })
-    return data
+  valueTrend: async (
+    id: string,
+    months = 12,
+  ): Promise<{ date: string; amount: number }[]> => {
+    const { data } = await api.get(`/assets/${id}/value-trend`, {
+      params: { months },
+    });
+    return data;
   },
-  addValue: async (id: string, value: { amount: number; date: string }): Promise<AssetValue> => {
-    const { data } = await api.post(`/assets/${id}/values`, value)
-    return data
+  addValue: async (
+    id: string,
+    value: { amount: number; date: string },
+  ): Promise<AssetValue> => {
+    const { data } = await api.post(`/assets/${id}/values`, value);
+    return data;
   },
   deleteValue: async (valueId: string): Promise<void> => {
-    await api.delete(`/assets/values/${valueId}`)
+    await api.delete(`/assets/values/${valueId}`);
   },
-  portfolioTrend: async (): Promise<{ assets: { id: string; name: string; type: string; group_id: string | null }[]; trend: Record<string, unknown>[]; total: number }> => {
-    const { data } = await api.get('/assets/portfolio-trend')
-    return data
+  portfolioTrend: async (): Promise<{
+    assets: {
+      id: string;
+      name: string;
+      type: string;
+      group_id: string | null;
+    }[];
+    trend: Record<string, unknown>[];
+    total: number;
+  }> => {
+    const { data } = await api.get("/assets/portfolio-trend");
+    return data;
   },
   marketSearch: async (q: string, limit = 15): Promise<MarketSymbolMatch[]> => {
-    const { data } = await api.get('/assets/market/search', { params: { q, limit } })
-    return data
+    const { data } = await api.get("/assets/market/search", {
+      params: { q, limit },
+    });
+    return data;
   },
   marketQuote: async (symbol: string): Promise<MarketSymbolQuote> => {
-    const { data } = await api.get('/assets/market/quote', { params: { symbol } })
-    return data
+    const { data } = await api.get("/assets/market/quote", {
+      params: { symbol },
+    });
+    return data;
   },
   refreshPrice: async (id: string): Promise<Asset> => {
-    const { data } = await api.post(`/assets/${id}/refresh-price`)
-    return data
+    const { data } = await api.post(`/assets/${id}/refresh-price`);
+    return data;
   },
-}
+};
 
 // Asset Groups ("wallets")
 export const assetGroups = {
   list: async (): Promise<AssetGroup[]> => {
-    const { data } = await api.get('/asset-groups')
-    return data
+    const { data } = await api.get("/asset-groups");
+    return data;
   },
-  create: async (group: Partial<AssetGroup> & { name: string }): Promise<AssetGroup> => {
-    const { data } = await api.post('/asset-groups', group)
-    return data
+  create: async (
+    group: Partial<AssetGroup> & { name: string },
+  ): Promise<AssetGroup> => {
+    const { data } = await api.post("/asset-groups", group);
+    return data;
   },
-  update: async (id: string, group: Partial<AssetGroup>): Promise<AssetGroup> => {
-    const { data } = await api.patch(`/asset-groups/${id}`, group)
-    return data
+  update: async (
+    id: string,
+    group: Partial<AssetGroup>,
+  ): Promise<AssetGroup> => {
+    const { data } = await api.patch(`/asset-groups/${id}`, group);
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/asset-groups/${id}`)
+    await api.delete(`/asset-groups/${id}`);
   },
-}
+};
 
 // Reports
 export const reports = {
-  netWorth: async (months = 12, interval = 'monthly'): Promise<ReportResponse> => {
-    const { data } = await api.get('/reports/net-worth', { params: { months, interval } })
-    return data
+  netWorth: async (
+    months = 12,
+    interval = "monthly",
+  ): Promise<ReportResponse> => {
+    const { data } = await api.get("/reports/net-worth", {
+      params: { months, interval },
+    });
+    return data;
   },
-  incomeExpenses: async (months = 12, interval = 'monthly'): Promise<ReportResponse> => {
-    const { data } = await api.get('/reports/income-expenses', { params: { months, interval } })
-    return data
+  incomeExpenses: async (
+    months = 12,
+    interval = "monthly",
+  ): Promise<ReportResponse> => {
+    const { data } = await api.get("/reports/income-expenses", {
+      params: { months, interval },
+    });
+    return data;
   },
-  cashFlow: async (months = 6, interval = 'daily'): Promise<ReportResponse> => {
-    const { data } = await api.get('/reports/cash-flow', { params: { months, interval } })
-    return data
+  cashFlow: async (months = 6, interval = "daily"): Promise<ReportResponse> => {
+    const { data } = await api.get("/reports/cash-flow", {
+      params: { months, interval },
+    });
+    return data;
   },
-}
+};
 
 // Currencies
 export const currencies = {
-  list: async (): Promise<{ code: string; symbol: string; name: string; flag: string }[]> => {
-    const { data } = await api.get('/currencies')
-    return data
+  list: async (): Promise<
+    { code: string; symbol: string; name: string; flag: string }[]
+  > => {
+    const { data } = await api.get("/currencies");
+    return data;
   },
-}
+};
 
 // FX Rates
 export const fxRates = {
-  refresh: async (): Promise<{ synced: boolean; rates_count: number; date: string }> => {
-    const { data } = await api.post('/fx-rates/refresh')
-    return data
+  refresh: async (): Promise<{
+    synced: boolean;
+    rates_count: number;
+    date: string;
+  }> => {
+    const { data } = await api.post("/fx-rates/refresh");
+    return data;
   },
-  status: async (): Promise<{ last_sync_date: string | null; total_rates: number }> => {
-    const { data } = await api.get('/fx-rates/status')
-    return data
+  status: async (): Promise<{
+    last_sync_date: string | null;
+    total_rates: number;
+  }> => {
+    const { data } = await api.get("/fx-rates/status");
+    return data;
   },
-}
+};
 
 // Import Logs
 export const importLogs = {
   list: async (): Promise<ImportLog[]> => {
-    const { data } = await api.get('/import-logs')
-    return data
+    const { data } = await api.get("/import-logs");
+    return data;
   },
   delete: async (id: string): Promise<void> => {
-    await api.delete(`/import-logs/${id}`)
+    await api.delete(`/import-logs/${id}`);
   },
-}
+};
 
 // Settings
 export const settings = {
-  attachments: async (): Promise<{ allowed_extensions: string[]; max_file_size_mb: number; max_attachments_per_transaction: number }> => {
-    const { data } = await api.get('/settings/attachments')
-    return data
+  attachments: async (): Promise<{
+    allowed_extensions: string[];
+    max_file_size_mb: number;
+    max_attachments_per_transaction: number;
+  }> => {
+    const { data } = await api.get("/settings/attachments");
+    return data;
   },
-}
+};
 
 // Backup
 export const backup = {
   download: async (): Promise<void> => {
-    const { data } = await api.get('/export/backup', { responseType: 'blob' })
-    const blob = new Blob([data], { type: 'application/zip' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `securo-backup-${new Date().toISOString().slice(0, 10)}.zip`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
+    const { data } = await api.get("/export/backup", { responseType: "blob" });
+    const blob = new Blob([data], { type: "application/zip" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `securo-backup-${new Date().toISOString().slice(0, 10)}.zip`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
   },
-}
+};
 
 // Admin
 export const admin = {
-  listUsers: async (params?: { search?: string; page?: number; limit?: number }): Promise<AdminUserList> => {
-    const { data } = await api.get('/admin/users', { params })
-    return data
+  listUsers: async (params?: {
+    search?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<AdminUserList> => {
+    const { data } = await api.get("/admin/users", { params });
+    return data;
   },
   getUser: async (id: string): Promise<AdminUser> => {
-    const { data } = await api.get(`/admin/users/${id}`)
-    return data
+    const { data } = await api.get(`/admin/users/${id}`);
+    return data;
   },
-  createUser: async (user: { email: string; password: string; is_superuser?: boolean; preferences?: Record<string, unknown> }): Promise<AdminUser> => {
-    const { data } = await api.post('/admin/users', user)
-    return data
+  createUser: async (user: {
+    email: string;
+    password: string;
+    is_superuser?: boolean;
+    preferences?: Record<string, unknown>;
+  }): Promise<AdminUser> => {
+    const { data } = await api.post("/admin/users", user);
+    return data;
   },
-  updateUser: async (id: string, user: Partial<{ email: string; password: string; is_active: boolean; is_superuser: boolean; preferences: Record<string, unknown> }>): Promise<AdminUser> => {
-    const { data } = await api.patch(`/admin/users/${id}`, user)
-    return data
+  updateUser: async (
+    id: string,
+    user: Partial<{
+      email: string;
+      password: string;
+      is_active: boolean;
+      is_superuser: boolean;
+      preferences: Record<string, unknown>;
+    }>,
+  ): Promise<AdminUser> => {
+    const { data } = await api.patch(`/admin/users/${id}`, user);
+    return data;
   },
   deleteUser: async (id: string): Promise<void> => {
-    await api.delete(`/admin/users/${id}`)
+    await api.delete(`/admin/users/${id}`);
   },
   getSetting: async (key: string): Promise<AppSetting> => {
-    const { data } = await api.get(`/admin/settings/${key}`)
-    return data
+    const { data } = await api.get(`/admin/settings/${key}`);
+    return data;
   },
   updateSetting: async (key: string, value: string): Promise<AppSetting> => {
-    const { data } = await api.patch(`/admin/settings/${key}`, { value })
-    return data
+    const { data } = await api.patch(`/admin/settings/${key}`, { value });
+    return data;
   },
   registrationStatus: async (): Promise<{ enabled: boolean }> => {
-    const { data } = await api.get('/admin/registration-status')
-    return data
+    const { data } = await api.get("/admin/registration-status");
+    return data;
   },
-  accountingMode: async (): Promise<{ mode: 'cash' | 'accrual' }> => {
-    const { data } = await api.get('/admin/accounting-mode')
-    return data
+  accountingMode: async (): Promise<{ mode: "cash" | "accrual" }> => {
+    const { data } = await api.get("/admin/accounting-mode");
+    return data;
   },
-}
+};
 
 // Global search (powers the command palette)
 export type SearchHitType =
-  | 'transaction'
-  | 'account'
-  | 'payee'
-  | 'category'
-  | 'goal'
-  | 'asset'
+  | "transaction"
+  | "account"
+  | "payee"
+  | "category"
+  | "goal"
+  | "asset";
 
 export interface SearchHit {
-  type: SearchHitType
-  id: string
-  label: string
-  subtitle: string | null
-  amount: number | null
-  currency: string | null
-  date: string | null
-  icon: string | null
-  color: string | null
-  meta: Record<string, unknown>
+  type: SearchHitType;
+  id: string;
+  label: string;
+  subtitle: string | null;
+  amount: number | null;
+  currency: string | null;
+  date: string | null;
+  icon: string | null;
+  color: string | null;
+  meta: Record<string, unknown>;
 }
 
 export const search = {
   query: async (q: string, limit = 5): Promise<SearchHit[]> => {
-    if (!q.trim()) return []
-    const { data } = await api.get('/search', { params: { q, limit } })
-    return data.results as SearchHit[]
+    if (!q.trim()) return [];
+    const { data } = await api.get("/search", { params: { q, limit } });
+    return data.results as SearchHit[];
   },
-}
+};
 
 // App-level feature flags (whether optional modules like agents are mounted)
 export interface AppInfo {
-  features: { agents: boolean }
+  features: { agents: boolean };
 }
 
 export const info = {
   get: async (): Promise<AppInfo> => {
-    const { data } = await api.get('/info')
-    return data
+    const { data } = await api.get("/info");
+    return data;
   },
-}
+};
 
 // Agents / MCP / RAG -- only meaningful when info.features.agents === true.
 export interface Agent {
-  id: string
-  name: string
-  description: string | null
-  system_prompt: string
-  icon: string
-  color: string
-  connection_id: string | null
-  provider: string | null
-  model: string | null
-  temperature: number
-  max_history_messages: number
-  top_n: number
-  similarity_threshold: number
-  extra: Record<string, unknown>
-  auto_context: boolean
-  is_archived: boolean
-  is_default: boolean
+  id: string;
+  name: string;
+  description: string | null;
+  system_prompt: string;
+  icon: string;
+  color: string;
+  connection_id: string | null;
+  provider: string | null;
+  model: string | null;
+  temperature: number;
+  max_history_messages: number;
+  top_n: number;
+  similarity_threshold: number;
+  extra: Record<string, unknown>;
+  auto_context: boolean;
+  is_archived: boolean;
+  is_default: boolean;
   // Populated by GET /agents (list endpoint) for the agents page.
   // Single-agent endpoints leave them at 0 since the row-level page
   // already shows tabs for both lists.
-  conversation_count: number
-  knowledge_count: number
-  created_at: string
-  updated_at: string
+  conversation_count: number;
+  knowledge_count: number;
+  created_at: string;
+  updated_at: string;
 }
 
-export type LlmConnectionKind = 'ollama' | 'openai' | 'anthropic' | 'openai_compatible'
+export type LlmConnectionKind =
+  | "ollama"
+  | "openai"
+  | "anthropic"
+  | "openai_compatible";
 
 export interface LlmConnection {
-  id: string
-  name: string
-  kind: LlmConnectionKind
-  base_url: string | null
-  default_model: string | null
-  extra: Record<string, unknown>
-  is_default: boolean
-  has_api_key: boolean
-  created_at: string
-  updated_at: string
+  id: string;
+  name: string;
+  kind: LlmConnectionKind;
+  base_url: string | null;
+  default_model: string | null;
+  extra: Record<string, unknown>;
+  is_default: boolean;
+  has_api_key: boolean;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface LlmConnectionPayload {
-  name: string
-  kind: LlmConnectionKind
-  base_url?: string | null
-  api_key?: string | null
-  default_model?: string | null
-  extra?: Record<string, unknown>
-  is_default?: boolean
+  name: string;
+  kind: LlmConnectionKind;
+  base_url?: string | null;
+  api_key?: string | null;
+  default_model?: string | null;
+  extra?: Record<string, unknown>;
+  is_default?: boolean;
 }
 
 export interface LlmConnectionTestResult {
-  ok: boolean
-  detail: string
-  models?: string[]
+  ok: boolean;
+  detail: string;
+  models?: string[];
 }
 
 export interface AgentConversation {
-  id: string
-  agent_id: string
-  channel: string
-  title: string | null
-  created_at: string
-  updated_at: string
+  id: string;
+  agent_id: string;
+  channel: string;
+  title: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface AgentMessage {
-  id: string
-  role: 'system' | 'user' | 'assistant' | 'tool'
-  ordinal: number
-  content: string | null
-  tool_calls: Array<{ id: string; name: string; arguments: Record<string, unknown> }> | null
-  tool_result: { tool_call_id?: string; name?: string; data?: unknown; ok?: boolean } | null
-  citations: unknown[] | null
-  input_tokens: number | null
-  output_tokens: number | null
-  created_at: string
+  id: string;
+  role: "system" | "user" | "assistant" | "tool";
+  ordinal: number;
+  content: string | null;
+  tool_calls: Array<{
+    id: string;
+    name: string;
+    arguments: Record<string, unknown>;
+  }> | null;
+  tool_result: {
+    tool_call_id?: string;
+    name?: string;
+    data?: unknown;
+    ok?: boolean;
+  } | null;
+  citations: unknown[] | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  created_at: string;
 }
 
 export interface AgentToolHandle {
-  server: string
-  name: string
-  description: string
-  is_proposal: boolean
-  enabled: boolean
+  server: string;
+  name: string;
+  description: string;
+  is_proposal: boolean;
+  enabled: boolean;
 }
 
 export interface KnowledgeDoc {
-  id: string
-  agent_id: string
-  title: string
-  source: string | null
-  mime: string
-  size_bytes: number
-  status: 'pending' | 'processing' | 'ready' | 'failed'
-  error: string | null
-  chunk_count: number
-  pinned: boolean
-  created_at: string
-  updated_at: string
+  id: string;
+  agent_id: string;
+  title: string;
+  source: string | null;
+  mime: string;
+  size_bytes: number;
+  status: "pending" | "processing" | "ready" | "failed";
+  error: string | null;
+  chunk_count: number;
+  pinned: boolean;
+  created_at: string;
+  updated_at: string;
 }
 
 export const agents = {
   info: async () => {
-    const { data } = await api.get('/agents/info')
+    const { data } = await api.get("/agents/info");
     return data as {
-      enabled: boolean
-      providers: string[]
-      embedding_dim: number
-      default_top_n: number
-      default_similarity_threshold: number
-      extra_mcp_servers_configured: boolean
-    }
+      enabled: boolean;
+      providers: string[];
+      embedding_dim: number;
+      default_top_n: number;
+      default_similarity_threshold: number;
+      extra_mcp_servers_configured: boolean;
+    };
   },
   list: async (includeArchived = false): Promise<Agent[]> => {
-    const { data } = await api.get('/agents', { params: { include_archived: includeArchived } })
-    return data
+    const { data } = await api.get("/agents", {
+      params: { include_archived: includeArchived },
+    });
+    return data;
   },
   // Default agent for the global slide-over chat panel. Returns the
   // user-flagged default; falls back to the most recent agent.
   // Throws 404 if the user has no agents at all.
   getDefault: async (): Promise<Agent> => {
-    const { data } = await api.get('/agents/default')
-    return data
+    const { data } = await api.get("/agents/default");
+    return data;
   },
   get: async (id: string): Promise<Agent> => {
-    const { data } = await api.get(`/agents/${id}`)
-    return data
+    const { data } = await api.get(`/agents/${id}`);
+    return data;
   },
-  create: async (payload: Partial<Agent> & { name: string }): Promise<Agent> => {
-    const { data } = await api.post('/agents', payload)
-    return data
+  create: async (
+    payload: Partial<Agent> & { name: string },
+  ): Promise<Agent> => {
+    const { data } = await api.post("/agents", payload);
+    return data;
   },
   update: async (id: string, payload: Partial<Agent>): Promise<Agent> => {
-    const { data } = await api.patch(`/agents/${id}`, payload)
-    return data
+    const { data } = await api.patch(`/agents/${id}`, payload);
+    return data;
   },
   remove: async (id: string): Promise<void> => {
-    await api.delete(`/agents/${id}`)
+    await api.delete(`/agents/${id}`);
   },
-  tools: async (id: string): Promise<{ servers: { name: string }[]; tools: AgentToolHandle[] }> => {
-    const { data } = await api.get(`/agents/${id}/tools`)
-    return data
+  tools: async (
+    id: string,
+  ): Promise<{ servers: { name: string }[]; tools: AgentToolHandle[] }> => {
+    const { data } = await api.get(`/agents/${id}/tools`);
+    return data;
   },
-  setTools: async (id: string, items: { server: string; tool_name: string; enabled: boolean }[]): Promise<void> => {
-    await api.put(`/agents/${id}/tools`, items)
+  setTools: async (
+    id: string,
+    items: { server: string; tool_name: string; enabled: boolean }[],
+  ): Promise<void> => {
+    await api.put(`/agents/${id}/tools`, items);
   },
   knowledge: {
-    list: async (id: string): Promise<{ items: KnowledgeDoc[]; total: number }> => {
-      const { data } = await api.get(`/agents/${id}/knowledge`)
-      return data
+    list: async (
+      id: string,
+    ): Promise<{ items: KnowledgeDoc[]; total: number }> => {
+      const { data } = await api.get(`/agents/${id}/knowledge`);
+      return data;
     },
-    upload: async (id: string, file: File, pinned = false): Promise<KnowledgeDoc> => {
-      const fd = new FormData()
-      fd.append('file', file)
-      fd.append('pinned', String(pinned))
-      const { data } = await api.post(`/agents/${id}/knowledge`, fd)
-      return data
+    upload: async (
+      id: string,
+      file: File,
+      pinned = false,
+    ): Promise<KnowledgeDoc> => {
+      const fd = new FormData();
+      fd.append("file", file);
+      fd.append("pinned", String(pinned));
+      const { data } = await api.post(`/agents/${id}/knowledge`, fd);
+      return data;
     },
-    pin: async (agentId: string, docId: string, pinned: boolean): Promise<KnowledgeDoc> => {
-      const { data } = await api.patch(`/agents/${agentId}/knowledge/${docId}/pin`, null, {
-        params: { pinned },
-      })
-      return data
+    pin: async (
+      agentId: string,
+      docId: string,
+      pinned: boolean,
+    ): Promise<KnowledgeDoc> => {
+      const { data } = await api.patch(
+        `/agents/${agentId}/knowledge/${docId}/pin`,
+        null,
+        {
+          params: { pinned },
+        },
+      );
+      return data;
     },
     remove: async (agentId: string, docId: string): Promise<void> => {
-      await api.delete(`/agents/${agentId}/knowledge/${docId}`)
+      await api.delete(`/agents/${agentId}/knowledge/${docId}`);
     },
   },
   conversations: {
-    list: async (agentId?: string, limit = 50): Promise<AgentConversation[]> => {
-      const { data } = await api.get('/agents/conversations', { params: { agent_id: agentId, limit } })
-      return data
+    list: async (
+      agentId?: string,
+      limit = 50,
+    ): Promise<AgentConversation[]> => {
+      const { data } = await api.get("/agents/conversations", {
+        params: { agent_id: agentId, limit },
+      });
+      return data;
     },
     get: async (id: string): Promise<AgentConversation> => {
-      const { data } = await api.get(`/agents/conversations/${id}`)
-      return data
+      const { data } = await api.get(`/agents/conversations/${id}`);
+      return data;
     },
     messages: async (id: string, limit = 200): Promise<AgentMessage[]> => {
-      const { data } = await api.get(`/agents/conversations/${id}/messages`, { params: { limit } })
-      return data
+      const { data } = await api.get(`/agents/conversations/${id}/messages`, {
+        params: { limit },
+      });
+      return data;
     },
     rename: async (id: string, title: string): Promise<AgentConversation> => {
-      const { data } = await api.patch(`/agents/conversations/${id}`, { title })
-      return data
+      const { data } = await api.patch(`/agents/conversations/${id}`, {
+        title,
+      });
+      return data;
     },
     generateTitle: async (id: string): Promise<AgentConversation> => {
-      const { data } = await api.post(`/agents/conversations/${id}/generate-title`)
-      return data
+      const { data } = await api.post(
+        `/agents/conversations/${id}/generate-title`,
+      );
+      return data;
     },
     remove: async (id: string): Promise<void> => {
-      await api.delete(`/agents/conversations/${id}`)
+      await api.delete(`/agents/conversations/${id}`);
     },
   },
   // Streaming chat endpoint — caller handles the SSE response themselves
@@ -1185,29 +1561,32 @@ export const agents = {
 
   connections: {
     list: async (): Promise<LlmConnection[]> => {
-      const { data } = await api.get('/agents/connections')
-      return data
+      const { data } = await api.get("/agents/connections");
+      return data;
     },
     get: async (id: string): Promise<LlmConnection> => {
-      const { data } = await api.get(`/agents/connections/${id}`)
-      return data
+      const { data } = await api.get(`/agents/connections/${id}`);
+      return data;
     },
     create: async (payload: LlmConnectionPayload): Promise<LlmConnection> => {
-      const { data } = await api.post('/agents/connections', payload)
-      return data
+      const { data } = await api.post("/agents/connections", payload);
+      return data;
     },
-    update: async (id: string, payload: Partial<LlmConnectionPayload>): Promise<LlmConnection> => {
-      const { data } = await api.patch(`/agents/connections/${id}`, payload)
-      return data
+    update: async (
+      id: string,
+      payload: Partial<LlmConnectionPayload>,
+    ): Promise<LlmConnection> => {
+      const { data } = await api.patch(`/agents/connections/${id}`, payload);
+      return data;
     },
     remove: async (id: string): Promise<void> => {
-      await api.delete(`/agents/connections/${id}`)
+      await api.delete(`/agents/connections/${id}`);
     },
     test: async (id: string): Promise<LlmConnectionTestResult> => {
-      const { data } = await api.post(`/agents/connections/${id}/test`)
-      return data
+      const { data } = await api.post(`/agents/connections/${id}/test`);
+      return data;
     },
   },
-}
+};
 
-export default api
+export default api;

--- a/frontend/src/pages/rules.tsx
+++ b/frontend/src/pages/rules.tsx
@@ -1,234 +1,294 @@
-import { useState, useMemo } from 'react'
-import { getAccountName } from '@/lib/account-utils'
-import { useTranslation } from 'react-i18next'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { categories as categoriesApi, categoryGroups as categoryGroupsApi, rules as rulesApi, accounts as accountsApi, payees as payeesApi } from '@/lib/api'
-import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
-import { toast } from 'sonner'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+import { useState, useMemo } from "react";
+import { getAccountName } from "@/lib/account-utils";
+import { useTranslation } from "react-i18next";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  categories as categoriesApi,
+  categoryGroups as categoryGroupsApi,
+  rules as rulesApi,
+  accounts as accountsApi,
+  payees as payeesApi,
+} from "@/lib/api";
+import { invalidateFinancialQueries } from "@/lib/invalidate-queries";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogFooter,
-} from '@/components/ui/dialog'
-import type { Category, CategoryGroup, Payee, Rule, RuleCondition, RuleAction } from '@/types'
-import { Trash2, Plus, RefreshCw, X, Package, Check, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react'
-import { cn } from '@/lib/utils'
-import { CategorySelect } from '@/components/category-select'
-import { PageHeader } from '@/components/page-header'
+} from "@/components/ui/dialog";
+import type {
+  Category,
+  CategoryGroup,
+  Payee,
+  Rule,
+  RuleCondition,
+  RuleAction,
+} from "@/types";
+import {
+  Trash2,
+  Plus,
+  RefreshCw,
+  X,
+  Package,
+  Check,
+  ArrowUpDown,
+  ArrowUp,
+  ArrowDown,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { CategorySelect } from "@/components/category-select";
+import { PageHeader } from "@/components/page-header";
 
 function SectionCard({ children }: { children: React.ReactNode }) {
   return (
     <div className="bg-card rounded-xl border border-border shadow-sm overflow-hidden">
       {children}
     </div>
-  )
+  );
 }
 
-function SectionHeader({ title, action }: { title: string; action?: React.ReactNode }) {
+function SectionHeader({
+  title,
+  action,
+}: {
+  title: string;
+  action?: React.ReactNode;
+}) {
   return (
     <div className="px-4 sm:px-5 py-4 border-b border-border flex flex-wrap items-center justify-between gap-2">
       <p className="text-sm font-semibold text-foreground">{title}</p>
       {action}
     </div>
-  )
+  );
 }
 
 const CONDITION_FIELDS = [
-  { value: 'description', label: 'rules.fieldDescription' },
-  { value: 'notes', label: 'rules.fieldNotes' },
-  { value: 'amount', label: 'rules.fieldAmount' },
-  { value: 'type', label: 'rules.fieldType' },
-  { value: 'account_id', label: 'rules.fieldAccount' },
-  { value: 'payee_id', label: 'rules.fieldPayee' },
-  { value: 'date', label: 'rules.fieldDate' },
-] as const
+  { value: "description", label: "rules.fieldDescription" },
+  { value: "notes", label: "rules.fieldNotes" },
+  { value: "amount", label: "rules.fieldAmount" },
+  { value: "type", label: "rules.fieldType" },
+  { value: "account_id", label: "rules.fieldAccount" },
+  { value: "payee_id", label: "rules.fieldPayee" },
+  { value: "date", label: "rules.fieldDate" },
+] as const;
 
 const STRING_OPS = [
-  { value: 'contains', label: 'rules.opContains' },
-  { value: 'not_contains', label: 'rules.opNotContains' },
-  { value: 'equals', label: 'rules.opEquals' },
-  { value: 'not_equals', label: 'rules.opNotEquals' },
-  { value: 'starts_with', label: 'rules.opStartsWith' },
-  { value: 'ends_with', label: 'rules.opEndsWith' },
-  { value: 'regex', label: 'rules.opRegex' },
-]
+  { value: "contains", label: "rules.opContains" },
+  { value: "not_contains", label: "rules.opNotContains" },
+  { value: "equals", label: "rules.opEquals" },
+  { value: "not_equals", label: "rules.opNotEquals" },
+  { value: "starts_with", label: "rules.opStartsWith" },
+  { value: "ends_with", label: "rules.opEndsWith" },
+  { value: "regex", label: "rules.opRegex" },
+];
 
 const NUMERIC_OPS = [
-  { value: 'equals', label: '=' },
-  { value: 'gt', label: '>' },
-  { value: 'gte', label: '>=' },
-  { value: 'lt', label: '<' },
-  { value: 'lte', label: '<=' },
-]
+  { value: "equals", label: "=" },
+  { value: "gt", label: ">" },
+  { value: "gte", label: ">=" },
+  { value: "lt", label: "<" },
+  { value: "lte", label: "<=" },
+];
 
 function getOpsForField(field: string) {
-  if (field === 'amount' || field === 'date') return NUMERIC_OPS
-  if (field === 'type') return [{ value: 'equals', label: 'rules.opIs' }]
-  if (field === 'payee_id' || field === 'account_id') return [
-    { value: 'equals', label: 'rules.opIs' },
-    { value: 'not_equals', label: 'rules.opIsNot' },
-  ]
-  return STRING_OPS
+  if (field === "amount" || field === "date") return NUMERIC_OPS;
+  if (field === "type") return [{ value: "equals", label: "rules.opIs" }];
+  if (field === "payee_id" || field === "account_id")
+    return [
+      { value: "equals", label: "rules.opIs" },
+      { value: "not_equals", label: "rules.opIsNot" },
+    ];
+  return STRING_OPS;
 }
 
-function conditionSummary(conditions: RuleCondition[], conditionsOp: string, t: (key: string) => string, payeesList: Payee[]): string {
+function conditionSummary(
+  conditions: RuleCondition[],
+  conditionsOp: string,
+  t: (key: string) => string,
+  payeesList: Payee[],
+): string {
   const fieldLabel = (f: string) => {
-    const key = CONDITION_FIELDS.find(x => x.value === f)?.label
-    return key ? t(key) : f
-  }
+    const key = CONDITION_FIELDS.find((x) => x.value === f)?.label;
+    return key ? t(key) : f;
+  };
   const opLabel = (f: string, op: string) => {
-    const key = getOpsForField(f).find(x => x.value === op)?.label
-    return key ? t(key) : op
-  }
+    const key = getOpsForField(f).find((x) => x.value === op)?.label;
+    return key ? t(key) : op;
+  };
   const valueLabel = (c: RuleCondition) => {
-    if (c.field === 'payee_id') {
-      const p = payeesList.find(p => p.id === c.value)
-      return p ? p.name : String(c.value)
+    if (c.field === "payee_id") {
+      const p = payeesList.find((p) => p.id === c.value);
+      return p ? p.name : String(c.value);
     }
-    return String(c.value)
-  }
-  const parts = conditions.map(c => `${fieldLabel(c.field)} ${opLabel(c.field, c.op)} "${valueLabel(c)}"`)
-  return parts.join(` ${conditionsOp === 'or' ? t('rules.orOp') : t('rules.andOp')} `) || t('rules.noConditions')
+    return String(c.value);
+  };
+  const parts = conditions.map(
+    (c) =>
+      `${fieldLabel(c.field)} ${opLabel(c.field, c.op)} "${valueLabel(c)}"`,
+  );
+  return (
+    parts.join(
+      ` ${conditionsOp === "or" ? t("rules.orOp") : t("rules.andOp")} `,
+    ) || t("rules.noConditions")
+  );
 }
 
-function actionSummary(actions: RuleAction[], categories: Category[], payeesList: Payee[], t: (key: string) => string): string {
-  return actions.map(a => {
-    if (a.op === 'set_category') {
-      const cat = categories.find(c => c.id === a.value)
-      return cat ? `→ ${cat.name}` : `→ ${t('transactions.category')}`
-    }
-    if (a.op === 'set_payee') {
-      const p = payeesList.find(p => p.id === a.value)
-      return p ? `→ ${t('payees.payee')}: ${p.name}` : `→ ${t('payees.payee')}`
-    }
-    if (a.op === 'append_notes') return `→ ${t('rules.fieldNotes')}: ${a.value}`
-    return a.op
-  }).join('  ') || t('rules.noActions')
+function actionSummary(
+  actions: RuleAction[],
+  categories: Category[],
+  payeesList: Payee[],
+  t: (key: string) => string,
+): string {
+  return (
+    actions
+      .map((a) => {
+        if (a.op === "set_category") {
+          const cat = categories.find((c) => c.id === a.value);
+          return cat ? `→ ${cat.name}` : `→ ${t("transactions.category")}`;
+        }
+        if (a.op === "set_payee") {
+          const p = payeesList.find((p) => p.id === a.value);
+          return p
+            ? `→ ${t("payees.payee")}: ${p.name}`
+            : `→ ${t("payees.payee")}`;
+        }
+        if (a.op === "append_notes")
+          return `→ ${t("rules.fieldNotes")}: ${a.value}`;
+        if (a.op === "ignore") return "→ Ignorar";
+        return a.op;
+      })
+      .join("  ") || t("rules.noActions")
+  );
 }
 
 export default function RulesPage() {
-  const { t } = useTranslation()
-  const queryClient = useQueryClient()
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [packsDialogOpen, setPacksDialogOpen] = useState(false)
-  const [editing, setEditing] = useState<Rule | null>(null)
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [packsDialogOpen, setPacksDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<Rule | null>(null);
 
   const { data: rulesList } = useQuery({
-    queryKey: ['rules'],
+    queryKey: ["rules"],
     queryFn: rulesApi.list,
-  })
+  });
 
   const { data: categoriesList } = useQuery({
-    queryKey: ['categories'],
+    queryKey: ["categories"],
     queryFn: categoriesApi.list,
-  })
+  });
 
   const { data: categoryGroupsList } = useQuery({
-    queryKey: ['categoryGroups'],
+    queryKey: ["categoryGroups"],
     queryFn: categoryGroupsApi.list,
-  })
+  });
 
   const { data: accountsList } = useQuery({
-    queryKey: ['accounts'],
+    queryKey: ["accounts"],
     queryFn: () => accountsApi.list(),
-  })
+  });
 
   const { data: payeesList } = useQuery({
-    queryKey: ['payees'],
+    queryKey: ["payees"],
     queryFn: payeesApi.list,
-  })
+  });
 
   const createMutation = useMutation({
-    mutationFn: (data: Omit<Rule, 'id' | 'user_id'>) => rulesApi.create(data),
+    mutationFn: (data: Omit<Rule, "id" | "user_id">) => rulesApi.create(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['rules'] })
-      queryClient.invalidateQueries({ queryKey: ['rule-packs'] })
-      setDialogOpen(false)
-      toast.success(t('rules.created'))
+      queryClient.invalidateQueries({ queryKey: ["rules"] });
+      queryClient.invalidateQueries({ queryKey: ["rule-packs"] });
+      setDialogOpen(false);
+      toast.success(t("rules.created"));
     },
     onError: (error: unknown) => {
-      const err = error as { response?: { status?: number } }
+      const err = error as { response?: { status?: number } };
       if (err?.response?.status === 409) {
-        toast.error(t('rules.duplicateName'))
+        toast.error(t("rules.duplicateName"));
       } else {
-        toast.error(t('common.error'))
+        toast.error(t("common.error"));
       }
     },
-  })
+  });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, ...data }: Partial<Rule> & { id: string }) => rulesApi.update(id, data),
+    mutationFn: ({ id, ...data }: Partial<Rule> & { id: string }) =>
+      rulesApi.update(id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['rules'] })
-      queryClient.invalidateQueries({ queryKey: ['rule-packs'] })
-      setDialogOpen(false)
-      setEditing(null)
-      toast.success(t('rules.updated'))
+      queryClient.invalidateQueries({ queryKey: ["rules"] });
+      queryClient.invalidateQueries({ queryKey: ["rule-packs"] });
+      setDialogOpen(false);
+      setEditing(null);
+      toast.success(t("rules.updated"));
     },
     onError: (error: unknown) => {
-      const err = error as { response?: { status?: number } }
+      const err = error as { response?: { status?: number } };
       if (err?.response?.status === 409) {
-        toast.error(t('rules.duplicateName'))
+        toast.error(t("rules.duplicateName"));
       } else {
-        toast.error(t('common.error'))
+        toast.error(t("common.error"));
       }
     },
-  })
+  });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => rulesApi.delete(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['rules'] })
-      queryClient.invalidateQueries({ queryKey: ['rule-packs'] })
-      toast.success(t('rules.deleted'))
+      queryClient.invalidateQueries({ queryKey: ["rules"] });
+      queryClient.invalidateQueries({ queryKey: ["rule-packs"] });
+      toast.success(t("rules.deleted"));
     },
-  })
+  });
 
   const applyAllMutation = useMutation({
     mutationFn: () => rulesApi.applyAll(),
     onSuccess: (data) => {
-      invalidateFinancialQueries(queryClient)
-      toast.success(t('rules.applied', { count: data.applied }))
+      invalidateFinancialQueries(queryClient);
+      toast.success(t("rules.applied", { count: data.applied }));
     },
-    onError: () => toast.error(t('common.error')),
-  })
+    onError: () => toast.error(t("common.error")),
+  });
 
-  const categories = categoriesList ?? []
-  const payees = payeesList ?? []
+  const categories = categoriesList ?? [];
+  const payees = payeesList ?? [];
 
-  const [sortBy, setSortBy] = useState<'priority' | 'name' | 'category'>('priority')
-  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc')
+  const [sortBy, setSortBy] = useState<"priority" | "name" | "category">(
+    "priority",
+  );
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
 
   const sortedRules = useMemo(() => {
-    const list = [...(rulesList ?? [])]
-    const dir = sortDir === 'asc' ? 1 : -1
-    if (sortBy === 'name') {
-      return list.sort((a, b) => dir * a.name.localeCompare(b.name))
+    const list = [...(rulesList ?? [])];
+    const dir = sortDir === "asc" ? 1 : -1;
+    if (sortBy === "name") {
+      return list.sort((a, b) => dir * a.name.localeCompare(b.name));
     }
-    if (sortBy === 'category') {
+    if (sortBy === "category") {
       const getCategoryName = (rule: Rule) => {
-        const action = rule.actions.find(a => a.op === 'set_category')
-        if (!action) return ''
-        const cat = categories.find(c => c.id === action.value)
-        return cat?.name ?? ''
-      }
-      return list.sort((a, b) => dir * getCategoryName(a).localeCompare(getCategoryName(b)))
+        const action = rule.actions.find((a) => a.op === "set_category");
+        if (!action) return "";
+        const cat = categories.find((c) => c.id === action.value);
+        return cat?.name ?? "";
+      };
+      return list.sort(
+        (a, b) => dir * getCategoryName(a).localeCompare(getCategoryName(b)),
+      );
     }
-    return list.sort((a, b) => dir * (a.priority - b.priority))
-  }, [rulesList, categories, sortBy, sortDir])
+    return list.sort((a, b) => dir * (a.priority - b.priority));
+  }, [rulesList, categories, sortBy, sortDir]);
 
   return (
     <div>
-      <PageHeader section={t('rules.section')} title={t('nav.rules')} />
+      <PageHeader section={t("rules.section")} title={t("nav.rules")} />
 
       <SectionCard>
         <SectionHeader
-          title={t('rules.sectionTitle')}
+          title={t("rules.sectionTitle")}
           action={
             <div className="flex gap-2">
               <Button
@@ -238,7 +298,7 @@ export default function RulesPage() {
                 onClick={() => setPacksDialogOpen(true)}
               >
                 <Package size={12} />
-                <span className="hidden sm:inline">{t('rules.packs')}</span>
+                <span className="hidden sm:inline">{t("rules.packs")}</span>
               </Button>
               <Button
                 variant="outline"
@@ -248,34 +308,56 @@ export default function RulesPage() {
                 disabled={applyAllMutation.isPending}
               >
                 <RefreshCw size={12} />
-                <span className="hidden sm:inline">{t('rules.reapplyAll')}</span>
+                <span className="hidden sm:inline">
+                  {t("rules.reapplyAll")}
+                </span>
               </Button>
-              <Button size="sm" className="gap-1.5 h-8" onClick={() => { setEditing(null); setDialogOpen(true) }}>
-                <Plus size={13} /> <span className="hidden sm:inline">{t('rules.add')}</span>
+              <Button
+                size="sm"
+                className="gap-1.5 h-8"
+                onClick={() => {
+                  setEditing(null);
+                  setDialogOpen(true);
+                }}
+              >
+                <Plus size={13} />{" "}
+                <span className="hidden sm:inline">{t("rules.add")}</span>
               </Button>
             </div>
           }
         />
         <div className="px-4 sm:px-5 py-2 bg-muted/50 border-b border-border flex items-center gap-2">
-          <span className="text-xs text-muted-foreground">{t('rules.sortLabel')}</span>
-          {(['priority', 'name', 'category'] as const).map(opt => (
+          <span className="text-xs text-muted-foreground">
+            {t("rules.sortLabel")}
+          </span>
+          {(["priority", "name", "category"] as const).map((opt) => (
             <button
               key={opt}
               onClick={() => {
-                if (sortBy === opt) setSortDir(d => d === 'asc' ? 'desc' : 'asc')
-                else { setSortBy(opt); setSortDir('asc') }
+                if (sortBy === opt)
+                  setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+                else {
+                  setSortBy(opt);
+                  setSortDir("asc");
+                }
               }}
               className={cn(
-                'flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium transition-colors',
+                "flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium transition-colors",
                 sortBy === opt
-                  ? 'bg-background border border-border text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-background/60'
+                  ? "bg-background border border-border text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground hover:bg-background/60",
               )}
             >
               {t(`rules.sortBy_${opt}`)}
-              {sortBy === opt
-                ? sortDir === 'asc' ? <ArrowUp size={11} /> : <ArrowDown size={11} />
-                : <ArrowUpDown size={11} className="opacity-30" />}
+              {sortBy === opt ? (
+                sortDir === "asc" ? (
+                  <ArrowUp size={11} />
+                ) : (
+                  <ArrowDown size={11} />
+                )
+              ) : (
+                <ArrowUpDown size={11} className="opacity-30" />
+              )}
             </button>
           ))}
         </div>
@@ -285,15 +367,20 @@ export default function RulesPage() {
               <div
                 key={rule.id}
                 className="px-4 sm:px-5 py-3 hover:bg-muted transition-colors cursor-pointer"
-                onClick={() => { setEditing(rule); setDialogOpen(true) }}
+                onClick={() => {
+                  setEditing(rule);
+                  setDialogOpen(true);
+                }}
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1">
-                      <p className="text-sm font-semibold text-foreground">{rule.name}</p>
+                      <p className="text-sm font-semibold text-foreground">
+                        {rule.name}
+                      </p>
                       {!rule.is_active && (
                         <span className="text-[10px] font-semibold bg-muted text-muted-foreground px-1.5 py-0 rounded-full">
-                          {t('rules.inactive')}
+                          {t("rules.inactive")}
                         </span>
                       )}
                       <span className="text-[10px] font-semibold bg-muted text-muted-foreground px-1.5 py-0 rounded-full">
@@ -301,7 +388,12 @@ export default function RulesPage() {
                       </span>
                     </div>
                     <p className="text-xs text-muted-foreground font-mono truncate">
-                      {conditionSummary(rule.conditions, rule.conditions_op, t, payees)}
+                      {conditionSummary(
+                        rule.conditions,
+                        rule.conditions_op,
+                        t,
+                        payees,
+                      )}
                     </p>
                     <p className="text-xs text-emerald-600 font-medium mt-0.5">
                       {actionSummary(rule.actions, categories, payees, t)}
@@ -310,7 +402,10 @@ export default function RulesPage() {
                   <div className="flex items-center gap-1 shrink-0">
                     <button
                       className="p-1.5 rounded-md text-muted-foreground hover:text-rose-500 hover:bg-rose-50 transition-colors"
-                      onClick={(e) => { e.stopPropagation(); deleteMutation.mutate(rule.id) }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        deleteMutation.mutate(rule.id);
+                      }}
                       disabled={deleteMutation.isPending}
                     >
                       <Trash2 size={13} />
@@ -321,7 +416,9 @@ export default function RulesPage() {
             ))}
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground text-center py-10">{t('rules.empty')}</p>
+          <p className="text-sm text-muted-foreground text-center py-10">
+            {t("rules.empty")}
+          </p>
         )}
       </SectionCard>
 
@@ -331,9 +428,12 @@ export default function RulesPage() {
       />
 
       <RuleDialog
-        key={editing?.id ?? 'new'}
+        key={editing?.id ?? "new"}
         open={dialogOpen}
-        onClose={() => { setDialogOpen(false); setEditing(null) }}
+        onClose={() => {
+          setDialogOpen(false);
+          setEditing(null);
+        }}
         rule={editing}
         categories={categories}
         categoryGroups={categoryGroupsList ?? []}
@@ -341,61 +441,68 @@ export default function RulesPage() {
         payees={payees}
         onSave={(data) => {
           if (editing) {
-            updateMutation.mutate({ id: editing.id, ...data })
+            updateMutation.mutate({ id: editing.id, ...data });
           } else {
-            createMutation.mutate(data as Omit<Rule, 'id' | 'user_id'>)
+            createMutation.mutate(data as Omit<Rule, "id" | "user_id">);
           }
         }}
         loading={createMutation.isPending || updateMutation.isPending}
       />
     </div>
-  )
+  );
 }
 
-function RulePacksDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const { t } = useTranslation()
-  const queryClient = useQueryClient()
-  const [createMissingCategories, setCreateMissingCategories] = useState(true)
+function RulePacksDialog({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [createMissingCategories, setCreateMissingCategories] = useState(true);
 
   const { data: rulePacks } = useQuery({
-    queryKey: ['rule-packs'],
+    queryKey: ["rule-packs"],
     queryFn: rulesApi.packs,
     enabled: open,
-  })
+  });
 
   const installPackMutation = useMutation({
-    mutationFn: (code: string) => rulesApi.installPack(code, createMissingCategories),
+    mutationFn: (code: string) =>
+      rulesApi.installPack(code, createMissingCategories),
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['rules'] })
-      queryClient.invalidateQueries({ queryKey: ['rule-packs'] })
+      queryClient.invalidateQueries({ queryKey: ["rules"] });
+      queryClient.invalidateQueries({ queryKey: ["rule-packs"] });
       if (data.categories_created > 0) {
-        queryClient.invalidateQueries({ queryKey: ['categories'] })
+        queryClient.invalidateQueries({ queryKey: ["categories"] });
       }
       if (data.installed === 0) {
         if (data.unresolved > 0) {
-          toast.error(t('rules.packMissingCategories'))
+          toast.error(t("rules.packMissingCategories"));
         } else {
-          toast.info(t('rules.packAlreadyInstalled'))
+          toast.info(t("rules.packAlreadyInstalled"));
         }
       } else if (data.categories_created > 0) {
         toast.success(
-          t('rules.packInstalledWithCategories', {
+          t("rules.packInstalledWithCategories", {
             rules: data.installed,
             categories: data.categories_created,
           }),
-        )
+        );
       } else {
-        toast.success(t('rules.packInstalled', { count: data.installed }))
+        toast.success(t("rules.packInstalled", { count: data.installed }));
       }
     },
-    onError: () => toast.error(t('common.error')),
-  })
+    onError: () => toast.error(t("common.error")),
+  });
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>{t('rules.packs')}</DialogTitle>
+          <DialogTitle>{t("rules.packs")}</DialogTitle>
         </DialogHeader>
         <div className="flex items-center gap-2 px-1">
           <input
@@ -409,7 +516,7 @@ function RulePacksDialog({ open, onClose }: { open: boolean; onClose: () => void
             htmlFor="create-missing-categories"
             className="text-xs text-muted-foreground cursor-pointer"
           >
-            {t('rules.createMissingCategories')}
+            {t("rules.createMissingCategories")}
           </Label>
         </div>
         <div className="space-y-2">
@@ -420,15 +527,17 @@ function RulePacksDialog({ open, onClose }: { open: boolean; onClose: () => void
             >
               <span className="text-2xl">{pack.flag}</span>
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-semibold text-foreground">{pack.name}</p>
+                <p className="text-sm font-semibold text-foreground">
+                  {pack.name}
+                </p>
                 <p className="text-xs text-muted-foreground">
-                  {t('rules.packRuleCount', { count: pack.rule_count })}
+                  {t("rules.packRuleCount", { count: pack.rule_count })}
                 </p>
               </div>
               {pack.installed ? (
                 <span className="flex items-center gap-1 text-xs font-medium text-emerald-600">
                   <Check size={14} />
-                  {t('rules.installed')}
+                  {t("rules.installed")}
                 </span>
               ) : (
                 <Button
@@ -439,7 +548,7 @@ function RulePacksDialog({ open, onClose }: { open: boolean; onClose: () => void
                   disabled={installPackMutation.isPending}
                 >
                   <Package size={11} />
-                  {t('rules.installPack')}
+                  {t("rules.installPack")}
                 </Button>
               )}
             </div>
@@ -447,100 +556,150 @@ function RulePacksDialog({ open, onClose }: { open: boolean; onClose: () => void
         </div>
       </DialogContent>
     </Dialog>
-  )
+  );
 }
 
 function RuleDialog({
-  open, onClose, rule, categories, categoryGroups, accounts, payees, onSave, loading,
+  open,
+  onClose,
+  rule,
+  categories,
+  categoryGroups,
+  accounts,
+  payees,
+  onSave,
+  loading,
 }: {
-  open: boolean
-  onClose: () => void
-  rule: Rule | null
-  categories: Category[]
-  categoryGroups: CategoryGroup[]
-  accounts: { id: string; name: string }[]
-  payees: Payee[]
-  onSave: (data: Partial<Rule>) => void
-  loading: boolean
+  open: boolean;
+  onClose: () => void;
+  rule: Rule | null;
+  categories: Category[];
+  categoryGroups: CategoryGroup[];
+  accounts: { id: string; name: string }[];
+  payees: Payee[];
+  onSave: (data: Partial<Rule>) => void;
+  loading: boolean;
 }) {
-  const { t } = useTranslation()
-  const [name, setName] = useState(rule?.name ?? '')
-  const [conditionsOp, setConditionsOp] = useState<'and' | 'or'>(rule?.conditions_op ?? 'and')
+  const { t } = useTranslation();
+  const [name, setName] = useState(rule?.name ?? "");
+  const [conditionsOp, setConditionsOp] = useState<"and" | "or">(
+    rule?.conditions_op ?? "and",
+  );
   const [conditions, setConditions] = useState<RuleCondition[]>(
-    rule?.conditions?.length ? rule.conditions as RuleCondition[] : [{ field: 'description', op: 'contains', value: '' }]
-  )
+    rule?.conditions?.length
+      ? (rule.conditions as RuleCondition[])
+      : [{ field: "description", op: "contains", value: "" }],
+  );
   const [actions, setActions] = useState<RuleAction[]>(
-    rule?.actions?.length ? rule.actions as RuleAction[] : [{ op: 'set_category', value: '' }]
-  )
-  const [priority, setPriority] = useState(rule?.priority ?? 0)
-  const [isActive, setIsActive] = useState(rule?.is_active ?? true)
+    rule?.actions?.length
+      ? (rule.actions as RuleAction[])
+      : [{ op: "set_category", value: "" }],
+  );
+  const [priority, setPriority] = useState(rule?.priority ?? 0);
+  const [isActive, setIsActive] = useState(rule?.is_active ?? true);
 
-  const selectClass = 'border border-border rounded-lg px-2 py-1.5 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary'
+  const selectClass =
+    "border border-border rounded-lg px-2 py-1.5 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary";
 
-  function updateCondition(i: number, field: keyof RuleCondition, val: string | number) {
-    setConditions(prev => prev.map((c, idx) => idx === i ? { ...c, [field]: val } : c))
+  function updateCondition(
+    i: number,
+    field: keyof RuleCondition,
+    val: string | number,
+  ) {
+    setConditions((prev) =>
+      prev.map((c, idx) => (idx === i ? { ...c, [field]: val } : c)),
+    );
   }
 
   function removeCondition(i: number) {
-    setConditions(prev => prev.filter((_, idx) => idx !== i))
+    setConditions((prev) => prev.filter((_, idx) => idx !== i));
   }
 
   function addCondition() {
-    setConditions(prev => [...prev, { field: 'description', op: 'contains', value: '' }])
+    setConditions((prev) => [
+      ...prev,
+      { field: "description", op: "contains", value: "" },
+    ]);
   }
 
   function updateAction(i: number, field: keyof RuleAction, val: string) {
-    setActions(prev => prev.map((a, idx) => idx === i ? { ...a, [field]: val } : a))
+    setActions((prev) =>
+      prev.map((a, idx) => (idx === i ? { ...a, [field]: val } : a)),
+    );
   }
 
   function removeAction(i: number) {
-    setActions(prev => prev.filter((_, idx) => idx !== i))
+    setActions((prev) => prev.filter((_, idx) => idx !== i));
   }
 
   function addAction() {
-    setActions(prev => [...prev, { op: 'set_category', value: '' }])
+    setActions((prev) => [...prev, { op: "set_category", value: "" }]);
   }
 
   function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    onSave({ name, conditions_op: conditionsOp, conditions, actions, priority, is_active: isActive })
+    e.preventDefault();
+    onSave({
+      name,
+      conditions_op: conditionsOp,
+      conditions,
+      actions,
+      priority,
+      is_active: isActive,
+    });
   }
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto overflow-x-hidden">
         <DialogHeader>
-          <DialogTitle>{rule ? t('rules.editRule') : t('rules.newRule')}</DialogTitle>
+          <DialogTitle>
+            {rule ? t("rules.editRule") : t("rules.newRule")}
+          </DialogTitle>
         </DialogHeader>
-        <form key={rule?.id ?? 'new'} onSubmit={handleSubmit} className="space-y-5">
+        <form
+          key={rule?.id ?? "new"}
+          onSubmit={handleSubmit}
+          className="space-y-5"
+        >
           {/* Name + Priority */}
           <div className="grid grid-cols-3 gap-3">
             <div className="col-span-2 space-y-1.5">
-              <Label>{t('rules.name')}</Label>
-              <Input value={name} onChange={(e) => setName(e.target.value)} required placeholder="Ex: Uber" />
+              <Label>{t("rules.name")}</Label>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+                placeholder="Ex: Uber"
+              />
             </div>
             <div className="space-y-1.5">
-              <Label>{t('rules.priority')}</Label>
-              <Input type="number" value={priority} onChange={(e) => setPriority(Number(e.target.value))} />
+              <Label>{t("rules.priority")}</Label>
+              <Input
+                type="number"
+                value={priority}
+                onChange={(e) => setPriority(Number(e.target.value))}
+              />
             </div>
           </div>
 
           {/* Conditions */}
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              <Label>{t('rules.conditions')}</Label>
+              <Label>{t("rules.conditions")}</Label>
               <div className="flex items-center gap-1 bg-muted rounded-lg p-0.5">
-                {(['and', 'or'] as const).map(op => (
+                {(["and", "or"] as const).map((op) => (
                   <button
                     key={op}
                     type="button"
                     className={cn(
-                      'px-3 py-1 text-xs font-semibold rounded-md transition-all',
-                      conditionsOp === op ? 'bg-card shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground'
+                      "px-3 py-1 text-xs font-semibold rounded-md transition-all",
+                      conditionsOp === op
+                        ? "bg-card shadow-sm text-foreground"
+                        : "text-muted-foreground hover:text-foreground",
                     )}
                     onClick={() => setConditionsOp(op)}
                   >
-                    {op === 'and' ? t('rules.andOp') : t('rules.orOp')}
+                    {op === "and" ? t("rules.andOp") : t("rules.orOp")}
                   </button>
                 ))}
               </div>
@@ -551,59 +710,89 @@ function RuleDialog({
                   <select
                     className={`${selectClass} w-32 shrink-0`}
                     value={cond.field}
-                    onChange={(e) => updateCondition(i, 'field', e.target.value)}
+                    onChange={(e) =>
+                      updateCondition(i, "field", e.target.value)
+                    }
                   >
-                    {CONDITION_FIELDS.map(f => (
-                      <option key={f.value} value={f.value}>{t(f.label)}</option>
+                    {CONDITION_FIELDS.map((f) => (
+                      <option key={f.value} value={f.value}>
+                        {t(f.label)}
+                      </option>
                     ))}
                   </select>
                   <select
                     className={`${selectClass} w-32 shrink-0`}
                     value={cond.op}
-                    onChange={(e) => updateCondition(i, 'op', e.target.value)}
+                    onChange={(e) => updateCondition(i, "op", e.target.value)}
                   >
-                    {getOpsForField(cond.field).map(o => (
-                      <option key={o.value} value={o.value}>{t(o.label)}</option>
+                    {getOpsForField(cond.field).map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {t(o.label)}
+                      </option>
                     ))}
                   </select>
-                  {cond.field === 'type' ? (
+                  {cond.field === "type" ? (
                     <select
                       className={`${selectClass} w-0 flex-1 min-w-0`}
                       value={String(cond.value)}
-                      onChange={(e) => updateCondition(i, 'value', e.target.value)}
+                      onChange={(e) =>
+                        updateCondition(i, "value", e.target.value)
+                      }
                     >
-                      <option value="debit">{t('rules.typeExpense')}</option>
-                      <option value="credit">{t('rules.typeIncome')}</option>
+                      <option value="debit">{t("rules.typeExpense")}</option>
+                      <option value="credit">{t("rules.typeIncome")}</option>
                     </select>
-                  ) : cond.field === 'account_id' ? (
+                  ) : cond.field === "account_id" ? (
                     <select
                       className={`${selectClass} w-0 flex-1 min-w-0`}
                       value={String(cond.value)}
-                      onChange={(e) => updateCondition(i, 'value', e.target.value)}
+                      onChange={(e) =>
+                        updateCondition(i, "value", e.target.value)
+                      }
                     >
-                      <option value="">{t('rules.selectAccount')}</option>
-                      {accounts.map(acc => (
-                        <option key={acc.id} value={acc.id}>{getAccountName(acc)}</option>
+                      <option value="">{t("rules.selectAccount")}</option>
+                      {accounts.map((acc) => (
+                        <option key={acc.id} value={acc.id}>
+                          {getAccountName(acc)}
+                        </option>
                       ))}
                     </select>
-                  ) : cond.field === 'payee_id' ? (
+                  ) : cond.field === "payee_id" ? (
                     <select
                       className={`${selectClass} w-0 flex-1 min-w-0`}
                       value={String(cond.value)}
-                      onChange={(e) => updateCondition(i, 'value', e.target.value)}
+                      onChange={(e) =>
+                        updateCondition(i, "value", e.target.value)
+                      }
                     >
-                      <option value="">{t('rules.selectPayee')}</option>
-                      {payees.map(p => (
-                        <option key={p.id} value={p.id}>{p.name}</option>
+                      <option value="">{t("rules.selectPayee")}</option>
+                      {payees.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.name}
+                        </option>
                       ))}
                     </select>
                   ) : (
                     <Input
                       className="w-0 flex-1 min-w-0 h-8 text-sm"
                       value={String(cond.value)}
-                      onChange={(e) => updateCondition(i, 'value', e.target.value)}
-                      placeholder={cond.field === 'amount' ? '0.00' : cond.field === 'date' ? 'YYYY-MM-DD' : t('rules.valuePlaceholder')}
-                      type={cond.field === 'amount' ? 'number' : cond.field === 'date' ? 'date' : 'text'}
+                      onChange={(e) =>
+                        updateCondition(i, "value", e.target.value)
+                      }
+                      placeholder={
+                        cond.field === "amount"
+                          ? "0.00"
+                          : cond.field === "date"
+                            ? "YYYY-MM-DD"
+                            : t("rules.valuePlaceholder")
+                      }
+                      type={
+                        cond.field === "amount"
+                          ? "number"
+                          : cond.field === "date"
+                            ? "date"
+                            : "text"
+                      }
                     />
                   )}
                   <button
@@ -620,54 +809,68 @@ function RuleDialog({
                 className="text-xs text-primary hover:text-primary/80 font-medium flex items-center gap-1"
                 onClick={addCondition}
               >
-                <Plus size={12} /> {t('rules.addCondition')}
+                <Plus size={12} /> {t("rules.addCondition")}
               </button>
             </div>
           </div>
 
           {/* Actions */}
           <div className="space-y-2">
-            <Label>{t('rules.actions')}</Label>
+            <Label>{t("rules.actions")}</Label>
             <div className="space-y-2">
               {actions.map((action, i) => (
                 <div key={i} className="flex items-center gap-2 min-w-0">
                   <select
                     className={`${selectClass} w-40 shrink-0`}
                     value={action.op}
-                    onChange={(e) => updateAction(i, 'op', e.target.value)}
+                    onChange={(e) => {
+                      updateAction(i, "op", e.target.value);
+                      if (e.target.value === "ignore") {
+                        updateAction(i, "value", "");
+                      }
+                    }}
                   >
-                    <option value="set_category">{t('rules.setCategory')}</option>
-                    <option value="set_payee">{t('rules.setPayee')}</option>
-                    <option value="append_notes">{t('rules.appendNotes')}</option>
+                    <option value="set_category">
+                      {t("rules.setCategory")}
+                    </option>
+                    <option value="set_payee">{t("rules.setPayee")}</option>
+                    <option value="append_notes">
+                      {t("rules.appendNotes")}
+                    </option>
+                    <option value="ignore">Ignorar</option>
                   </select>
-                  {action.op === 'set_category' ? (
+                  {action.op === "set_category" ? (
                     <div className="w-0 flex-1 min-w-0">
                       <CategorySelect
                         value={action.value}
-                        onChange={(val) => updateAction(i, 'value', val)}
+                        onChange={(val) => updateAction(i, "value", val)}
                         categories={categories}
                         groups={categoryGroups}
-                        placeholder={t('rules.selectCategory')}
+                        placeholder={t("rules.selectCategory")}
                         className={`${selectClass} w-full`}
                       />
                     </div>
-                  ) : action.op === 'set_payee' ? (
+                  ) : action.op === "set_payee" ? (
                     <select
                       className={`${selectClass} w-0 flex-1 min-w-0`}
                       value={action.value}
-                      onChange={(e) => updateAction(i, 'value', e.target.value)}
+                      onChange={(e) => updateAction(i, "value", e.target.value)}
                       required
                     >
-                      <option value="">{t('rules.selectPayee')}</option>
-                      {payees.map(p => (
-                        <option key={p.id} value={p.id}>{p.name}</option>
+                      <option value="">{t("rules.selectPayee")}</option>
+                      {payees.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.name}
+                        </option>
                       ))}
                     </select>
+                  ) : action.op === "ignore" ? (
+                    <div className="w-0 flex-1 min-w-0" />
                   ) : (
                     <Input
                       className="w-0 flex-1 min-w-0 h-8 text-sm"
                       value={action.value}
-                      onChange={(e) => updateAction(i, 'value', e.target.value)}
+                      onChange={(e) => updateAction(i, "value", e.target.value)}
                       placeholder="Ex: #work #reimbursable"
                     />
                   )}
@@ -685,7 +888,7 @@ function RuleDialog({
                 className="text-xs text-primary hover:text-primary/80 font-medium flex items-center gap-1"
                 onClick={addAction}
               >
-                <Plus size={12} /> {t('rules.addAction')}
+                <Plus size={12} /> {t("rules.addAction")}
               </button>
             </div>
           </div>
@@ -698,17 +901,21 @@ function RuleDialog({
               onChange={(e) => setIsActive(e.target.checked)}
               className="h-4 w-4 rounded border-border"
             />
-            <span className="text-sm text-foreground">{t('rules.ruleActive')}</span>
+            <span className="text-sm text-foreground">
+              {t("rules.ruleActive")}
+            </span>
           </label>
 
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={onClose}>{t('common.cancel')}</Button>
+            <Button type="button" variant="outline" onClick={onClose}>
+              {t("common.cancel")}
+            </Button>
             <Button type="submit" disabled={loading}>
-              {loading ? t('common.loading') : t('common.save')}
+              {loading ? t("common.loading") : t("common.save")}
             </Button>
           </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -1,20 +1,29 @@
-import { useState, useMemo, useEffect, useRef } from 'react'
-import { useRegisterPageChatContext } from '@/lib/page-chat-context'
-import { getAccountName } from '@/lib/account-utils'
-import { useNavigate, useSearchParams } from 'react-router-dom'
-import { useTranslation } from 'react-i18next'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { transactions, categories as categoriesApi, categoryGroups as categoryGroupsApi, accounts as accountsApi, recurring, payees as payeesApi, admin, groups as groupsApi } from '@/lib/api'
-import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
-import { toast } from 'sonner'
-import { Button } from '@/components/ui/button'
+import { useState, useMemo, useEffect, useRef } from "react";
+import { useRegisterPageChatContext } from "@/lib/page-chat-context";
+import { getAccountName } from "@/lib/account-utils";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  transactions,
+  categories as categoriesApi,
+  categoryGroups as categoryGroupsApi,
+  accounts as accountsApi,
+  recurring,
+  payees as payeesApi,
+  admin,
+  groups as groupsApi,
+} from "@/lib/api";
+import { invalidateFinancialQueries } from "@/lib/invalidate-queries";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog'
+} from "@/components/ui/dialog";
 import {
   Table,
   TableBody,
@@ -22,161 +31,206 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table'
-import { Skeleton } from '@/components/ui/skeleton'
-import { AlertTriangle, ArrowLeftRight, ArrowUp, ArrowDown, Check, Copy, Download, HelpCircle, Info, Paperclip, Users, X } from 'lucide-react'
-import type { Transaction } from '@/types'
-import { PageHeader } from '@/components/page-header'
-import { CategoryIcon } from '@/components/category-icon'
-import { CategorySelect } from '@/components/category-select'
-import { TransactionDialog, extractApiError, type SaveAction } from '@/components/transaction-dialog'
-import { TransactionsColumnPicker } from '@/components/transactions-column-picker'
-import { type ColumnDef, type ColumnId, useTransactionsGridState } from '@/components/transactions-grid-columns'
-import { TransferDialog } from '@/components/transfer-dialog'
-import { LinkTransferDialog } from '@/components/link-transfer-dialog'
-import { BulkAddToGroupDialog, type BulkAddToGroupSubmission } from '@/components/bulk-add-to-group-dialog'
-import { TransactionsFilterBar } from '@/components/transactions-filter-bar'
-import { usePrivacyMode } from '@/hooks/use-privacy-mode'
-import { useAuth } from '@/contexts/auth-context'
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertTriangle,
+  ArrowLeftRight,
+  ArrowUp,
+  ArrowDown,
+  Check,
+  Copy,
+  Download,
+  Eye,
+  EyeOff,
+  HelpCircle,
+  Info,
+  Paperclip,
+  Users,
+  X,
+} from "lucide-react";
+import type { Transaction } from "@/types";
+import { PageHeader } from "@/components/page-header";
+import { CategoryIcon } from "@/components/category-icon";
+import { CategorySelect } from "@/components/category-select";
+import {
+  TransactionDialog,
+  extractApiError,
+  type SaveAction,
+} from "@/components/transaction-dialog";
+import { TransactionsColumnPicker } from "@/components/transactions-column-picker";
+import {
+  type ColumnDef,
+  type ColumnId,
+  useTransactionsGridState,
+} from "@/components/transactions-grid-columns";
+import { TransferDialog } from "@/components/transfer-dialog";
+import { LinkTransferDialog } from "@/components/link-transfer-dialog";
+import {
+  BulkAddToGroupDialog,
+  type BulkAddToGroupSubmission,
+} from "@/components/bulk-add-to-group-dialog";
+import { TransactionsFilterBar } from "@/components/transactions-filter-bar";
+import { usePrivacyMode } from "@/hooks/use-privacy-mode";
+import { useAuth } from "@/contexts/auth-context";
 
 type TransactionUpdatePayload = Partial<Transaction> & {
-  apply_to_transfer_pair?: boolean
-}
+  apply_to_transfer_pair?: boolean;
+};
 
 type PendingTransferCategoryUpdate = {
-  id: string
-  data: TransactionUpdatePayload
-}
+  id: string;
+  data: TransactionUpdatePayload;
+};
 
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
+function formatCurrency(value: number, currency = "USD", locale = "en-US") {
+  return new Intl.NumberFormat(locale, { style: "currency", currency }).format(
+    value,
+  );
 }
 
 function parseHashtags(notes: string | null): string[] {
-  if (!notes) return []
-  const matches = notes.match(/#[\w\u00C0-\u017E-]+/g)
-  return matches ?? []
+  if (!notes) return [];
+  const matches = notes.match(/#[\w\u00C0-\u017E-]+/g);
+  return matches ?? [];
 }
 
 export default function TransactionsPage() {
-  const { t, i18n } = useTranslation()
-  const [searchParams] = useSearchParams()
-  const navigate = useNavigate()
-  const locale = i18n.language === 'en' ? 'en-US' : i18n.language
-  const { mask } = usePrivacyMode()
-  const { user } = useAuth()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
-  const queryClient = useQueryClient()
-  const [page, setPage] = useState(1)
-  const [filterAccountIds, setFilterAccountIds] = useState<string[]>([])
+  const { t, i18n } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const locale = i18n.language === "en" ? "en-US" : i18n.language;
+  const { mask } = usePrivacyMode();
+  const { user } = useAuth();
+  const userCurrency = user?.preferences?.currency_display ?? "USD";
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(1);
+  const [filterAccountIds, setFilterAccountIds] = useState<string[]>([]);
   const [filterCategoryIds, setFilterCategoryIds] = useState<string[]>(() => {
-    const initial = searchParams.get('category_id')
-    return initial ? [initial] : []
-  })
-  const [filterUncategorized, setFilterUncategorized] = useState<boolean>(false)
-  const [filterFrom, setFilterFrom] = useState<string>('')
-  const [filterTo, setFilterTo] = useState<string>('')
-  const [searchInput, setSearchInput] = useState(() => searchParams.get('q') ?? '')
-  const [searchQuery, setSearchQuery] = useState(() => searchParams.get('q') ?? '')
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [editingTx, setEditingTx] = useState<Transaction | null>(null)
+    const initial = searchParams.get("category_id");
+    return initial ? [initial] : [];
+  });
+  const [filterUncategorized, setFilterUncategorized] =
+    useState<boolean>(false);
+  const [filterFrom, setFilterFrom] = useState<string>("");
+  const [filterTo, setFilterTo] = useState<string>("");
+  const [searchInput, setSearchInput] = useState(
+    () => searchParams.get("q") ?? "",
+  );
+  const [searchQuery, setSearchQuery] = useState(
+    () => searchParams.get("q") ?? "",
+  );
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingTx, setEditingTx] = useState<Transaction | null>(null);
   const [pendingTransferCategoryUpdate, setPendingTransferCategoryUpdate] =
-    useState<PendingTransferCategoryUpdate | null>(null)
-  const [formResetKey, setFormResetKey] = useState(0)
-  const [duplicateDraft, setDuplicateDraft] = useState<Partial<Transaction> | null>(null)
-  const [filterPayee, setFilterPayee] = useState<string>(searchParams.get('payee_id') ?? '')
-  const [filterGroupId, setFilterGroupId] = useState<string>(searchParams.get('group_id') ?? '')
-  const [filterType, setFilterType] = useState<string>(searchParams.get('type') ?? '')
-  const [tagFilters, setTagFilters] = useState<string[]>([])
+    useState<PendingTransferCategoryUpdate | null>(null);
+  const [formResetKey, setFormResetKey] = useState(0);
+  const [duplicateDraft, setDuplicateDraft] =
+    useState<Partial<Transaction> | null>(null);
+  const [filterPayee, setFilterPayee] = useState<string>(
+    searchParams.get("payee_id") ?? "",
+  );
+  const [filterGroupId, setFilterGroupId] = useState<string>(
+    searchParams.get("group_id") ?? "",
+  );
+  const [filterType, setFilterType] = useState<string>(
+    searchParams.get("type") ?? "",
+  );
+  const [tagFilters, setTagFilters] = useState<string[]>([]);
+  const [ignoredFilter, setIgnoredFilter] = useState<
+    "hide" | "include" | "only"
+  >("include");
 
   // When the page is opened with a `group_id`, fetch its name so the
   // active-filter chip is recognizable rather than a raw uuid.
   const { data: filterGroup } = useQuery({
-    queryKey: ['groups', filterGroupId],
+    queryKey: ["groups", filterGroupId],
     queryFn: () => groupsApi.get(filterGroupId),
     enabled: !!filterGroupId,
-  })
+  });
 
   // Used to resolve the group name on shared transaction rows.
   const { data: allGroups } = useQuery({
-    queryKey: ['groups', 'all'],
+    queryKey: ["groups", "all"],
     queryFn: () => groupsApi.list(true),
     staleTime: 60_000,
-  })
+  });
   const groupNameById = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const g of allGroups ?? []) map.set(g.id, g.name)
-    return map
-  }, [allGroups])
+    const map = new Map<string, string>();
+    for (const g of allGroups ?? []) map.set(g.id, g.name);
+    return map;
+  }, [allGroups]);
 
   const addTagFilter = (tag: string) => {
-    const normalized = tag.startsWith('#') ? tag : `#${tag}`
-    setTagFilters(prev => (prev.includes(normalized) ? prev : [...prev, normalized]))
-    setPage(1)
-  }
+    const normalized = tag.startsWith("#") ? tag : `#${tag}`;
+    setTagFilters((prev) =>
+      prev.includes(normalized) ? prev : [...prev, normalized],
+    );
+    setPage(1);
+  };
   const removeTagFilter = (tag: string) => {
-    setTagFilters(prev => prev.filter(t => t !== tag))
-    setPage(1)
-  }
+    setTagFilters((prev) => prev.filter((t) => t !== tag));
+    setPage(1);
+  };
   const clearTagFilters = () => {
-    setTagFilters([])
-    setPage(1)
-  }
-  const [exporting, setExporting] = useState(false)
-  const [transferDialogOpen, setTransferDialogOpen] = useState(false)
-  const [linkTransferDialogOpen, setLinkTransferDialogOpen] = useState(false)
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const grid = useTransactionsGridState()
-  const [bulkCategory, setBulkCategory] = useState<string>('')
-  const [bulkAddToGroupOpen, setBulkAddToGroupOpen] = useState(false)
-  const [bulkTagInput, setBulkTagInput] = useState<string>('')
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null)
-  const highlightId = searchParams.get('highlight')
-  const highlightedRowRef = useRef<HTMLTableRowElement | null>(null)
+    setTagFilters([]);
+    setPage(1);
+  };
+  const [exporting, setExporting] = useState(false);
+  const [transferDialogOpen, setTransferDialogOpen] = useState(false);
+  const [linkTransferDialogOpen, setLinkTransferDialogOpen] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const grid = useTransactionsGridState();
+  const [bulkCategory, setBulkCategory] = useState<string>("");
+  const [bulkAddToGroupOpen, setBulkAddToGroupOpen] = useState(false);
+  const [bulkTagInput, setBulkTagInput] = useState<string>("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const highlightId = searchParams.get("highlight");
+  const highlightedRowRef = useRef<HTMLTableRowElement | null>(null);
 
   // Sync state from URL when navigating (e.g. from the command palette) while
   // the page is already mounted. Typing in the search box does not touch the
   // URL, so this effect only fires on genuine navigation events.
   useEffect(() => {
-    const nextQ = searchParams.get('q') ?? ''
-    setSearchInput(nextQ)
-    setSearchQuery(nextQ)
-    const tags = searchParams.get('tags');
-    setTagFilters(tags ? tags.split(',') : []);
-    setFilterPayee(searchParams.get('payee_id') ?? '')
-    setFilterGroupId(searchParams.get('group_id') ?? '')
-    setFilterType(searchParams.get('type') ?? '')
-    const categories = searchParams.get('category_id');
-    setFilterCategoryIds(categories ? categories.split(',') : []);
-    setFilterUncategorized(searchParams.get('uncategorized') === '1');
-    const accounts = searchParams.get('account_id');
-    setFilterAccountIds(accounts ? accounts.split(',') : []);
-    setFilterFrom(searchParams.get('from') ?? '');
-    setFilterTo(searchParams.get('to') ?? '');
-    setPage(1)
-  }, [searchParams])
+    const nextQ = searchParams.get("q") ?? "";
+    setSearchInput(nextQ);
+    setSearchQuery(nextQ);
+    const tags = searchParams.get("tags");
+    setTagFilters(tags ? tags.split(",") : []);
+    setFilterPayee(searchParams.get("payee_id") ?? "");
+    setFilterGroupId(searchParams.get("group_id") ?? "");
+    setFilterType(searchParams.get("type") ?? "");
+    const categories = searchParams.get("category_id");
+    setFilterCategoryIds(categories ? categories.split(",") : []);
+    setFilterUncategorized(searchParams.get("uncategorized") === "1");
+    const accounts = searchParams.get("account_id");
+    setFilterAccountIds(accounts ? accounts.split(",") : []);
+    setFilterFrom(searchParams.get("from") ?? "");
+    setFilterTo(searchParams.get("to") ?? "");
+    setPage(1);
+  }, [searchParams]);
 
   // Keep the URL in sync with the current filters, so that the current page can be
   // refreshed, bookmarked or shared.
   useEffect(() => {
     const params = new URLSearchParams(
       [
-        ['q', searchQuery],
-        ['tags', tagFilters.join(',')],
-        ['payee_id', filterPayee],
-        ['group_id', filterGroupId],
-        ['type', filterType],
-        ['category_id', filterCategoryIds.join(',')],
-        ['uncategorized', filterUncategorized ? '1' : ''],
-        ['account_id', filterAccountIds.join(',')],
-        ['from', filterFrom],
-        ['to', filterTo],
+        ["q", searchQuery],
+        ["tags", tagFilters.join(",")],
+        ["payee_id", filterPayee],
+        ["group_id", filterGroupId],
+        ["type", filterType],
+        ["category_id", filterCategoryIds.join(",")],
+        ["uncategorized", filterUncategorized ? "1" : ""],
+        ["account_id", filterAccountIds.join(",")],
+        ["from", filterFrom],
+        ["to", filterTo],
       ].filter(([, v]) => v.length),
     );
 
     window.history.replaceState(
       null,
-      '',
+      "",
       params.size ? `?${params}` : window.location.pathname,
     );
   }, [
@@ -193,54 +247,83 @@ export default function TransactionsPage() {
   ]);
 
   useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      setSearchQuery(searchInput)
-      setPage(1)
-    }, 300)
-    return () => { if (debounceRef.current) clearTimeout(debounceRef.current) }
-  }, [searchInput])
+      setSearchQuery(searchInput);
+      setPage(1);
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [searchInput]);
 
   // Clear selection on page/filter change
   useEffect(() => {
-    setSelectedIds(new Set())
-    setBulkCategory('')
-  }, [page, filterAccountIds, filterCategoryIds, filterUncategorized, filterPayee, filterType, filterFrom, filterTo, searchQuery])
+    setSelectedIds(new Set());
+    setBulkCategory("");
+  }, [
+    page,
+    filterAccountIds,
+    filterCategoryIds,
+    filterUncategorized,
+    filterPayee,
+    filterType,
+    filterFrom,
+    filterTo,
+    searchQuery,
+  ]);
 
   // Reset bulk category when selection changes so the same category can be re-applied
   useEffect(() => {
-    setBulkCategory('')
-  }, [selectedIds])
+    setBulkCategory("");
+  }, [selectedIds]);
 
   // Scroll to and flash a highlighted row after navigation (e.g. opened via
   // the command palette). Re-runs whenever highlightId or the current data
   // set changes so that when results finish loading we animate the row.
   useEffect(() => {
-    if (!highlightId) return
-    const el = highlightedRowRef.current
-    if (!el) return
+    if (!highlightId) return;
+    const el = highlightedRowRef.current;
+    if (!el) return;
     const raf = requestAnimationFrame(() => {
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      el.classList.add('securo-highlight-flash')
-    })
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.classList.add("securo-highlight-flash");
+    });
     const timer = setTimeout(() => {
-      el.classList.remove('securo-highlight-flash')
-    }, 2500)
+      el.classList.remove("securo-highlight-flash");
+    }, 2500);
     return () => {
-      cancelAnimationFrame(raf)
-      clearTimeout(timer)
-      el.classList.remove('securo-highlight-flash')
-    }
-  }, [highlightId, searchQuery, filterPayee, filterCategoryIds, page])
+      cancelAnimationFrame(raf);
+      clearTimeout(timer);
+      el.classList.remove("securo-highlight-flash");
+    };
+  }, [highlightId, searchQuery, filterPayee, filterCategoryIds, page]);
 
   const { data, isLoading } = useQuery({
-    queryKey: ['transactions', page, filterAccountIds, filterCategoryIds, filterUncategorized, filterPayee, filterGroupId, filterType, filterFrom, filterTo, searchQuery, tagFilters, grid.sortBy, grid.sortDir],
+    queryKey: [
+      "transactions",
+      page,
+      filterAccountIds,
+      filterCategoryIds,
+      filterUncategorized,
+      filterPayee,
+      filterGroupId,
+      filterType,
+      filterFrom,
+      filterTo,
+      searchQuery,
+      tagFilters,
+      grid.sortBy,
+      grid.sortDir,
+      ignoredFilter,
+    ],
     queryFn: () =>
       transactions.list({
         page,
         limit: 20,
         account_ids: filterAccountIds.length > 0 ? filterAccountIds : undefined,
-        category_ids: filterCategoryIds.length > 0 ? filterCategoryIds : undefined,
+        category_ids:
+          filterCategoryIds.length > 0 ? filterCategoryIds : undefined,
         payee_id: filterPayee || undefined,
         group_id: filterGroupId || undefined,
         type: filterType || undefined,
@@ -249,9 +332,10 @@ export default function TransactionsPage() {
         to: filterTo || undefined,
         q: searchQuery || undefined,
         tags: tagFilters.length > 0 ? tagFilters : undefined,
+        ignored_filter: ignoredFilter,
         ...grid.apiSort,
       }),
-  })
+  });
 
   // Publish the active filters + result count to the global chat panel.
   // The agent uses this so "what about THIS list?" / "soma essas" /
@@ -271,57 +355,91 @@ export default function TransactionsPage() {
     sort_by: grid.sortBy,
     sort_dir: grid.sortDir,
     page,
-  }
-  const ctxKey = JSON.stringify(ctxFilters) + ':' + (data?.total ?? '')
+  };
+  const ctxKey = JSON.stringify(ctxFilters) + ":" + (data?.total ?? "");
   useRegisterPageChatContext(
     {
-      path: '/transactions',
-      label: 'Transactions',
-      summary: data?.total != null
-        ? `${data.total} transaction(s) match the active filters (showing page ${page}, 20 per page).`
-        : 'Transactions list with active filters.',
+      path: "/transactions",
+      label: "Transactions",
+      summary:
+        data?.total != null
+          ? `${data.total} transaction(s) match the active filters (showing page ${page}, 20 per page).`
+          : "Transactions list with active filters.",
       filters: ctxFilters,
     },
     ctxKey,
-  )
+  );
 
   const { data: categoriesList } = useQuery({
-    queryKey: ['categories'],
+    queryKey: ["categories"],
     queryFn: categoriesApi.list,
-  })
+  });
 
   const { data: categoryGroupsList } = useQuery({
-    queryKey: ['categoryGroups'],
+    queryKey: ["categoryGroups"],
     queryFn: categoryGroupsApi.list,
-  })
+  });
 
   const { data: accountsList } = useQuery({
-    queryKey: ['accounts'],
+    queryKey: ["accounts"],
     queryFn: () => accountsApi.list(),
-  })
+  });
 
   const { data: payeesList } = useQuery({
-    queryKey: ['payees'],
+    queryKey: ["payees"],
     queryFn: payeesApi.list,
-  })
+  });
 
   const { data: recurringList } = useQuery({
-    queryKey: ['recurring'],
+    queryKey: ["recurring"],
     queryFn: recurring.list,
-  })
+  });
 
   const { data: accountingModeData } = useQuery({
-    queryKey: ['admin', 'accounting-mode'],
+    queryKey: ["admin", "accounting-mode"],
     queryFn: () => admin.accountingMode(),
     staleTime: 5 * 60 * 1000,
-  })
-  const isAccrual = accountingModeData?.mode === 'accrual'
+  });
+  const isAccrual = accountingModeData?.mode === "accrual";
 
-  const invalidateAfterTxMutation = () => invalidateFinancialQueries(queryClient)
+  const invalidateAfterTxMutation = () =>
+    invalidateFinancialQueries(queryClient);
+
+  const ignoreMutation = useMutation({
+    mutationFn: (id: string) => transactions.ignore(id),
+    onSuccess: () => {
+      invalidateAfterTxMutation();
+    },
+    onError: (error) => {
+      toast.error(extractApiError(error));
+    },
+  });
+
+  const bulkIgnoreMutation = useMutation({
+    mutationFn: ({ ids, ignore }: { ids: string[]; ignore: boolean }) =>
+      transactions.bulkIgnore(ids, ignore),
+    onSuccess: (result, { ignore }) => {
+      invalidateAfterTxMutation();
+      setSelectedIds(new Set());
+      toast.success(
+        ignore
+          ? `${result.updated} transactions ignored`
+          : `${result.updated} transactions restored`,
+      );
+    },
+    onError: (error) => {
+      toast.error(extractApiError(error));
+    },
+  });
 
   const createMutation = useMutation({
-    mutationFn: async (payload: { tx: Partial<Transaction>; recurringData?: { frequency: string; end_date?: string }; pendingFiles?: File[]; action?: SaveAction }) => {
-      const created = await transactions.create(payload.tx)
+    mutationFn: async (payload: {
+      tx: Partial<Transaction>;
+      recurringData?: { frequency: string; end_date?: string };
+      pendingFiles?: File[];
+      action?: SaveAction;
+    }) => {
+      const created = await transactions.create(payload.tx);
       if (payload.recurringData) {
         await recurring.create({
           description: payload.tx.description,
@@ -334,258 +452,288 @@ export default function TransactionsPage() {
           category_id: payload.tx.category_id || undefined,
           account_id: payload.tx.account_id || undefined,
           skip_first: true,
-        } as Record<string, unknown>)
+        } as Record<string, unknown>);
       }
       if (payload.pendingFiles?.length) {
         await Promise.all(
-          payload.pendingFiles.map(file => transactions.attachments.upload(created.id, file))
-        )
+          payload.pendingFiles.map((file) =>
+            transactions.attachments.upload(created.id, file),
+          ),
+        );
       }
-      return created
+      return created;
     },
     onSuccess: (_created, variables) => {
-      invalidateAfterTxMutation()
-      queryClient.invalidateQueries({ queryKey: ['recurring'] })
-      toast.success(t('transactions.created'))
-      if (variables.action === 'saveAndNew') {
-        setDuplicateDraft(null)
-        setFormResetKey(k => k + 1)
-      } else if (variables.action === 'saveAndDuplicate') {
-        setDuplicateDraft(variables.tx)
-        setFormResetKey(k => k + 1)
+      invalidateAfterTxMutation();
+      queryClient.invalidateQueries({ queryKey: ["recurring"] });
+      toast.success(t("transactions.created"));
+      if (variables.action === "saveAndNew") {
+        setDuplicateDraft(null);
+        setFormResetKey((k) => k + 1);
+      } else if (variables.action === "saveAndDuplicate") {
+        setDuplicateDraft(variables.tx);
+        setFormResetKey((k) => k + 1);
       } else {
-        setDialogOpen(false)
+        setDialogOpen(false);
       }
     },
     onError: (error) => {
-      toast.error(extractApiError(error))
+      toast.error(extractApiError(error));
     },
-  })
+  });
 
   const updateMutation = useMutation({
     mutationFn: ({ id, ...data }: TransactionUpdatePayload & { id: string }) =>
       transactions.update(id, data),
     onSuccess: () => {
-      invalidateAfterTxMutation()
-      setDialogOpen(false)
-      setEditingTx(null)
-      toast.success(t('transactions.updated'))
+      invalidateAfterTxMutation();
+      setDialogOpen(false);
+      setEditingTx(null);
+      toast.success(t("transactions.updated"));
     },
     onError: (error) => {
-      toast.error(extractApiError(error))
+      toast.error(extractApiError(error));
     },
-  })
+  });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => transactions.delete(id),
     onSuccess: () => {
-      invalidateAfterTxMutation()
-      setDialogOpen(false)
-      setEditingTx(null)
-      toast.success(t('transactions.deleted'))
+      invalidateAfterTxMutation();
+      setDialogOpen(false);
+      setEditingTx(null);
+      toast.success(t("transactions.deleted"));
     },
     onError: (error) => {
-      toast.error(extractApiError(error))
+      toast.error(extractApiError(error));
     },
-  })
+  });
 
   const bulkCategorizeMutation = useMutation({
-    mutationFn: ({ ids, categoryId }: { ids: string[]; categoryId: string | null }) =>
-      transactions.bulkCategorize(ids, categoryId),
+    mutationFn: ({
+      ids,
+      categoryId,
+    }: {
+      ids: string[];
+      categoryId: string | null;
+    }) => transactions.bulkCategorize(ids, categoryId),
     onSuccess: (result) => {
-      invalidateAfterTxMutation()
-      setSelectedIds(new Set())
-      setBulkCategory('')
-      toast.success(t('transactions.bulkSuccess', { count: result.updated }))
+      invalidateAfterTxMutation();
+      setSelectedIds(new Set());
+      setBulkCategory("");
+      toast.success(t("transactions.bulkSuccess", { count: result.updated }));
     },
     onError: (error) => {
-      toast.error(extractApiError(error))
+      toast.error(extractApiError(error));
     },
-  })
+  });
 
   const bulkAddTagsMutation = useMutation({
     mutationFn: ({ ids, tags }: { ids: string[]; tags: string[] }) =>
       transactions.bulkAddTags(ids, tags),
     onSuccess: (result) => {
-      invalidateAfterTxMutation()
-      setSelectedIds(new Set())
-      setBulkTagInput('')
-      toast.success(t('transactions.bulkSuccess', { count: result.updated }))
+      invalidateAfterTxMutation();
+      setSelectedIds(new Set());
+      setBulkTagInput("");
+      toast.success(t("transactions.bulkSuccess", { count: result.updated }));
     },
     onError: (error) => {
-      toast.error(extractApiError(error))
+      toast.error(extractApiError(error));
     },
-  })
+  });
 
   const bulkAddToGroupMutation = useMutation({
-    mutationFn: ({ ids, payload }: { ids: string[]; payload: BulkAddToGroupSubmission }) =>
+    mutationFn: ({
+      ids,
+      payload,
+    }: {
+      ids: string[];
+      payload: BulkAddToGroupSubmission;
+    }) =>
       transactions.bulkAddToGroup(ids, payload.groupId, {
         share_type: payload.share_type,
         member_splits: payload.member_splits,
       }),
     onSuccess: (result) => {
-      invalidateAfterTxMutation()
-      setSelectedIds(new Set())
-      setBulkAddToGroupOpen(false)
+      invalidateAfterTxMutation();
+      setSelectedIds(new Set());
+      setBulkAddToGroupOpen(false);
       if (result.skipped > 0) {
-        toast.success(t('transactions.bulkAddToGroupPartial', { added: result.updated, skipped: result.skipped }))
+        toast.success(
+          t("transactions.bulkAddToGroupPartial", {
+            added: result.updated,
+            skipped: result.skipped,
+          }),
+        );
       } else {
-        toast.success(t('transactions.bulkAddToGroupSuccess', { count: result.updated }))
+        toast.success(
+          t("transactions.bulkAddToGroupSuccess", { count: result.updated }),
+        );
       }
     },
     onError: (error) => {
-      toast.error(extractApiError(error))
+      toast.error(extractApiError(error));
     },
-  })
+  });
 
   const linkTransferMutation = useMutation({
     mutationFn: (ids: [string, string]) => transactions.linkTransfer(ids),
     onSuccess: () => {
-      invalidateAfterTxMutation()
-      queryClient.invalidateQueries({ queryKey: ['transfer-candidates'] })
-      setLinkTransferDialogOpen(false)
-      setSelectedIds(new Set())
-      toast.success(t('transactions.linkTransferSuccess'))
+      invalidateAfterTxMutation();
+      queryClient.invalidateQueries({ queryKey: ["transfer-candidates"] });
+      setLinkTransferDialogOpen(false);
+      setSelectedIds(new Set());
+      toast.success(t("transactions.linkTransferSuccess"));
     },
     onError: (error) => {
-      toast.error(extractApiError(error))
+      toast.error(extractApiError(error));
     },
-  })
+  });
 
   const createCounterpartMutation = useMutation({
-    mutationFn: ({ anchorId, toAccountId }: { anchorId: string; toAccountId: string }) =>
-      transactions.createTransferCounterpart(anchorId, toAccountId),
+    mutationFn: ({
+      anchorId,
+      toAccountId,
+    }: {
+      anchorId: string;
+      toAccountId: string;
+    }) => transactions.createTransferCounterpart(anchorId, toAccountId),
     onSuccess: () => {
-      invalidateAfterTxMutation()
-      queryClient.invalidateQueries({ queryKey: ['transfer-candidates'] })
-      setLinkTransferDialogOpen(false)
-      setSelectedIds(new Set())
-      toast.success(t('transactions.linkTransferSuccess'))
+      invalidateAfterTxMutation();
+      queryClient.invalidateQueries({ queryKey: ["transfer-candidates"] });
+      setLinkTransferDialogOpen(false);
+      setSelectedIds(new Set());
+      toast.success(t("transactions.linkTransferSuccess"));
     },
     onError: (error) => {
-      toast.error(extractApiError(error))
+      toast.error(extractApiError(error));
     },
-  })
+  });
 
   const unlinkTransferMutation = useMutation({
     mutationFn: (pairId: string) => transactions.unlinkTransfer(pairId),
     onSuccess: () => {
-      invalidateAfterTxMutation()
-      setDialogOpen(false)
-      setEditingTx(null)
-      toast.success(t('transactions.unlinkTransferSuccess'))
+      invalidateAfterTxMutation();
+      setDialogOpen(false);
+      setEditingTx(null);
+      toast.success(t("transactions.unlinkTransferSuccess"));
     },
     onError: (error) => {
-      toast.error(extractApiError(error))
+      toast.error(extractApiError(error));
     },
-  })
+  });
 
   const transferMutation = useMutation({
     mutationFn: (data: {
-      from_account_id: string
-      to_account_id: string
-      amount: number
-      date: string
-      description: string
-      notes?: string
-      fx_rate?: number
+      from_account_id: string;
+      to_account_id: string;
+      amount: number;
+      date: string;
+      description: string;
+      notes?: string;
+      fx_rate?: number;
     }) => transactions.createTransfer(data),
     onSuccess: () => {
-      invalidateAfterTxMutation()
-      setTransferDialogOpen(false)
-      toast.success(t('transactions.transferCreated'))
+      invalidateAfterTxMutation();
+      setTransferDialogOpen(false);
+      toast.success(t("transactions.transferCreated"));
     },
     onError: (error) => {
-      toast.error(extractApiError(error))
+      toast.error(extractApiError(error));
     },
-  })
+  });
 
   const toggleSelect = (id: string) => {
-    setSelectedIds(prev => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
   // Tag filtering is now applied server-side, so the visible list and the
   // page count both reflect the same filtered total — issue #88.
-  const filteredItems = data?.items ?? []
-  const selectableItems = filteredItems.filter(tx => !tx.is_shared)
+  const filteredItems = data?.items ?? [];
+  const selectableItems = filteredItems.filter((tx) => !tx.is_shared);
 
   const toggleSelectAll = () => {
-    if (!selectableItems.length) return
-    const allSelected = selectableItems.every(tx => selectedIds.has(tx.id))
+    if (!selectableItems.length) return;
+    const allSelected = selectableItems.every((tx) => selectedIds.has(tx.id));
     if (allSelected) {
-      setSelectedIds(new Set())
+      setSelectedIds(new Set());
     } else {
-      setSelectedIds(new Set(selectableItems.map(tx => tx.id)))
+      setSelectedIds(new Set(selectableItems.map((tx) => tx.id)));
     }
-  }
+  };
 
-  const allSelected = selectableItems.length > 0 && selectableItems.every(tx => selectedIds.has(tx.id))
-  const someSelected = selectableItems.some(tx => selectedIds.has(tx.id)) && !allSelected
+  const allSelected =
+    selectableItems.length > 0 &&
+    selectableItems.every((tx) => selectedIds.has(tx.id));
+  const someSelected =
+    selectableItems.some((tx) => selectedIds.has(tx.id)) && !allSelected;
 
   // Net total of the currently-selected rows (issue #185). Selection is
   // always page-scoped (cleared on page/filter change), so summing the
   // visible page covers every selected id. Cross-currency rows use their
   // primary-currency amount; credits add, debits subtract.
   const selectedNet = useMemo(() => {
-    let net = 0
+    let net = 0;
     for (const tx of data?.items ?? []) {
-      if (!selectedIds.has(tx.id)) continue
-      const base = Math.abs(Number(tx.amount_primary ?? tx.amount))
-      net += tx.type === 'credit' ? base : -base
+      if (!selectedIds.has(tx.id)) continue;
+      const base = Math.abs(Number(tx.amount_primary ?? tx.amount));
+      net += tx.type === "credit" ? base : -base;
     }
-    return net
-  }, [data?.items, selectedIds])
+    return net;
+  }, [data?.items, selectedIds]);
 
   // Resolve the currently-selected transactions into a valid debit/credit pair
   // for the "Link as transfer" action. Returns null if the pair is invalid
   // (wrong count, same account, same type, or already linked).
   const linkablePair = useMemo(() => {
-    if (selectedIds.size !== 2) return null
-    const selected = (data?.items ?? []).filter(tx => selectedIds.has(tx.id))
-    if (selected.length !== 2) return null
-    if (selected.some(tx => tx.transfer_pair_id)) return null
-    if (selected[0].account_id === selected[1].account_id) return null
-    const debit = selected.find(tx => tx.type === 'debit')
-    const credit = selected.find(tx => tx.type === 'credit')
-    if (!debit || !credit) return null
-    return { debit, credit }
-  }, [selectedIds, data?.items])
+    if (selectedIds.size !== 2) return null;
+    const selected = (data?.items ?? []).filter((tx) => selectedIds.has(tx.id));
+    if (selected.length !== 2) return null;
+    if (selected.some((tx) => tx.transfer_pair_id)) return null;
+    if (selected[0].account_id === selected[1].account_id) return null;
+    const debit = selected.find((tx) => tx.type === "debit");
+    const credit = selected.find((tx) => tx.type === "credit");
+    if (!debit || !credit) return null;
+    return { debit, credit };
+  }, [selectedIds, data?.items]);
 
   // Single-selection picker mode: when exactly one unlinked transaction is
   // selected, the user can search for its counterpart across all accounts.
   const linkAnchor = useMemo(() => {
-    if (selectedIds.size !== 1) return null
-    const selected = (data?.items ?? []).find(tx => selectedIds.has(tx.id))
-    if (!selected) return null
-    if (selected.transfer_pair_id) return null
-    return selected
-  }, [selectedIds, data?.items])
+    if (selectedIds.size !== 1) return null;
+    const selected = (data?.items ?? []).find((tx) => selectedIds.has(tx.id));
+    if (!selected) return null;
+    if (selected.transfer_pair_id) return null;
+    return selected;
+  }, [selectedIds, data?.items]);
 
-  const canOpenLinkDialog = !!linkablePair || !!linkAnchor
+  const canOpenLinkDialog = !!linkablePair || !!linkAnchor;
   const linkDisabledTooltip =
     !canOpenLinkDialog && selectedIds.size >= 2
-      ? t('transactions.linkTransferInvalidPair')
-      : undefined
+      ? t("transactions.linkTransferInvalidPair")
+      : undefined;
 
-  const totalPages = data ? Math.ceil(data.total / 20) : 0
+  const totalPages = data ? Math.ceil(data.total / 20) : 0;
 
-  const isTransferCategoryPromptOpen = !!pendingTransferCategoryUpdate
+  const isTransferCategoryPromptOpen = !!pendingTransferCategoryUpdate;
 
-  const submitPendingTransferCategoryUpdate = (applyToTransferPair: boolean) => {
-    if (!pendingTransferCategoryUpdate) return
-    const { id, data } = pendingTransferCategoryUpdate
+  const submitPendingTransferCategoryUpdate = (
+    applyToTransferPair: boolean,
+  ) => {
+    if (!pendingTransferCategoryUpdate) return;
+    const { id, data } = pendingTransferCategoryUpdate;
     updateMutation.mutate({
       id,
       ...data,
       apply_to_transfer_pair: applyToTransferPair,
-    })
-    setPendingTransferCategoryUpdate(null)
-  }
+    });
+    setPendingTransferCategoryUpdate(null);
+  };
 
   const handleTransactionSave = (
     data: Partial<Transaction>,
@@ -594,22 +742,22 @@ export default function TransactionsPage() {
     action?: SaveAction,
   ) => {
     if (!editingTx) {
-      createMutation.mutate({ tx: data, recurringData, pendingFiles, action })
-      return
+      createMutation.mutate({ tx: data, recurringData, pendingFiles, action });
+      return;
     }
 
     const isTransferCategoryChange =
       !!editingTx.transfer_pair_id &&
-      Object.prototype.hasOwnProperty.call(data, 'category_id') &&
-      data.category_id !== editingTx.category_id
+      Object.prototype.hasOwnProperty.call(data, "category_id") &&
+      data.category_id !== editingTx.category_id;
 
     if (isTransferCategoryChange) {
-      setPendingTransferCategoryUpdate({ id: editingTx.id, data })
-      return
+      setPendingTransferCategoryUpdate({ id: editingTx.id, data });
+      return;
     }
 
-    updateMutation.mutate({ id: editingTx.id, ...data })
-  }
+    updateMutation.mutate({ id: editingTx.id, ...data });
+  };
 
   // Open the Add Transaction dialog seeded from an existing row's
   // fields (issue #158). Identity-bearing fields (id, transfer_pair,
@@ -629,50 +777,71 @@ export default function TransactionsPage() {
       payee: tx.payee,
       payee_name: tx.payee_name,
       notes: tx.notes,
-    }
-    setEditingTx(null)
-    setDuplicateDraft(draft)
-    setFormResetKey(k => k + 1)
-    setDialogOpen(true)
-  }
+    };
+    setEditingTx(null);
+    setDuplicateDraft(draft);
+    setFormResetKey((k) => k + 1);
+    setDialogOpen(true);
+  };
 
   // Resize: track which column is being dragged so we can clear listeners
   // when the gesture ends. The width is committed to grid state on every
   // pointermove for live feedback (cheap — single React state update).
-  const resizingRef = useRef<{ id: ColumnId; startX: number; startWidth: number } | null>(null)
-  const startResize = (e: React.PointerEvent<HTMLSpanElement>, col: ColumnDef) => {
-    e.preventDefault()
-    e.stopPropagation()
-    resizingRef.current = { id: col.id, startX: e.clientX, startWidth: grid.widthOf(col.id) }
+  const resizingRef = useRef<{
+    id: ColumnId;
+    startX: number;
+    startWidth: number;
+  } | null>(null);
+  const startResize = (
+    e: React.PointerEvent<HTMLSpanElement>,
+    col: ColumnDef,
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+    resizingRef.current = {
+      id: col.id,
+      startX: e.clientX,
+      startWidth: grid.widthOf(col.id),
+    };
     const onMove = (ev: PointerEvent) => {
-      const r = resizingRef.current
-      if (!r) return
-      grid.setWidth(r.id, r.startWidth + (ev.clientX - r.startX))
-    }
+      const r = resizingRef.current;
+      if (!r) return;
+      grid.setWidth(r.id, r.startWidth + (ev.clientX - r.startX));
+    };
     const onUp = () => {
-      resizingRef.current = null
-      window.removeEventListener('pointermove', onMove)
-      window.removeEventListener('pointerup', onUp)
-    }
-    window.addEventListener('pointermove', onMove)
-    window.addEventListener('pointerup', onUp)
-  }
+      resizingRef.current = null;
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
 
   const renderHeaderCell = (col: ColumnDef) => {
-    const isSorted = grid.sortBy === col.id
-    const sortIndicator = isSorted ? (grid.sortDir === 'asc' ? <ArrowUp size={12} /> : <ArrowDown size={12} />) : null
-    const alignClass = col.align === 'right' ? 'text-right' : 'text-left'
-    const justify = col.align === 'right' ? 'justify-end' : 'justify-start'
-    const cursorClass = col.sortable ? 'cursor-pointer select-none hover:text-foreground' : ''
+    const isSorted = grid.sortBy === col.id;
+    const sortIndicator = isSorted ? (
+      grid.sortDir === "asc" ? (
+        <ArrowUp size={12} />
+      ) : (
+        <ArrowDown size={12} />
+      )
+    ) : null;
+    const alignClass = col.align === "right" ? "text-right" : "text-left";
+    const justify = col.align === "right" ? "justify-end" : "justify-start";
+    const cursorClass = col.sortable
+      ? "cursor-pointer select-none hover:text-foreground"
+      : "";
     // Match the amount/attachments body cells' pr-5 so right-aligned
     // headers line up with their values (issue #161 polish).
-    const padX = col.align === 'right' ? 'pr-5' : ''
+    const padX = col.align === "right" ? "pr-5" : "";
     return (
       <TableHead
         key={col.id}
         style={{ width: grid.widthOf(col.id), minWidth: grid.widthOf(col.id) }}
         className={`relative text-xs font-medium text-muted-foreground py-3 ${alignClass} ${padX}`}
-        onClick={() => { if (col.sortable) grid.toggleSort(col.id) }}
+        onClick={() => {
+          if (col.sortable) grid.toggleSort(col.id);
+        }}
       >
         <div className={`flex items-center gap-1 ${justify} ${cursorClass}`}>
           <span className="truncate">{t(col.labelKey)}</span>
@@ -685,24 +854,26 @@ export default function TransactionsPage() {
           className="absolute right-0 top-0 h-full w-2 -mr-1 cursor-col-resize select-none hover:bg-primary/40 active:bg-primary/60"
         />
       </TableHead>
-    )
-  }
+    );
+  };
 
-  const stripHashtags = (notes: string) => notes.replace(/#[\wÀ-ž-]+/g, '').trim()
+  const stripHashtags = (notes: string) =>
+    notes.replace(/#[\wÀ-ž-]+/g, "").trim();
 
   const renderAmountCell = (tx: Transaction) => {
-    const displayAmount = tx.is_shared && tx.viewer_share != null
-      ? Number(tx.viewer_share)
-      : Number(tx.amount)
+    const displayAmount =
+      tx.is_shared && tx.viewer_share != null
+        ? Number(tx.viewer_share)
+        : Number(tx.amount);
     return (
       <>
         <span
           className={`text-xs md:text-sm font-bold tabular-nums ${
-            tx.type === 'credit' ? 'text-emerald-600' : 'text-rose-500'
+            tx.type === "credit" ? "text-emerald-600" : "text-rose-500"
           }`}
         >
           {mask(
-            `${tx.type === 'credit' ? '+' : '−'}${formatCurrency(
+            `${tx.type === "credit" ? "+" : "−"}${formatCurrency(
               Math.abs(displayAmount),
               tx.currency,
               locale,
@@ -711,78 +882,112 @@ export default function TransactionsPage() {
         </span>
         {tx.is_shared && (
           <p className="text-[10px] text-muted-foreground tabular-nums">
-            {t('splitGroups.sharedRowParent', {
-              total: formatCurrency(Math.abs(Number(tx.amount)), tx.currency, locale),
+            {t("splitGroups.sharedRowParent", {
+              total: formatCurrency(
+                Math.abs(Number(tx.amount)),
+                tx.currency,
+                locale,
+              ),
             })}
           </p>
         )}
-        {!tx.is_shared && tx.viewer_share != null
-          && Math.abs(Number(tx.viewer_share)) !== Math.abs(Number(tx.amount)) && (
-          <p className="text-[10px] text-muted-foreground tabular-nums">
-            {t('splitGroups.ownerRowYourShare', {
-              share: formatCurrency(Math.abs(Number(tx.viewer_share)), tx.currency, locale),
-            })}
-          </p>
-        )}
+        {!tx.is_shared &&
+          tx.viewer_share != null &&
+          Math.abs(Number(tx.viewer_share)) !== Math.abs(Number(tx.amount)) && (
+            <p className="text-[10px] text-muted-foreground tabular-nums">
+              {t("splitGroups.ownerRowYourShare", {
+                share: formatCurrency(
+                  Math.abs(Number(tx.viewer_share)),
+                  tx.currency,
+                  locale,
+                ),
+              })}
+            </p>
+          )}
         {tx.amount_primary != null && tx.currency !== userCurrency && (
           <div className="flex items-center justify-end gap-1">
             {tx.fx_fallback && (
-              <span title={t('transactions.fxFallbackTooltip')}><AlertTriangle size={11} className="text-amber-500 shrink-0" /></span>
+              <span title={t("transactions.fxFallbackTooltip")}>
+                <AlertTriangle size={11} className="text-amber-500 shrink-0" />
+              </span>
             )}
             <span className="text-[10px] text-muted-foreground tabular-nums">
-              {mask(formatCurrency(Math.abs(tx.amount_primary), userCurrency, locale))}
+              {mask(
+                formatCurrency(
+                  Math.abs(tx.amount_primary),
+                  userCurrency,
+                  locale,
+                ),
+              )}
             </span>
           </div>
         )}
       </>
-    )
-  }
+    );
+  };
 
   const renderDescriptionCell = (tx: Transaction) => {
-    const showInlineDate = !grid.isVisible('date')
-    const showInlineNotes = !grid.isVisible('notes')
-    const showInlineTags = !grid.isVisible('tags')
-    const noteText = tx.notes ? stripHashtags(tx.notes) : ''
-    const noteTags = tx.notes ? parseHashtags(tx.notes) : []
+    const showInlineDate = !grid.isVisible("date");
+    const showInlineNotes = !grid.isVisible("notes");
+    const showInlineTags = !grid.isVisible("tags");
+    const noteText = tx.notes ? stripHashtags(tx.notes) : "";
+    const noteTags = tx.notes ? parseHashtags(tx.notes) : [];
     return (
       <div className="flex items-center gap-2 md:gap-3">
-        <CategoryIcon icon={tx.category?.icon} color={tx.category?.color} size="lg" />
+        <CategoryIcon
+          icon={tx.category?.icon}
+          color={tx.category?.color}
+          size="lg"
+        />
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <p className="text-sm font-semibold text-foreground truncate">{tx.description}</p>
+            <p
+              className={`text-sm font-semibold text-foreground truncate ${tx.is_ignored ? "line-through text-muted-foreground" : ""}`}
+            >
+              {tx.description}
+            </p>
             {tx.group_id && (
               <span
                 className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-violet-700 bg-violet-50 border border-violet-200 dark:bg-violet-950/40 dark:text-violet-300 dark:border-violet-900 px-1.5 py-0.5 rounded-full"
-                title={t('splitGroups.sharedRowTooltip')}
+                title={t("splitGroups.sharedRowTooltip")}
               >
                 {tx.is_shared && tx.parent_owner_name
-                  ? t('splitGroups.sharedRowBadgeAuthor', {
+                  ? t("splitGroups.sharedRowBadgeAuthor", {
                       author: tx.parent_owner_name,
-                      group: groupNameById.get(tx.group_id) ?? '',
+                      group: groupNameById.get(tx.group_id) ?? "",
                     })
-                  : t('splitGroups.ownerRowBadge', {
-                      group: groupNameById.get(tx.group_id) ?? '',
+                  : t("splitGroups.ownerRowBadge", {
+                      group: groupNameById.get(tx.group_id) ?? "",
                     })}
               </span>
             )}
             {!!tx.transfer_pair_id && (
               <span className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-blue-600 bg-blue-50 border border-blue-200 px-1.5 py-0.5 rounded-full">
                 <ArrowLeftRight className="h-3 w-3" />
-                {t('transactions.transfer')}
-                <span title={t('transactions.transferTooltip')}><HelpCircle className="h-3 w-3 text-blue-400" /></span>
+                {t("transactions.transfer")}
+                <span title={t("transactions.transferTooltip")}>
+                  <HelpCircle className="h-3 w-3 text-blue-400" />
+                </span>
               </span>
             )}
-            {recurringList?.some(r => r.description === tx.description && r.type === tx.type) && (
+            {recurringList?.some(
+              (r) => r.description === tx.description && r.type === tx.type,
+            ) && (
               <span className="text-[10px] font-semibold uppercase tracking-wide text-primary bg-primary/5 border border-primary/10 px-1.5 py-0.5 rounded-full">
-                {t('transactions.recurringBadge')}
+                {t("transactions.recurringBadge")}
               </span>
             )}
             {tx.installment_number != null && tx.total_installments != null && (
               <span
                 className="inline-flex items-center text-[10px] font-bold tabular-nums text-amber-700 dark:text-amber-400 bg-amber-100 dark:bg-amber-500/20 border border-amber-200 dark:border-amber-500/30 px-1.5 py-0.5 rounded-full"
-                title={tx.installment_total_amount != null
-                  ? t('transactions.installmentTooltip', { count: tx.total_installments, total: tx.installment_total_amount })
-                  : undefined}
+                title={
+                  tx.installment_total_amount != null
+                    ? t("transactions.installmentTooltip", {
+                        count: tx.total_installments,
+                        total: tx.installment_total_amount,
+                      })
+                    : undefined
+                }
               >
                 {tx.installment_number}/{tx.total_installments}
               </span>
@@ -790,14 +995,39 @@ export default function TransactionsPage() {
             {(tx.attachment_count ?? 0) > 0 && (
               <Paperclip size={12} className="text-muted-foreground shrink-0" />
             )}
+            {tx.is_ignored &&
+              (ignoredFilter === "only" ? (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    ignoreMutation.mutate(tx.id);
+                  }}
+                  disabled={ignoreMutation.isPending}
+                  title="Unignore transaction"
+                  className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-slate-500 bg-slate-100 border border-slate-200 dark:bg-slate-800/60 dark:text-slate-400 dark:border-slate-700 px-1.5 py-0.5 rounded-full shrink-0 hover:bg-rose-50 hover:text-rose-500 hover:border-rose-200 dark:hover:bg-rose-950/40 dark:hover:text-rose-400 dark:hover:border-rose-800 transition-colors disabled:opacity-40"
+                >
+                  <EyeOff className="h-2.5 w-2.5" />
+                  Ignored
+                </button>
+              ) : (
+                <span className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-slate-500 bg-slate-100 border border-slate-200 dark:bg-slate-800/60 dark:text-slate-400 dark:border-slate-700 px-1.5 py-0.5 rounded-full shrink-0">
+                  <EyeOff className="h-2.5 w-2.5" />
+                  Ignored
+                </span>
+              ))}
           </div>
           {showInlineDate && (
-            <p className="text-xs text-muted-foreground mt-0.5">{new Date(tx.date + 'T00:00:00').toLocaleDateString(locale)}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {new Date(tx.date + "T00:00:00").toLocaleDateString(locale)}
+            </p>
           )}
           {(showInlineNotes || showInlineTags) && tx.notes && (
             <div className="mt-1 space-y-0.5">
               {showInlineNotes && noteText && (
-                <p className="text-xs text-muted-foreground italic leading-snug">{noteText}</p>
+                <p className="text-xs text-muted-foreground italic leading-snug">
+                  {noteText}
+                </p>
               )}
               {showInlineTags && noteTags.length > 0 && (
                 <div className="flex flex-wrap gap-1">
@@ -805,7 +1035,10 @@ export default function TransactionsPage() {
                     <span
                       key={tag}
                       className="inline-block text-[11px] font-medium bg-primary/5 text-primary border border-primary/10 px-1.5 py-0 rounded-full leading-5 cursor-pointer hover:bg-primary/10 transition-colors"
-                      onClick={(e) => { e.stopPropagation(); addTagFilter(tag) }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        addTagFilter(tag);
+                      }}
                     >
                       {tag}
                     </span>
@@ -816,66 +1049,102 @@ export default function TransactionsPage() {
           )}
         </div>
       </div>
-    )
-  }
+    );
+  };
 
   const renderBodyCell = (col: ColumnDef, tx: Transaction) => {
-    const widthStyle = { width: grid.widthOf(col.id), minWidth: grid.widthOf(col.id) }
-    const alignClass = col.align === 'right' ? 'text-right' : ''
-    const baseClass = `py-2.5 ${alignClass}`
+    const widthStyle = {
+      width: grid.widthOf(col.id),
+      minWidth: grid.widthOf(col.id),
+    };
+    const alignClass = col.align === "right" ? "text-right" : "";
+    const baseClass = `py-2.5 ${alignClass}`;
     switch (col.id) {
-      case 'date':
+      case "date":
         return (
-          <TableCell key={col.id} style={widthStyle} className={`${baseClass} text-sm text-muted-foreground tabular-nums`}>
-            {new Date(tx.date + 'T00:00:00').toLocaleDateString(locale)}
+          <TableCell
+            key={col.id}
+            style={widthStyle}
+            className={`${baseClass} text-sm text-muted-foreground tabular-nums`}
+          >
+            {new Date(tx.date + "T00:00:00").toLocaleDateString(locale)}
           </TableCell>
-        )
-      case 'description':
+        );
+      case "description":
         return (
-          <TableCell key={col.id} style={widthStyle} className={`${baseClass} pl-2 max-w-0`}>
+          <TableCell
+            key={col.id}
+            style={widthStyle}
+            className={`${baseClass} pl-2 max-w-0`}
+          >
             {renderDescriptionCell(tx)}
           </TableCell>
-        )
-      case 'category':
+        );
+      case "category":
         return (
           <TableCell key={col.id} style={widthStyle} className={baseClass}>
             {tx.category ? (
-              <span className="text-sm text-muted-foreground">{tx.category.name}</span>
+              <span className="text-sm text-muted-foreground">
+                {tx.category.name}
+              </span>
             ) : (
-              <span className="text-xs text-muted-foreground italic">{t('transactions.noCategory')}</span>
+              <span className="text-xs text-muted-foreground italic">
+                {t("transactions.noCategory")}
+              </span>
             )}
           </TableCell>
-        )
-      case 'account':
+        );
+      case "account":
         return (
-          <TableCell key={col.id} style={widthStyle} className={`${baseClass} text-sm text-muted-foreground`}>
-            {getAccountName(accountsList?.find((a) => a.id === tx.account_id) ?? { name: '', display_name: null }) || (
+          <TableCell
+            key={col.id}
+            style={widthStyle}
+            className={`${baseClass} text-sm text-muted-foreground`}
+          >
+            {getAccountName(
+              accountsList?.find((a) => a.id === tx.account_id) ?? {
+                name: "",
+                display_name: null,
+              },
+            ) || <span className="text-muted-foreground">—</span>}
+          </TableCell>
+        );
+      case "amount":
+        return (
+          <TableCell
+            key={col.id}
+            style={widthStyle}
+            className={`${baseClass} pr-5`}
+          >
+            {renderAmountCell(tx)}
+          </TableCell>
+        );
+      case "payee":
+        return (
+          <TableCell
+            key={col.id}
+            style={widthStyle}
+            className={`${baseClass} text-sm text-muted-foreground`}
+          >
+            {tx.payee_name ?? tx.payee ?? (
               <span className="text-muted-foreground">—</span>
             )}
           </TableCell>
-        )
-      case 'amount':
+        );
+      case "notes": {
+        const text = tx.notes ? stripHashtags(tx.notes) : "";
         return (
-          <TableCell key={col.id} style={widthStyle} className={`${baseClass} pr-5`}>
-            {renderAmountCell(tx)}
-          </TableCell>
-        )
-      case 'payee':
-        return (
-          <TableCell key={col.id} style={widthStyle} className={`${baseClass} text-sm text-muted-foreground`}>
-            {tx.payee_name ?? tx.payee ?? <span className="text-muted-foreground">—</span>}
-          </TableCell>
-        )
-      case 'notes': {
-        const text = tx.notes ? stripHashtags(tx.notes) : ''
-        return (
-          <TableCell key={col.id} style={widthStyle} className={`${baseClass} text-xs text-muted-foreground italic max-w-0 truncate`}>
+          <TableCell
+            key={col.id}
+            style={widthStyle}
+            className={`${baseClass} text-xs text-muted-foreground italic max-w-0 truncate`}
+          >
             {text || <span className="not-italic">—</span>}
           </TableCell>
-        )
+        );
       }
-      case 'tags': {
-        const tags = tx.notes ? parseHashtags(tx.notes) : []
+      case "tags": {
+        const tags = tx.notes ? parseHashtags(tx.notes) : [];
         return (
           <TableCell key={col.id} style={widthStyle} className={baseClass}>
             {tags.length === 0 ? (
@@ -886,7 +1155,10 @@ export default function TransactionsPage() {
                   <span
                     key={tag}
                     className="inline-block text-[11px] font-medium bg-primary/5 text-primary border border-primary/10 px-1.5 py-0 rounded-full leading-5 cursor-pointer hover:bg-primary/10"
-                    onClick={(e) => { e.stopPropagation(); addTagFilter(tag) }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      addTagFilter(tag);
+                    }}
                   >
                     {tag}
                   </span>
@@ -894,42 +1166,63 @@ export default function TransactionsPage() {
               </div>
             )}
           </TableCell>
-        )
+        );
       }
-      case 'attachments':
+      case "attachments":
         return (
-          <TableCell key={col.id} style={widthStyle} className={`${baseClass} pr-5 text-sm text-muted-foreground tabular-nums`}>
+          <TableCell
+            key={col.id}
+            style={widthStyle}
+            className={`${baseClass} pr-5 text-sm text-muted-foreground tabular-nums`}
+          >
             {(tx.attachment_count ?? 0) > 0 ? (
               <span className="inline-flex items-center gap-1 justify-end w-full">
-                <Paperclip size={12} />{tx.attachment_count}
+                <Paperclip size={12} />
+                {tx.attachment_count}
               </span>
-            ) : <span>—</span>}
+            ) : (
+              <span>—</span>
+            )}
           </TableCell>
-        )
-      case 'type':
+        );
+      case "type":
         return (
-          <TableCell key={col.id} style={widthStyle} className={`${baseClass} text-sm`}>
-            <span className={tx.type === 'credit' ? 'text-emerald-600' : 'text-rose-500'}>
-              {tx.type === 'credit' ? t('transactions.typeIncome') : t('transactions.typeExpense')}
+          <TableCell
+            key={col.id}
+            style={widthStyle}
+            className={`${baseClass} text-sm`}
+          >
+            <span
+              className={
+                tx.type === "credit" ? "text-emerald-600" : "text-rose-500"
+              }
+            >
+              {tx.type === "credit"
+                ? t("transactions.typeIncome")
+                : t("transactions.typeExpense")}
             </span>
           </TableCell>
-        )
-      case 'status':
+        );
+      case "status":
         return (
-          <TableCell key={col.id} style={widthStyle} className={`${baseClass} text-sm text-muted-foreground capitalize`}>
-            {tx.status === 'pending'
-              ? t('transactions.statusPending')
-              : t('transactions.statusPosted')}
+          <TableCell
+            key={col.id}
+            style={widthStyle}
+            className={`${baseClass} text-sm text-muted-foreground capitalize`}
+          >
+            {tx.status === "pending"
+              ? t("transactions.statusPending")
+              : t("transactions.statusPosted")}
           </TableCell>
-        )
+        );
     }
-  }
+  };
 
   return (
     <div>
       <PageHeader
-        section={t('transactions.section')}
-        title={t('transactions.title')}
+        section={t("transactions.section")}
+        title={t("transactions.title")}
         action={
           <div className="flex items-center gap-2">
             <TransactionsColumnPicker state={grid} />
@@ -937,63 +1230,102 @@ export default function TransactionsPage() {
               variant="outline"
               disabled={exporting}
               onClick={async () => {
-                setExporting(true)
+                setExporting(true);
                 try {
                   if (selectedIds.size > 0) {
                     // Selection-only export bypasses other filters and
                     // hits the backend's `transaction_ids` short-circuit.
                     await transactions.export({
                       transaction_ids: Array.from(selectedIds),
-                    })
+                    });
                   } else {
                     await transactions.export({
-                      account_ids: filterAccountIds.length > 0 ? filterAccountIds : undefined,
-                      category_ids: filterCategoryIds.length > 0 ? filterCategoryIds : undefined,
+                      account_ids:
+                        filterAccountIds.length > 0
+                          ? filterAccountIds
+                          : undefined,
+                      category_ids:
+                        filterCategoryIds.length > 0
+                          ? filterCategoryIds
+                          : undefined,
                       uncategorized: filterUncategorized ? true : undefined,
                       from: filterFrom || undefined,
                       to: filterTo || undefined,
                       q: searchQuery || undefined,
-                    })
+                    });
                   }
-                  toast.success(t('transactions.exportSuccess'))
+                  toast.success(t("transactions.exportSuccess"));
                 } catch {
-                  toast.error(t('transactions.exportError'))
+                  toast.error(t("transactions.exportError"));
                 } finally {
-                  setExporting(false)
+                  setExporting(false);
                 }
               }}
             >
               <Download size={16} className="mr-1.5" />
               {exporting
-                ? t('transactions.exporting')
+                ? t("transactions.exporting")
                 : selectedIds.size > 0
-                  ? t('transactions.exportSelected', { count: selectedIds.size })
-                  : t('transactions.exportCsv')}
+                  ? t("transactions.exportSelected", {
+                      count: selectedIds.size,
+                    })
+                  : t("transactions.exportCsv")}
             </Button>
             {/* Duplicate (issue #158): only when a single row is
                 selected. Pre-fills the Add Transaction dialog from
                 that row's fields; identity-bearing fields (id,
                 transfer_pair_id, splits) are not copied. Hidden for
                 shared rows and transfers — they can't be duplicated. */}
-            {selectedIds.size === 1 && (() => {
-              const selectedTx = filteredItems.find(tx => selectedIds.has(tx.id))
-              if (!selectedTx || selectedTx.is_shared || selectedTx.transfer_pair_id) return null
-              return (
-                <Button
-                  variant="outline"
-                  onClick={() => handleDuplicateTransaction(selectedTx)}
-                >
-                  <Copy size={16} className="mr-1.5" />
-                  {t('transactions.duplicate')}
-                </Button>
-              )
-            })()}
-            <Button variant="outline" onClick={() => setTransferDialogOpen(true)}>
+            {selectedIds.size === 1 &&
+              (() => {
+                const selectedTx = filteredItems.find((tx) =>
+                  selectedIds.has(tx.id),
+                );
+                if (
+                  !selectedTx ||
+                  selectedTx.is_shared ||
+                  selectedTx.transfer_pair_id
+                )
+                  return null;
+                return (
+                  <Button
+                    variant="outline"
+                    onClick={() => handleDuplicateTransaction(selectedTx)}
+                  >
+                    <Copy size={16} className="mr-1.5" />
+                    {t("transactions.duplicate")}
+                  </Button>
+                );
+              })()}
+            {selectedIds.size > 0 && (
+              <Button
+                variant="outline"
+                onClick={() =>
+                  bulkIgnoreMutation.mutate({
+                    ids: Array.from(selectedIds),
+                    ignore: true,
+                  })
+                }
+                disabled={bulkIgnoreMutation.isPending}
+              >
+                <EyeOff size={16} className="mr-1.5" />
+                Ignore
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              onClick={() => setTransferDialogOpen(true)}
+            >
               <ArrowLeftRight size={16} className="mr-1.5" />
-              {t('transactions.transfer')}
+              {t("transactions.transfer")}
             </Button>
-            <Button onClick={() => { setEditingTx(null); setDialogOpen(true) }}>
-              + {t('transactions.addManual')}
+            <Button
+              onClick={() => {
+                setEditingTx(null);
+                setDialogOpen(true);
+              }}
+            >
+              + {t("transactions.addManual")}
             </Button>
           </div>
         }
@@ -1004,46 +1336,74 @@ export default function TransactionsPage() {
         searchInput={searchInput}
         onSearchChange={(v) => setSearchInput(v)}
         onSearchSubmit={(value) => {
-          const trimmed = value.trim()
+          const trimmed = value.trim();
           // Tokenize submitted text. `#`-tokens become live tag filter
           // chips below the search bar (filtering applies immediately, no
           // Enter required). Non-`#` text remains as the free-text search
           // query (issue #88).
-          const tokens = trimmed.split(/\s+/).filter(Boolean)
-          const tags = tokens.filter(t => t.startsWith('#'))
-          const text = tokens.filter(t => !t.startsWith('#')).join(' ')
-          tags.forEach(addTagFilter)
-          setSearchInput(text)
-          setSearchQuery(text)
+          const tokens = trimmed.split(/\s+/).filter(Boolean);
+          const tags = tokens.filter((t) => t.startsWith("#"));
+          const text = tokens.filter((t) => !t.startsWith("#")).join(" ");
+          tags.forEach(addTagFilter);
+          setSearchInput(text);
+          setSearchQuery(text);
         }}
         filterAccountIds={filterAccountIds}
-        onAccountIdsChange={(v) => { setFilterAccountIds(v); setPage(1) }}
+        onAccountIdsChange={(v) => {
+          setFilterAccountIds(v);
+          setPage(1);
+        }}
         filterCategoryIds={filterCategoryIds}
-        onCategoryIdsChange={(v) => { setFilterCategoryIds(v); setPage(1) }}
+        onCategoryIdsChange={(v) => {
+          setFilterCategoryIds(v);
+          setPage(1);
+        }}
         filterUncategorized={filterUncategorized}
-        onUncategorizedChange={(v) => { setFilterUncategorized(v); setPage(1) }}
+        onUncategorizedChange={(v) => {
+          setFilterUncategorized(v);
+          setPage(1);
+        }}
         filterPayee={filterPayee}
-        onPayeeChange={(v) => { setFilterPayee(v); setPage(1) }}
+        onPayeeChange={(v) => {
+          setFilterPayee(v);
+          setPage(1);
+        }}
         filterGroupId={filterGroupId}
-        onGroupIdChange={(v) => { setFilterGroupId(v); setPage(1) }}
+        onGroupIdChange={(v) => {
+          setFilterGroupId(v);
+          setPage(1);
+        }}
         filterType={filterType}
-        onTypeChange={(v) => { setFilterType(v); setPage(1) }}
+        onTypeChange={(v) => {
+          setFilterType(v);
+          setPage(1);
+        }}
+        ignoredFilter={ignoredFilter}
+        onIgnoredFilterChange={(v) => {
+          setIgnoredFilter(v);
+          setPage(1);
+        }}
         filterFrom={filterFrom}
         filterTo={filterTo}
-        onDateRangeChange={(from, to) => { setFilterFrom(from); setFilterTo(to); setPage(1) }}
+        onDateRangeChange={(from, to) => {
+          setFilterFrom(from);
+          setFilterTo(to);
+          setPage(1);
+        }}
         onClearAll={() => {
-          setFilterFrom('')
-          setFilterTo('')
-          setFilterAccountIds([])
-          setFilterCategoryIds([])
-          setFilterUncategorized(false)
-          setFilterPayee('')
-          setFilterGroupId('')
-          setFilterType('')
-          setSearchInput('')
-          setSearchQuery('')
-          clearTagFilters()
-          setPage(1)
+          setFilterFrom("");
+          setFilterTo("");
+          setFilterAccountIds([]);
+          setFilterCategoryIds([]);
+          setFilterUncategorized(false);
+          setFilterPayee("");
+          setFilterGroupId("");
+          setFilterType("");
+          setSearchInput("");
+          setSearchQuery("");
+          clearTagFilters();
+          setIgnoredFilter("include");
+          setPage(1);
         }}
         accounts={accountsList ?? []}
         categories={categoriesList ?? []}
@@ -1054,9 +1414,12 @@ export default function TransactionsPage() {
       {filterGroupId && (
         <div className="mb-4 flex flex-wrap items-center gap-1.5">
           <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/15 bg-primary/5 px-3 py-1 text-xs font-medium text-primary">
-            {t('splitGroups.title')}: {filterGroup?.name ?? '…'}
+            {t("splitGroups.title")}: {filterGroup?.name ?? "…"}
             <button
-              onClick={() => { setFilterGroupId(''); setPage(1) }}
+              onClick={() => {
+                setFilterGroupId("");
+                setPage(1);
+              }}
               className="ml-0.5 text-primary/60 hover:text-primary"
               aria-label="Clear group filter"
             >
@@ -1067,7 +1430,7 @@ export default function TransactionsPage() {
       )}
       {tagFilters.length > 0 && (
         <div className="mb-4 flex flex-wrap items-center gap-1.5">
-          {tagFilters.map(tag => (
+          {tagFilters.map((tag) => (
             <span
               key={tag}
               className="inline-flex items-center gap-1.5 rounded-full border border-primary/15 bg-primary/5 px-3 py-1 text-xs font-medium text-primary"
@@ -1087,7 +1450,7 @@ export default function TransactionsPage() {
       {isAccrual && (filterFrom || filterTo) && (
         <div className="mb-4 flex items-start gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground">
           <Info size={12} className="mt-0.5 shrink-0" />
-          <span>{t('dashboard.accrualNote')}</span>
+          <span>{t("dashboard.accrualNote")}</span>
         </div>
       )}
 
@@ -1101,65 +1464,80 @@ export default function TransactionsPage() {
           </div>
         ) : (
           <div className="overflow-x-auto">
-          <Table style={{ tableLayout: 'fixed' }}>
-            <TableHeader>
-              <TableRow className="border-b border-border hover:bg-transparent">
-                <TableHead style={{ width: 40, minWidth: 40 }} className="py-3 pl-4 pr-0">
-                  <input
-                    type="checkbox"
-                    checked={allSelected}
-                    ref={(el) => { if (el) el.indeterminate = someSelected }}
-                    onChange={toggleSelectAll}
-                    className="h-4 w-4 rounded border-border accent-primary cursor-pointer"
-                  />
-                </TableHead>
-                {grid.visibleColumns.map(renderHeaderCell)}
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredItems.map((tx) => (
-                <TableRow
-                  key={tx.id}
-                  ref={tx.id === highlightId ? highlightedRowRef : undefined}
-                  className={`hover:bg-muted border-b border-border last:border-0 ${
-                    selectedIds.has(tx.id) ? 'bg-primary/5' : ''
-                  } ${tx.is_shared ? 'cursor-default' : 'cursor-pointer'}`}
-                  onClick={() => {
-                    if (tx.is_shared) {
-                      // Owned by another user — view in the group context instead.
-                      if (tx.group_id) navigate(`/groups/${tx.group_id}`)
-                      return
-                    }
-                    setEditingTx(tx)
-                    setDialogOpen(true)
-                  }}
-                >
-                  <TableCell style={{ width: 40, minWidth: 40 }} className="py-2.5 pl-4 pr-0">
-                    {/* Bulk operations are scoped to user.id so they
+            <Table style={{ tableLayout: "fixed" }}>
+              <TableHeader>
+                <TableRow className="border-b border-border hover:bg-transparent">
+                  <TableHead
+                    style={{ width: 40, minWidth: 40 }}
+                    className="py-3 pl-4 pr-0"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      ref={(el) => {
+                        if (el) el.indeterminate = someSelected;
+                      }}
+                      onChange={toggleSelectAll}
+                      className="h-4 w-4 rounded border-border accent-primary cursor-pointer"
+                    />
+                  </TableHead>
+                  {grid.visibleColumns.map(renderHeaderCell)}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredItems.map((tx) => (
+                  <TableRow
+                    key={tx.id}
+                    ref={tx.id === highlightId ? highlightedRowRef : undefined}
+                    className={`group hover:bg-muted border-b border-border last:border-0 ${
+                      selectedIds.has(tx.id) ? "bg-primary/5" : ""
+                    } ${tx.is_shared ? "cursor-default" : "cursor-pointer"} ${
+                      tx.is_ignored && ignoredFilter !== "only"
+                        ? "opacity-40"
+                        : ""
+                    }`}
+                    onClick={() => {
+                      if (tx.is_shared) {
+                        // Owned by another user — view in the group context instead.
+                        if (tx.group_id) navigate(`/groups/${tx.group_id}`);
+                        return;
+                      }
+                      setEditingTx(tx);
+                      setDialogOpen(true);
+                    }}
+                  >
+                    <TableCell
+                      style={{ width: 40, minWidth: 40 }}
+                      className="py-2.5 pl-4 pr-0"
+                    >
+                      {/* Bulk operations are scoped to user.id so they
                         silently skip shared rows — hide the checkbox
                         on those to avoid the dead-end UX. */}
-                    {!tx.is_shared && (
-                      <input
-                        type="checkbox"
-                        checked={selectedIds.has(tx.id)}
-                        onChange={() => toggleSelect(tx.id)}
-                        onClick={(e) => e.stopPropagation()}
-                        className="h-4 w-4 rounded border-border accent-primary cursor-pointer"
-                      />
-                    )}
-                  </TableCell>
-                  {grid.visibleColumns.map(col => renderBodyCell(col, tx))}
-                </TableRow>
-              ))}
-              {filteredItems.length === 0 && (
-                <TableRow>
-                  <TableCell colSpan={grid.visibleColumns.length + 1} className="text-center py-16 text-muted-foreground">
-                    {t('transactions.noResults')}
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+                      {!tx.is_shared && (
+                        <input
+                          type="checkbox"
+                          checked={selectedIds.has(tx.id)}
+                          onChange={() => toggleSelect(tx.id)}
+                          onClick={(e) => e.stopPropagation()}
+                          className="h-4 w-4 rounded border-border accent-primary cursor-pointer"
+                        />
+                      )}
+                    </TableCell>
+                    {grid.visibleColumns.map((col) => renderBodyCell(col, tx))}
+                  </TableRow>
+                ))}
+                {filteredItems.length === 0 && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={grid.visibleColumns.length + 1}
+                      className="text-center py-16 text-muted-foreground"
+                    >
+                      {t("transactions.noResults")}
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
           </div>
         )}
         {/* Filtered summary (issue #185): income / expenses / net across
@@ -1167,28 +1545,52 @@ export default function TransactionsPage() {
         {!isLoading && data?.summary && filteredItems.length > 0 && (
           <div className="flex flex-wrap items-center gap-x-5 gap-y-1 border-t border-border bg-muted/30 px-4 py-2.5">
             <span className="mr-auto text-xs text-muted-foreground">
-              {t('transactions.summaryCount', { count: data.total })}
+              {t("transactions.summaryCount", { count: data.total })}
             </span>
             <span className="flex items-baseline gap-1.5 text-xs">
-              <span className="text-muted-foreground">{t('transactions.summaryIncome')}</span>
+              <span className="text-muted-foreground">
+                {t("transactions.summaryIncome")}
+              </span>
               <span className="text-sm font-semibold tabular-nums text-emerald-600">
-                {mask(formatCurrency(data.summary.income, data.summary.currency, locale))}
+                {mask(
+                  formatCurrency(
+                    data.summary.income,
+                    data.summary.currency,
+                    locale,
+                  ),
+                )}
               </span>
             </span>
             <span className="flex items-baseline gap-1.5 text-xs">
-              <span className="text-muted-foreground">{t('transactions.summaryExpenses')}</span>
+              <span className="text-muted-foreground">
+                {t("transactions.summaryExpenses")}
+              </span>
               <span className="text-sm font-semibold tabular-nums text-rose-500">
-                {mask(formatCurrency(data.summary.expense, data.summary.currency, locale))}
+                {mask(
+                  formatCurrency(
+                    data.summary.expense,
+                    data.summary.currency,
+                    locale,
+                  ),
+                )}
               </span>
             </span>
             <span className="flex items-baseline gap-1.5 text-xs">
-              <span className="text-muted-foreground">{t('transactions.summaryNet')}</span>
+              <span className="text-muted-foreground">
+                {t("transactions.summaryNet")}
+              </span>
               <span
                 className={`text-sm font-bold tabular-nums ${
-                  data.summary.net >= 0 ? 'text-emerald-600' : 'text-rose-500'
+                  data.summary.net >= 0 ? "text-emerald-600" : "text-rose-500"
                 }`}
               >
-                {mask(formatCurrency(data.summary.net, data.summary.currency, locale))}
+                {mask(
+                  formatCurrency(
+                    data.summary.net,
+                    data.summary.currency,
+                    locale,
+                  ),
+                )}
               </span>
             </span>
           </div>
@@ -1197,14 +1599,16 @@ export default function TransactionsPage() {
 
       {/* Pagination */}
       {totalPages > 1 && (
-        <div className={`flex items-center justify-center gap-2 ${selectedIds.size > 0 ? 'pb-16' : ''}`}>
+        <div
+          className={`flex items-center justify-center gap-2 ${selectedIds.size > 0 ? "pb-16" : ""}`}
+        >
           <Button
             variant="outline"
             size="sm"
             disabled={page <= 1}
             onClick={() => setPage(page - 1)}
           >
-            {t('transactions.previous')}
+            {t("transactions.previous")}
           </Button>
           <span className="text-sm text-muted-foreground">
             {page} / {totalPages}
@@ -1215,7 +1619,7 @@ export default function TransactionsPage() {
             disabled={page >= totalPages}
             onClick={() => setPage(page + 1)}
           >
-            {t('transactions.next')}
+            {t("transactions.next")}
           </Button>
         </div>
       )}
@@ -1225,7 +1629,7 @@ export default function TransactionsPage() {
           so the bar visually sits over the transactions list, not the
           full viewport. */}
       <div
-        className={`fixed bottom-0 left-0 right-0 lg:left-60 z-50 transition-transform duration-200 ease-out ${selectedIds.size > 0 ? 'translate-y-0' : 'translate-y-full'}`}
+        className={`fixed bottom-0 left-0 right-0 lg:left-60 z-50 transition-transform duration-200 ease-out ${selectedIds.size > 0 ? "translate-y-0" : "translate-y-full"}`}
       >
         <div className="mx-auto max-w-7xl px-3 md:px-6 pb-4 md:pb-6">
           <div className="flex items-stretch gap-1.5 bg-card border border-border shadow-xl rounded-2xl p-2">
@@ -1239,15 +1643,15 @@ export default function TransactionsPage() {
               </span>
               <div className="hidden sm:flex flex-col leading-tight">
                 <span className="text-[11px] font-medium text-muted-foreground">
-                  {t('transactions.selected')}
+                  {t("transactions.selected")}
                 </span>
                 <span
                   className={`text-sm font-bold tabular-nums ${
-                    selectedNet >= 0 ? 'text-emerald-600' : 'text-rose-500'
+                    selectedNet >= 0 ? "text-emerald-600" : "text-rose-500"
                   }`}
                 >
                   {mask(
-                    `${selectedNet >= 0 ? '+' : '−'}${formatCurrency(
+                    `${selectedNet >= 0 ? "+" : "−"}${formatCurrency(
                       Math.abs(selectedNet),
                       userCurrency,
                       locale,
@@ -1264,17 +1668,20 @@ export default function TransactionsPage() {
               key={bulkCategory}
               value={bulkCategory}
               onChange={(next) => {
-                setBulkCategory(next)
+                setBulkCategory(next);
                 if (next) {
-                  bulkCategorizeMutation.mutate({ ids: Array.from(selectedIds), categoryId: next })
+                  bulkCategorizeMutation.mutate({
+                    ids: Array.from(selectedIds),
+                    categoryId: next,
+                  });
                 }
               }}
               categories={categoriesList ?? []}
               groups={categoryGroupsList ?? []}
-              placeholder={t('transactions.selectCategory')}
+              placeholder={t("transactions.selectCategory")}
               disabled={bulkCategorizeMutation.isPending}
               className="w-44 md:w-56 h-auto py-2 border-transparent bg-transparent hover:bg-muted/60 focus:bg-muted/60 focus-visible:ring-0"
-              contentProps={{ side: 'top', sideOffset: 8 }}
+              contentProps={{ side: "top", sideOffset: 8 }}
             />
 
             <div className="w-px bg-border/60 self-stretch" />
@@ -1286,11 +1693,13 @@ export default function TransactionsPage() {
               variant="ghost"
               disabled={bulkAddToGroupMutation.isPending}
               onClick={() => setBulkAddToGroupOpen(true)}
-              title={t('transactions.addToGroup')}
+              title={t("transactions.addToGroup")}
               className="h-8 px-3 shrink-0 text-sm"
             >
               <Users size={15} className="lg:mr-1.5" />
-              <span className="hidden lg:inline">{t('transactions.addToGroup')}</span>
+              <span className="hidden lg:inline">
+                {t("transactions.addToGroup")}
+              </span>
             </Button>
 
             <div className="w-px bg-border/60 self-stretch" />
@@ -1301,13 +1710,19 @@ export default function TransactionsPage() {
                 type="text"
                 value={bulkTagInput}
                 onChange={(e) => setBulkTagInput(e.target.value)}
-                placeholder={t('transactions.addTagsPlaceholder', '#tag…')}
+                placeholder={t("transactions.addTagsPlaceholder", "#tag…")}
                 className="rounded-lg px-2.5 py-2 text-sm bg-transparent text-foreground placeholder:text-muted-foreground/70 focus:outline-none focus:bg-muted/60 w-28 md:w-40"
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && bulkTagInput.trim()) {
-                    e.preventDefault()
-                    const tagList = bulkTagInput.trim().split(/[\s,]+/).filter(Boolean)
-                    bulkAddTagsMutation.mutate({ ids: Array.from(selectedIds), tags: tagList })
+                  if (e.key === "Enter" && bulkTagInput.trim()) {
+                    e.preventDefault();
+                    const tagList = bulkTagInput
+                      .trim()
+                      .split(/[\s,]+/)
+                      .filter(Boolean);
+                    bulkAddTagsMutation.mutate({
+                      ids: Array.from(selectedIds),
+                      tags: tagList,
+                    });
                   }
                 }}
               />
@@ -1316,12 +1731,18 @@ export default function TransactionsPage() {
                 variant="ghost"
                 disabled={!bulkTagInput.trim() || bulkAddTagsMutation.isPending}
                 onClick={() => {
-                  const tagList = bulkTagInput.trim().split(/[\s,]+/).filter(Boolean)
-                  if (tagList.length === 0) return
-                  bulkAddTagsMutation.mutate({ ids: Array.from(selectedIds), tags: tagList })
+                  const tagList = bulkTagInput
+                    .trim()
+                    .split(/[\s,]+/)
+                    .filter(Boolean);
+                  if (tagList.length === 0) return;
+                  bulkAddTagsMutation.mutate({
+                    ids: Array.from(selectedIds),
+                    tags: tagList,
+                  });
                 }}
                 className="h-8 w-8 px-0 shrink-0"
-                title={t('transactions.bulkAddTags', 'Add tags')}
+                title={t("transactions.bulkAddTags", "Add tags")}
               >
                 <Check size={15} />
               </Button>
@@ -1334,21 +1755,27 @@ export default function TransactionsPage() {
               size="sm"
               variant="ghost"
               disabled={!canOpenLinkDialog}
-              title={linkDisabledTooltip ?? t('transactions.linkAsTransfer')}
+              title={linkDisabledTooltip ?? t("transactions.linkAsTransfer")}
               onClick={() => setLinkTransferDialogOpen(true)}
               className="h-8 px-3 shrink-0 text-sm"
             >
               <ArrowLeftRight size={15} className="mr-1.5" />
-              <span className="hidden lg:inline">{t('transactions.linkAsTransfer')}</span>
+              <span className="hidden lg:inline">
+                {t("transactions.linkAsTransfer")}
+              </span>
             </Button>
 
             <div className="ml-auto" />
 
             {/* Close */}
             <button
-              onClick={() => { setSelectedIds(new Set()); setBulkCategory(''); setBulkTagInput('') }}
+              onClick={() => {
+                setSelectedIds(new Set());
+                setBulkCategory("");
+                setBulkTagInput("");
+              }}
               className="text-muted-foreground hover:text-foreground p-2 shrink-0 self-center rounded-lg hover:bg-muted/60"
-              title={t('common.close', 'Close')}
+              title={t("common.close", "Close")}
             >
               <X size={16} />
             </button>
@@ -1362,7 +1789,10 @@ export default function TransactionsPage() {
         onClose={() => setBulkAddToGroupOpen(false)}
         selectedCount={selectedIds.size}
         onSubmit={(payload) =>
-          bulkAddToGroupMutation.mutate({ ids: Array.from(selectedIds), payload })
+          bulkAddToGroupMutation.mutate({
+            ids: Array.from(selectedIds),
+            payload,
+          })
         }
         isPending={bulkAddToGroupMutation.isPending}
       />
@@ -1376,12 +1806,14 @@ export default function TransactionsPage() {
         anchor={linkAnchor}
         accounts={accountsList ?? []}
         onConfirm={(debitId, creditId) => {
-          linkTransferMutation.mutate([debitId, creditId])
+          linkTransferMutation.mutate([debitId, creditId]);
         }}
         onCreateCounterpart={(anchorId, toAccountId) => {
-          createCounterpartMutation.mutate({ anchorId, toAccountId })
+          createCounterpartMutation.mutate({ anchorId, toAccountId });
         }}
-        loading={linkTransferMutation.isPending || createCounterpartMutation.isPending}
+        loading={
+          linkTransferMutation.isPending || createCounterpartMutation.isPending
+        }
       />
 
       {/* Transfer Dialog */}
@@ -1397,14 +1829,14 @@ export default function TransactionsPage() {
       <TransactionDialog
         open={dialogOpen}
         onClose={() => {
-          setDialogOpen(false)
-          setEditingTx(null)
-          setDuplicateDraft(null)
-          setPendingTransferCategoryUpdate(null)
+          setDialogOpen(false);
+          setEditingTx(null);
+          setDuplicateDraft(null);
+          setPendingTransferCategoryUpdate(null);
           // Drop any prior mutation error so reopening the dialog
           // doesn't surface a stale message (issue #155).
-          createMutation.reset()
-          updateMutation.reset()
+          createMutation.reset();
+          updateMutation.reset();
         }}
         transaction={editingTx}
         duplicateDraft={duplicateDraft}
@@ -1412,27 +1844,58 @@ export default function TransactionsPage() {
         categories={categoriesList ?? []}
         categoryGroups={categoryGroupsList ?? []}
         accounts={accountsList ?? []}
-        recurringMatch={editingTx ? recurringList?.find(r => r.description === editingTx.description && r.type === editingTx.type) : undefined}
+        recurringMatch={
+          editingTx
+            ? recurringList?.find(
+                (r) =>
+                  r.description === editingTx.description &&
+                  r.type === editingTx.type,
+              )
+            : undefined
+        }
         onSave={handleTransactionSave}
-        onDelete={editingTx ? () => deleteMutation.mutate(editingTx.id) : undefined}
+        onDelete={
+          editingTx ? () => deleteMutation.mutate(editingTx.id) : undefined
+        }
+        onIgnore={
+          editingTx
+            ? () => {
+                ignoreMutation.mutate(editingTx.id);
+                setDialogOpen(false);
+                setEditingTx(null);
+              }
+            : undefined
+        }
         onUnlinkTransfer={(pairId) => unlinkTransferMutation.mutate(pairId)}
-        loading={createMutation.isPending || updateMutation.isPending || deleteMutation.isPending || unlinkTransferMutation.isPending}
-        error={createMutation.error || updateMutation.error ? extractApiError(createMutation.error || updateMutation.error) : null}
-        isSynced={editingTx?.source === 'sync'}
+        loading={
+          createMutation.isPending ||
+          updateMutation.isPending ||
+          deleteMutation.isPending ||
+          ignoreMutation.isPending ||
+          unlinkTransferMutation.isPending
+        }
+        error={
+          createMutation.error || updateMutation.error
+            ? extractApiError(createMutation.error || updateMutation.error)
+            : null
+        }
+        isSynced={editingTx?.source === "sync"}
       />
 
       <Dialog
         open={isTransferCategoryPromptOpen}
         onOpenChange={(open) => {
-          if (!open) setPendingTransferCategoryUpdate(null)
+          if (!open) setPendingTransferCategoryUpdate(null);
         }}
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{t('transactions.confirmTransferCategoryTitle')}</DialogTitle>
+            <DialogTitle>
+              {t("transactions.confirmTransferCategoryTitle")}
+            </DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
-            {t('transactions.confirmTransferCategoryDesc')}
+            {t("transactions.confirmTransferCategoryDesc")}
           </p>
           <DialogFooter className="flex-row flex-nowrap items-center justify-end gap-2 sm:space-x-0">
             <Button
@@ -1440,7 +1903,7 @@ export default function TransactionsPage() {
               variant="outline"
               onClick={() => setPendingTransferCategoryUpdate(null)}
             >
-              {t('common.cancel')}
+              {t("common.cancel")}
             </Button>
             <Button
               className="min-w-0 flex-1 truncate"
@@ -1448,7 +1911,7 @@ export default function TransactionsPage() {
               onClick={() => submitPendingTransferCategoryUpdate(false)}
               disabled={updateMutation.isPending}
             >
-              {t('transactions.confirmTransferCategorySingle')}
+              {t("transactions.confirmTransferCategorySingle")}
             </Button>
             <Button
               className="min-w-0 flex-1 truncate"
@@ -1456,12 +1919,12 @@ export default function TransactionsPage() {
               disabled={updateMutation.isPending}
             >
               {updateMutation.isPending
-                ? t('common.loading')
-                : t('transactions.confirmTransferCategoryBoth')}
+                ? t("common.loading")
+                : t("transactions.confirmTransferCategoryBoth")}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>
-  )
+  );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,628 +1,634 @@
 export interface User {
-  id: string
-  email: string
-  is_active: boolean
-  is_superuser: boolean
-  is_verified: boolean
-  is_2fa_enabled: boolean
-  preferences: UserPreferences
+  id: string;
+  email: string;
+  is_active: boolean;
+  is_superuser: boolean;
+  is_verified: boolean;
+  is_2fa_enabled: boolean;
+  preferences: UserPreferences;
 }
 
 export interface AdminUser {
-  id: string
-  email: string
-  is_active: boolean
-  is_superuser: boolean
-  is_verified: boolean
-  preferences: UserPreferences | null
+  id: string;
+  email: string;
+  is_active: boolean;
+  is_superuser: boolean;
+  is_verified: boolean;
+  preferences: UserPreferences | null;
 }
 
 export interface AdminUserList {
-  items: AdminUser[]
-  total: number
+  items: AdminUser[];
+  total: number;
 }
 
 export interface AppSetting {
-  key: string
-  value: string
+  key: string;
+  value: string;
 }
 
 export interface UserPreferences {
-  language?: string
-  date_format?: string
-  timezone?: string
-  currency_display?: string
-  display_name?: string
-  onboarding_completed?: boolean
+  language?: string;
+  date_format?: string;
+  timezone?: string;
+  currency_display?: string;
+  display_name?: string;
+  onboarding_completed?: boolean;
 }
 
 export interface Category {
-  id: string
-  user_id: string
-  group_id: string | null
-  name: string
-  icon: string
-  color: string
-  is_system: boolean
-  treat_as_transfer: boolean
+  id: string;
+  user_id: string;
+  group_id: string | null;
+  name: string;
+  icon: string;
+  color: string;
+  is_system: boolean;
+  treat_as_transfer: boolean;
 }
 
 export interface CategoryGroup {
-  id: string
-  user_id: string
-  name: string
-  icon: string
-  color: string
-  position: number
-  is_system: boolean
-  categories: Category[]
+  id: string;
+  user_id: string;
+  name: string;
+  icon: string;
+  color: string;
+  position: number;
+  is_system: boolean;
+  categories: Category[];
 }
 
 export interface BankConnection {
-  id: string
-  user_id: string
-  provider: string
-  institution_name: string
-  external_id: string
-  status: string
-  settings: ConnectionSettings | null
-  last_sync_at: string | null
-  created_at: string
+  id: string;
+  user_id: string;
+  provider: string;
+  institution_name: string;
+  external_id: string;
+  status: string;
+  settings: ConnectionSettings | null;
+  last_sync_at: string | null;
+  created_at: string;
 }
 
 export interface ConnectionSettings {
-  payee_source?: 'auto' | 'merchant' | 'payment_data' | 'description' | 'none'
-  import_pending?: boolean
+  payee_source?: "auto" | "merchant" | "payment_data" | "description" | "none";
+  import_pending?: boolean;
 }
 
 export interface Account {
-  id: string
-  user_id: string
-  connection_id: string | null
-  external_id: string | null
-  name: string
-  display_name: string | null
-  type: string
-  balance: number
-  current_balance: number
-  previous_balance: number | null
-  balance_primary: number | null
-  currency: string
-  credit_limit: number | null
-  available_credit: number | null
-  statement_close_day: number | null
-  payment_due_day: number | null
-  next_close_date: string | null
-  next_due_date: string | null
-  minimum_payment: number | null
-  card_brand: string | null
-  card_level: string | null
-  is_closed: boolean
-  closed_at: string | null
+  id: string;
+  user_id: string;
+  connection_id: string | null;
+  external_id: string | null;
+  name: string;
+  display_name: string | null;
+  type: string;
+  balance: number;
+  current_balance: number;
+  previous_balance: number | null;
+  balance_primary: number | null;
+  currency: string;
+  credit_limit: number | null;
+  available_credit: number | null;
+  statement_close_day: number | null;
+  payment_due_day: number | null;
+  next_close_date: string | null;
+  next_due_date: string | null;
+  minimum_payment: number | null;
+  card_brand: string | null;
+  card_level: string | null;
+  is_closed: boolean;
+  closed_at: string | null;
 }
 
 export interface CreditCardBill {
-  id: string
-  account_id: string
-  external_id: string
-  due_date: string // YYYY-MM-DD
-  total_amount: number
-  currency: string
-  minimum_payment: number | null
+  id: string;
+  account_id: string;
+  external_id: string;
+  due_date: string; // YYYY-MM-DD
+  total_amount: number;
+  currency: string;
+  minimum_payment: number | null;
 }
 
 export interface AccountSummary {
-  account_id: string
-  current_balance: number
-  monthly_income: number
-  monthly_expenses: number
-  current_balance_primary: number | null
-  monthly_income_primary: number | null
-  monthly_expenses_primary: number | null
+  account_id: string;
+  current_balance: number;
+  monthly_income: number;
+  monthly_expenses: number;
+  current_balance_primary: number | null;
+  monthly_income_primary: number | null;
+  monthly_expenses_primary: number | null;
 }
 
 export interface Transaction {
-  id: string
-  user_id: string
-  account_id: string | null
-  category_id: string | null
-  category: Category | null
-  external_id: string | null
-  description: string
-  amount: number
-  currency: string
-  date: string
-  type: 'debit' | 'credit'
-  source: string
-  status: 'posted' | 'pending'
-  payee: string | null
-  payee_id: string | null
-  payee_name: string | null
-  notes: string | null
-  transfer_pair_id: string | null
-  amount_primary: number | null
-  fx_rate_used: number | null
-  fx_fallback: boolean
-  attachment_count?: number
-  installment_number: number | null
-  total_installments: number | null
-  installment_total_amount: number | null
-  installment_purchase_date: string | null
-  bill_id: string | null
+  id: string;
+  user_id: string;
+  account_id: string | null;
+  category_id: string | null;
+  category: Category | null;
+  external_id: string | null;
+  description: string;
+  amount: number;
+  currency: string;
+  date: string;
+  type: "debit" | "credit";
+  source: string;
+  status: "posted" | "pending";
+  payee: string | null;
+  payee_id: string | null;
+  payee_name: string | null;
+  notes: string | null;
+  transfer_pair_id: string | null;
+  amount_primary: number | null;
+  fx_rate_used: number | null;
+  fx_fallback: boolean;
+  attachment_count?: number;
+  installment_number: number | null;
+  total_installments: number | null;
+  installment_total_amount: number | null;
+  installment_purchase_date: string | null;
+  bill_id: string | null;
   // Manual override for which credit-card bill cycle this tx belongs to
   // (issue #92). Empty / null = use auto bucketing (Pluggy bill_id when
   // available, cycle math otherwise). Setting it forces the tx into the
   // bill whose due_date matches.
-  effective_bill_date: string | null
-  splits: TransactionSplit[]
+  effective_bill_date: string | null;
+  splits: TransactionSplit[];
   // Shared-transaction view fields. Set per-request when the viewer
   // is a linked split member but not the owner. Render `viewer_share`
   // as the amount and treat the row as read-only — editing belongs
   // to the parent's owner.
-  is_shared?: boolean
-  viewer_share?: number | null
-  group_id?: string | null
+  is_shared?: boolean;
+  viewer_share?: number | null;
+  group_id?: string | null;
   // Display name of the parent's owner (the person who actually paid).
   // Derived per-request from the group's `is_self` member.
-  parent_owner_name?: string | null
+  parent_owner_name?: string | null;
+  is_ignored: boolean;
 }
 
-export type ShareType = 'equal' | 'exact' | 'percent'
+export type ShareType = "equal" | "exact" | "percent";
 
 export interface TransactionSplit {
-  id: string
-  transaction_id: string
-  group_member_id: string
-  share_amount: number
-  share_type: string
-  share_pct: number | null
-  notes: string | null
-  created_at: string
+  id: string;
+  transaction_id: string;
+  group_member_id: string;
+  share_amount: number;
+  share_type: string;
+  share_pct: number | null;
+  notes: string | null;
+  created_at: string;
 }
 
 export interface TransactionSplitInput {
-  group_member_id: string
-  share_amount?: number | null
-  share_pct?: number | null
-  notes?: string | null
+  group_member_id: string;
+  share_amount?: number | null;
+  share_pct?: number | null;
+  notes?: string | null;
 }
 
 export interface TransactionSplitsInput {
-  share_type: ShareType
-  splits: TransactionSplitInput[]
+  share_type: ShareType;
+  splits: TransactionSplitInput[];
 }
 
-export type GroupKind = 'social' | 'cost_center' | 'project' | 'client' | 'other'
+export type GroupKind =
+  | "social"
+  | "cost_center"
+  | "project"
+  | "client"
+  | "other";
 
 export interface Group {
-  id: string
-  user_id: string
-  name: string
-  kind: GroupKind
-  default_currency: string
-  icon: string
-  color: string
-  is_archived: boolean
+  id: string;
+  user_id: string;
+  name: string;
+  kind: GroupKind;
+  default_currency: string;
+  icon: string;
+  color: string;
+  is_archived: boolean;
   // Derived server-side per request. False = the current user is a
   // linked member, not the owner — UI should hide edit affordances.
-  is_owner: boolean
-  notes: string | null
-  created_at: string
-  members: GroupMember[]
+  is_owner: boolean;
+  notes: string | null;
+  created_at: string;
+  members: GroupMember[];
 }
 
 export interface GroupMember {
-  id: string
-  group_id: string
-  name: string
-  linked_user_id: string | null
-  email: string | null
-  is_self: boolean
-  created_at: string
+  id: string;
+  group_id: string;
+  name: string;
+  linked_user_id: string | null;
+  email: string | null;
+  is_self: boolean;
+  created_at: string;
 }
 
 export interface GroupSettlement {
-  id: string
-  group_id: string
-  from_member_id: string
-  to_member_id: string
-  amount: number
-  currency: string
-  date: string
-  transaction_id: string | null
-  notes: string | null
-  created_at: string
+  id: string;
+  group_id: string;
+  from_member_id: string;
+  to_member_id: string;
+  amount: number;
+  currency: string;
+  date: string;
+  transaction_id: string | null;
+  notes: string | null;
+  created_at: string;
 }
 
 export interface GroupBalanceLine {
-  member_id: string
-  currency: string
+  member_id: string;
+  currency: string;
   // Positive = member owes the owner. Negative = owner owes member.
-  amount: number
+  amount: number;
   // FX-converted to the group's default currency for cross-currency rollups.
-  amount_in_default_currency: number
+  amount_in_default_currency: number;
 }
 
 export interface GroupBalances {
-  group_id: string
-  self_member_id: string | null
-  default_currency: string
-  lines: GroupBalanceLine[]
+  group_id: string;
+  self_member_id: string | null;
+  default_currency: string;
+  lines: GroupBalanceLine[];
 }
 
 export interface Payee {
-  id: string
-  user_id: string
-  name: string
-  type: 'merchant' | 'person' | 'company'
-  is_favorite: boolean
-  notes: string | null
-  created_at: string
-  transaction_count: number
+  id: string;
+  user_id: string;
+  name: string;
+  type: "merchant" | "person" | "company";
+  is_favorite: boolean;
+  notes: string | null;
+  created_at: string;
+  transaction_count: number;
 }
 
 export interface PayeeSummary {
-  payee: Payee
-  total_spent: number
-  total_received: number
-  transaction_count: number
-  most_common_category: Category | null
-  last_transaction_date: string | null
+  payee: Payee;
+  total_spent: number;
+  total_received: number;
+  transaction_count: number;
+  most_common_category: Category | null;
+  last_transaction_date: string | null;
 }
 
 export interface RuleCondition {
-  field: string
-  op: string
-  value: string | number
+  field: string;
+  op: string;
+  value: string | number;
 }
 
 export interface RuleAction {
-  op: string
-  value: string
+  op: string;
+  value: string;
 }
 
 export interface Rule {
-  id: string
-  user_id: string
-  name: string
-  conditions_op: 'and' | 'or'
-  conditions: RuleCondition[]
-  actions: RuleAction[]
-  priority: number
-  is_active: boolean
+  id: string;
+  user_id: string;
+  name: string;
+  conditions_op: "and" | "or";
+  conditions: RuleCondition[];
+  actions: RuleAction[];
+  priority: number;
+  is_active: boolean;
 }
 
 export interface ImportLog {
-  id: string
-  user_id: string
-  account_id: string
-  account_name: string | null
-  filename: string
-  format: string
-  transaction_count: number
-  total_credit: number
-  total_debit: number
-  created_at: string
+  id: string;
+  user_id: string;
+  account_id: string;
+  account_name: string | null;
+  filename: string;
+  format: string;
+  transaction_count: number;
+  total_credit: number;
+  total_debit: number;
+  created_at: string;
 }
 
 export interface ImportPreviewTransaction {
-  description: string
-  amount: number
-  date: string
-  type: 'debit' | 'credit'
-  external_id?: string | null
-  currency?: string | null
-  fx_rate?: number | null
-  payee_raw?: string | null
-  category_name?: string | null
-  suggested_category_id?: string | null
-  suggested_category_name?: string | null
-  excluded?: boolean
-  category_id?: string | null
-  force_uncategorized?: boolean
+  description: string;
+  amount: number;
+  date: string;
+  type: "debit" | "credit";
+  external_id?: string | null;
+  currency?: string | null;
+  fx_rate?: number | null;
+  payee_raw?: string | null;
+  category_name?: string | null;
+  suggested_category_id?: string | null;
+  suggested_category_name?: string | null;
+  excluded?: boolean;
+  category_id?: string | null;
+  force_uncategorized?: boolean;
 }
 
 export interface ImportReviewTransaction extends ImportPreviewTransaction {
-  _id: string
-  excluded: boolean
-  selected_category_id?: string | null
+  _id: string;
+  excluded: boolean;
+  selected_category_id?: string | null;
 }
 
 export interface RecurringTransaction {
-  id: string
-  user_id: string
-  account_id: string | null
-  category_id: string | null
-  description: string
-  amount: number
-  currency: string
-  type: 'debit' | 'credit'
-  frequency: 'monthly' | 'weekly' | 'yearly'
-  day_of_month: number | null
-  start_date: string
-  end_date: string | null
-  is_active: boolean
-  next_occurrence: string
-  amount_primary: number | null
-  fx_rate_used: number | null
+  id: string;
+  user_id: string;
+  account_id: string | null;
+  category_id: string | null;
+  description: string;
+  amount: number;
+  currency: string;
+  type: "debit" | "credit";
+  frequency: "monthly" | "weekly" | "yearly";
+  day_of_month: number | null;
+  start_date: string;
+  end_date: string | null;
+  is_active: boolean;
+  next_occurrence: string;
+  amount_primary: number | null;
+  fx_rate_used: number | null;
 }
 
 export interface ProjectedTransaction {
-  recurring_id: string
-  description: string
-  amount: number
-  amount_primary: number | null
-  currency: string
-  type: 'debit' | 'credit'
-  date: string
-  category_id: string | null
-  category_name: string | null
-  category_icon: string | null
-  category_color: string | null
+  recurring_id: string;
+  description: string;
+  amount: number;
+  amount_primary: number | null;
+  currency: string;
+  type: "debit" | "credit";
+  date: string;
+  category_id: string | null;
+  category_name: string | null;
+  category_icon: string | null;
+  category_color: string | null;
 }
 
 export interface DashboardSummary {
-  total_balance: Record<string, number>
-  total_balance_primary: number
-  balance_date: string
-  monthly_income: number
-  monthly_expenses: number
-  monthly_income_primary: number
-  monthly_expenses_primary: number
-  accounts_count: number
-  pending_categorization: number
-  pending_categorization_amount: number
-  assets_value: Record<string, number>
-  assets_value_primary: number
-  primary_currency: string
+  total_balance: Record<string, number>;
+  total_balance_primary: number;
+  balance_date: string;
+  monthly_income: number;
+  monthly_expenses: number;
+  monthly_income_primary: number;
+  monthly_expenses_primary: number;
+  accounts_count: number;
+  pending_categorization: number;
+  pending_categorization_amount: number;
+  assets_value: Record<string, number>;
+  assets_value_primary: number;
+  primary_currency: string;
   // Net pending balance from group splits in primary currency.
   // Negative = net liability, positive = net receivable. Already
   // accounts for partial settlements.
-  pending_shares_net: number
+  pending_shares_net: number;
 }
 
 export interface SpendingByCategory {
-  category_id: string | null
-  category_name: string
-  category_icon: string
-  category_color: string
-  total: number
-  percentage: number
+  category_id: string | null;
+  category_name: string;
+  category_icon: string;
+  category_color: string;
+  total: number;
+  percentage: number;
 }
 
 export interface MonthlyTrend {
-  month: string
-  income: number
-  expenses: number
+  month: string;
+  income: number;
+  expenses: number;
 }
 
 export interface DailyBalance {
-  day: number
-  balance: number | null
+  day: number;
+  balance: number | null;
 }
 
 export interface BalanceHistory {
-  current: DailyBalance[]
-  previous: DailyBalance[]
+  current: DailyBalance[];
+  previous: DailyBalance[];
 }
 
 export interface Budget {
-  id: string
-  user_id: string
-  category_id: string
-  amount: number
-  month: string
-  is_recurring: boolean
+  id: string;
+  user_id: string;
+  category_id: string;
+  amount: number;
+  month: string;
+  is_recurring: boolean;
 }
 
 export interface BudgetVsActual {
-  category_id: string
-  category_name: string
-  category_icon: string
-  category_color: string
-  group_id: string | null
-  group_name: string | null
-  budget_amount: number | null
-  actual_amount: number
-  prev_month_amount: number
-  percentage_used: number | null
-  is_recurring: boolean
+  category_id: string;
+  category_name: string;
+  category_icon: string;
+  category_color: string;
+  group_id: string | null;
+  group_name: string | null;
+  budget_amount: number | null;
+  actual_amount: number;
+  prev_month_amount: number;
+  percentage_used: number | null;
+  is_recurring: boolean;
 }
 
 export interface Asset {
-  id: string
-  user_id: string
-  name: string
-  type: string
-  currency: string
-  units: number | null
-  valuation_method: string
-  purchase_date: string | null
-  purchase_price: number | null
-  sell_date: string | null
-  sell_price: number | null
-  growth_type: string | null
-  growth_rate: number | null
-  growth_frequency: string | null
-  growth_start_date: string | null
-  is_archived: boolean
-  position: number
-  current_value: number | null
-  current_value_primary: number | null
-  gain_loss: number | null
-  gain_loss_primary: number | null
-  value_count: number
-  source: string
-  connection_id: string | null
-  isin: string | null
-  maturity_date: string | null
-  group_id: string | null
-  ticker: string | null
-  ticker_exchange: string | null
-  last_price: number | null
-  last_price_at: string | null
-  logo_url: string | null
+  id: string;
+  user_id: string;
+  name: string;
+  type: string;
+  currency: string;
+  units: number | null;
+  valuation_method: string;
+  purchase_date: string | null;
+  purchase_price: number | null;
+  sell_date: string | null;
+  sell_price: number | null;
+  growth_type: string | null;
+  growth_rate: number | null;
+  growth_frequency: string | null;
+  growth_start_date: string | null;
+  is_archived: boolean;
+  position: number;
+  current_value: number | null;
+  current_value_primary: number | null;
+  gain_loss: number | null;
+  gain_loss_primary: number | null;
+  value_count: number;
+  source: string;
+  connection_id: string | null;
+  isin: string | null;
+  maturity_date: string | null;
+  group_id: string | null;
+  ticker: string | null;
+  ticker_exchange: string | null;
+  last_price: number | null;
+  last_price_at: string | null;
+  logo_url: string | null;
 }
 
 export interface MarketSymbolMatch {
-  symbol: string
-  name: string | null
-  exchange: string | null
-  quote_type: string | null
+  symbol: string;
+  name: string | null;
+  exchange: string | null;
+  quote_type: string | null;
 }
 
 export interface MarketSymbolQuote {
-  symbol: string
-  name: string | null
-  exchange: string | null
-  currency: string
-  price: number
-  quote_type: string | null
+  symbol: string;
+  name: string | null;
+  exchange: string | null;
+  currency: string;
+  price: number;
+  quote_type: string | null;
 }
 
 export interface AssetGroup {
-  id: string
-  user_id: string
-  name: string
-  icon: string
-  color: string
-  position: number
-  source: string
-  connection_id: string | null
-  institution_name: string | null
-  asset_count: number
-  current_value: number
-  current_value_primary: number
+  id: string;
+  user_id: string;
+  name: string;
+  icon: string;
+  color: string;
+  position: number;
+  source: string;
+  connection_id: string | null;
+  institution_name: string | null;
+  asset_count: number;
+  current_value: number;
+  current_value_primary: number;
 }
 
 export interface AssetValue {
-  id: string
-  asset_id: string
-  amount: number
-  date: string
-  source: string
+  id: string;
+  asset_id: string;
+  amount: number;
+  date: string;
+  source: string;
 }
 
 export interface Goal {
-  id: string
-  user_id: string
-  name: string
-  target_amount: number
-  current_amount: number
-  currency: string
-  target_amount_primary: number | null
-  current_amount_primary: number | null
-  target_date: string | null
-  tracking_type: 'manual' | 'account' | 'asset' | 'net_worth'
-  account_id: string | null
-  asset_id: string | null
-  status: 'active' | 'completed' | 'paused' | 'archived'
-  icon: string | null
-  color: string | null
-  position: number
-  metadata_json: Record<string, unknown> | null
-  created_at: string
-  updated_at: string
-  percentage: number
-  monthly_contribution: number | null
-  on_track: 'ahead' | 'on_track' | 'behind' | 'overdue' | 'achieved' | null
-  account_name: string | null
-  asset_name: string | null
+  id: string;
+  user_id: string;
+  name: string;
+  target_amount: number;
+  current_amount: number;
+  currency: string;
+  target_amount_primary: number | null;
+  current_amount_primary: number | null;
+  target_date: string | null;
+  tracking_type: "manual" | "account" | "asset" | "net_worth";
+  account_id: string | null;
+  asset_id: string | null;
+  status: "active" | "completed" | "paused" | "archived";
+  icon: string | null;
+  color: string | null;
+  position: number;
+  metadata_json: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+  percentage: number;
+  monthly_contribution: number | null;
+  on_track: "ahead" | "on_track" | "behind" | "overdue" | "achieved" | null;
+  account_name: string | null;
+  asset_name: string | null;
 }
 
 export interface GoalSummary {
-  id: string
-  name: string
-  target_amount: number
-  current_amount: number
-  currency: string
-  target_date: string | null
-  status: string
-  icon: string | null
-  color: string | null
-  percentage: number
-  monthly_contribution: number | null
-  on_track: string | null
+  id: string;
+  name: string;
+  target_amount: number;
+  current_amount: number;
+  currency: string;
+  target_date: string | null;
+  status: string;
+  icon: string | null;
+  color: string | null;
+  percentage: number;
+  monthly_contribution: number | null;
+  on_track: string | null;
 }
 
 export interface PaginatedResponse<T> {
-  items: T[]
-  total: number
-  page: number
-  limit: number
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
 }
 
 // Income / expense / net totals for all transactions matching the active
 // filters (issue #185) — accompanies the paginated /transactions response.
 export interface TransactionsSummary {
-  income: number
-  expense: number
-  net: number
-  currency: string
+  income: number;
+  expense: number;
+  net: number;
+  currency: string;
 }
 
 export interface PaginatedTransactions extends PaginatedResponse<Transaction> {
-  summary?: TransactionsSummary
+  summary?: TransactionsSummary;
 }
 
 // Reports (universal schema for all report types)
 export interface ReportBreakdown {
-  key: string
-  label: string
-  value: number
-  color: string
+  key: string;
+  label: string;
+  value: number;
+  color: string;
 }
 
 export interface ReportSummary {
-  primary_value: number
-  change_amount: number
-  change_percent: number | null
-  breakdowns: ReportBreakdown[]
+  primary_value: number;
+  change_amount: number;
+  change_percent: number | null;
+  breakdowns: ReportBreakdown[];
 }
 
 export interface ReportDataPoint {
-  date: string
-  value: number
-  breakdowns: Record<string, number>
+  date: string;
+  value: number;
+  breakdowns: Record<string, number>;
 }
 
 export interface ReportMeta {
-  type: string
-  series_keys: string[]
-  currency: string
-  interval: string
+  type: string;
+  series_keys: string[];
+  currency: string;
+  interval: string;
 }
 
 export interface ReportCompositionItem {
-  key: string
-  label: string
-  value: number
-  color: string
-  group: string
+  key: string;
+  label: string;
+  value: number;
+  color: string;
+  group: string;
 }
 
 export interface CategoryTrendItem {
-  key: string
-  label: string
-  color: string
-  total: number
-  group: string
-  series: ReportDataPoint[]
+  key: string;
+  label: string;
+  color: string;
+  total: number;
+  group: string;
+  series: ReportDataPoint[];
 }
 
 export interface Attachment {
-  id: string
-  transaction_id: string
-  filename: string
-  content_type: string
-  size: number
-  created_at: string
+  id: string;
+  transaction_id: string;
+  filename: string;
+  content_type: string;
+  size: number;
+  created_at: string;
 }
 
 export interface ReportResponse {
-  summary: ReportSummary
-  trend: ReportDataPoint[]
-  meta: ReportMeta
-  composition: ReportCompositionItem[]
-  category_trend: CategoryTrendItem[]
+  summary: ReportSummary;
+  trend: ReportDataPoint[];
+  meta: ReportMeta;
+  composition: ReportCompositionItem[];
+  category_trend: CategoryTrendItem[];
 }


### PR DESCRIPTION
## Problem

When Pluggy syncs, it re-fetches deleted transactions — making it impossible to permanently remove duplicates like the double credit-card payment described in #200. Users need a way to suppress a transaction without deleting it.

## Solution

Adds a persistent `is_ignored` flag to transactions. Ignored transactions survive re-syncs unchanged and are hidden from views/totals by default.

## Changes

**Backend**
- Migration `051`: adds `is_ignored` boolean column (default `false`) to `transactions`
- `PATCH /transactions/{id}/ignore` — toggles ignored state
- `PATCH /transactions/bulk-ignore` — bulk toggle for selected transactions
- `GET /transactions` — new `ignored_filter` query param: `hide` (default) | `include` | `only`
- Rule engine: new `ignore` action type to auto-ignore matching transactions on sync

**Frontend**
- Filter bar: "Ignored" submenu with hide / show all / only options
- Ignored rows: 40% opacity + strikethrough description + "Ignored" badge
- Hover on table row: EyeOff button to ignore/unignore inline
- "Only ignored" view: inline clickable badge to restore the transaction
- Transaction dialog footer: ignore/unignore action button
- Selection bar: bulk "Ignore" button for selected rows

## Test plan

- [ ] Sync an account — ignored transactions stay ignored after re-sync
- [ ] Toggle ignore via dialog footer, row hover, and bulk selection
- [ ] Filter bar: hide / show all / only ignored each show correct rows
- [ ] Ignored transactions excluded from income/expense totals when hidden
- [ ] Rule with "ignore" action auto-ignores matching new transactions
- [ ] Bulk ignore + bulk restore updates counts correctly

Fixes #200