### PR TITLE
feat: ignore transactions/categories (issue #200)

### DIFF
--- a/backend/alembic/versions/050_is_ignored_category_and_transaction.py
+++ b/backend/alembic/versions/050_is_ignored_category_and_transaction.py
@@ -1,0 +1,58 @@
+"""Add is_ignored flag to categories and transactions
+
+Revision ID: 050
+Revises: 049
+Create Date: 2026-05-19
+
+When is_ignored is True:
+- For transactions: excluded from reports, dashboard aggregations, and budget calculations
+- For categories: transactions in these categories are excluded from the above
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "050"
+down_revision = "049"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add is_ignored column to categories table
+    op.add_column(
+        "categories",
+        sa.Column(
+            "is_ignored",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    # Add is_ignored column to transactions table
+    op.add_column(
+        "transactions",
+        sa.Column(
+            "is_ignored",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    # Create index on transactions.is_ignored for query filtering efficiency
+    op.create_index(
+        "ix_transactions_is_ignored",
+        "transactions",
+        ["is_ignored"],
+    )
+
+
+def downgrade() -> None:
+    # Drop index
+    op.drop_index("ix_transactions_is_ignored", table_name="transactions")
+
+    # Remove columns
+    op.drop_column("transactions", "is_ignored")
+    op.drop_column("categories", "is_ignored")

--- a/backend/app/api/transactions.py
+++ b/backend/app/api/transactions.py
@@ -343,6 +343,19 @@ async def update_transaction(
     return _tag_fx_fallback(TransactionRead.model_validate(transaction, from_attributes=True), primary_currency)
 
 
+@router.patch("/{transaction_id}/ignore", response_model=TransactionRead)
+async def toggle_ignore_transaction(
+    transaction_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(current_active_user),
+):
+    transaction = await transaction_service.toggle_ignore_transaction(session, transaction_id, user.id)
+    if not transaction:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+    primary_currency = user.primary_currency
+    return _tag_fx_fallback(TransactionRead.model_validate(transaction, from_attributes=True), primary_currency)
+
+
 @router.delete("/{transaction_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_transaction(
     transaction_id: uuid.UUID,

--- a/backend/app/models/category.py
+++ b/backend/app/models/category.py
@@ -31,5 +31,10 @@ class Category(Base):
     # the counterpart lives in Assets, not Accounts.
     treat_as_transfer: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
 
+    # Flag to exclude transactions in this category from reports and dashboard aggregations.
+    # When set to True, transactions with this category are treated as if they don't exist
+    # for income/expense calculations.
+    is_ignored: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+
     user: Mapped["User"] = relationship(back_populates="categories")
     group: Mapped[Optional["CategoryGroup"]] = relationship(back_populates="categories")

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -3,7 +3,7 @@ from datetime import date as _date, datetime, timezone
 from decimal import Decimal
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Date, DateTime, ForeignKey, JSON, Numeric, SmallInteger, String, event
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, JSON, Numeric, SmallInteger, String, event
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -73,6 +73,9 @@ class Transaction(Base):
         nullable=True,
         index=True,
     )
+    # Flag to exclude this transaction from reports and dashboard aggregations.
+    # When set to True, the transaction is ignored for income/expense calculations.
+    is_ignored: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     account: Mapped["Account"] = relationship(back_populates="transactions")

--- a/backend/app/schemas/category.py
+++ b/backend/app/schemas/category.py
@@ -13,6 +13,7 @@ class CategoryBase(BaseModel):
 class CategoryCreate(CategoryBase):
     group_id: Optional[uuid.UUID] = None
     treat_as_transfer: bool = False
+    is_ignored: bool = False
 
 
 class CategoryUpdate(BaseModel):
@@ -21,6 +22,7 @@ class CategoryUpdate(BaseModel):
     color: Optional[str] = None
     group_id: Optional[uuid.UUID] = None
     treat_as_transfer: Optional[bool] = None
+    is_ignored: Optional[bool] = None
 
 
 class CategoryRead(CategoryBase):
@@ -29,5 +31,6 @@ class CategoryRead(CategoryBase):
     group_id: Optional[uuid.UUID] = None
     is_system: bool
     treat_as_transfer: bool = False
+    is_ignored: bool = False
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -48,6 +48,7 @@ class TransactionUpdate(BaseModel):
     notes: Optional[str] = None
     amount_primary: Optional[Decimal] = None
     fx_rate_used: Optional[Decimal] = None
+    is_ignored: Optional[bool] = None
     apply_to_transfer_pair: bool = False
     # CC bucketing override (issue #92). Empty string / explicit null clears
     # it back to auto. Only meaningful for credit-card accounts.
@@ -93,6 +94,7 @@ class TransactionRead(TransactionBase):
     # is_self member at request time. Helps the UI show who paid
     # instead of a generic "shared" badge.
     parent_owner_name: Optional[str] = None
+    is_ignored: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/_query_filters.py
+++ b/backend/app/services/_query_filters.py
@@ -22,7 +22,9 @@ def counts_as_pnl():
       - paired transfers (both legs were matched; already cancel out),
       - transactions in categories flagged `treat_as_transfer` (one-sided
         movements like investment applications where the counterpart is
-        an Asset/Holding, not another Account).
+        an Asset/Holding, not another Account),
+      - transactions flagged `is_ignored=True` (user-marked as not to be reported),
+      - transactions in categories flagged `is_ignored=True` (user-marked as not to be reported).
 
     Does NOT exclude `source='opening_balance'` — callers that already
     filter those keep doing so; this helper only handles the transfer-like
@@ -30,6 +32,7 @@ def counts_as_pnl():
     """
     return and_(
         Transaction.transfer_pair_id.is_(None),
+        Transaction.is_ignored.is_(False),
         # Settlement *debits* are repayments of debts that were already
         # booked as an expense via the share. Counting them would
         # double-count. Settlement *credits*, however, represent the
@@ -40,7 +43,12 @@ def counts_as_pnl():
         or_(
             Transaction.category_id.is_(None),
             Transaction.category_id.not_in(
-                select(Category.id).where(Category.treat_as_transfer.is_(True))
+                select(Category.id).where(
+                    or_(
+                        Category.treat_as_transfer.is_(True),
+                        Category.is_ignored.is_(True),
+                    )
+                )
             ),
         ),
     )

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -13,6 +13,7 @@ from app.models.transaction import Transaction
 from app.schemas.account import AccountCreate, AccountUpdate
 from app.services._query_filters import counts_as_pnl
 from app.services.credit_card_service import apply_effective_date, compute_available_credit, get_cycle_dates
+from app.models.category import Category
 
 
 def get_account_name(account: Account) -> str:
@@ -38,6 +39,14 @@ async def get_accounts(session: AsyncSession, user_id: uuid.UUID, include_closed
             func.coalesce(func.sum(signed_amount), 0).label("current_balance"),
         )
         .join(Account, Transaction.account_id == Account.id)
+        .outerjoin(Category, Transaction.category_id == Category.id)
+        .where(
+            Transaction.is_ignored == False,
+            or_(
+                Transaction.category_id.is_(None),
+                Category.is_ignored == False,
+            ),
+        )
         .group_by(Transaction.account_id)
         .subquery()
     )
@@ -52,8 +61,15 @@ async def get_accounts(session: AsyncSession, user_id: uuid.UUID, include_closed
             Transaction.account_id,
             func.coalesce(func.sum(signed_amount), 0).label("previous_balance"),
         )
-        .join(Account, Transaction.account_id == Account.id)
-        .where(Transaction.date <= prev_month_end)
+        .outerjoin(Category, Transaction.category_id == Category.id)
+        .where(
+            Transaction.date <= prev_month_end,
+            Transaction.is_ignored == False,
+            or_(
+                Transaction.category_id.is_(None),
+                Category.is_ignored == False,
+            ),
+        )
         .group_by(Transaction.account_id)
         .subquery()
     )
@@ -79,11 +95,10 @@ async def get_accounts(session: AsyncSession, user_id: uuid.UUID, include_closed
         query = query.where(Account.is_closed == False)
     query = query.order_by(Account.name)
     result = await session.execute(query)
-
     return [
-        serialize_account(acc, current_balance, previous_balance)
-        for acc, current_balance, previous_balance in result.all()
-    ]
+            serialize_account(acc, current_balance, previous_balance)
+            for acc, current_balance, previous_balance in result.all()
+        ]
 
 
 def serialize_account(
@@ -556,7 +571,16 @@ async def get_account_summary(
                     ),
                     0,
                 )
-            ).where(Transaction.account_id == account_id)
+            ).where(
+                Transaction.account_id == account_id,
+                Transaction.is_ignored == False,
+                or_(
+                    Transaction.category_id.is_(None),
+                    Transaction.category_id.not_in(
+                        select(Category.id).where(Category.is_ignored == True)
+                    ),
+                ),
+            )
         )
         current_balance = float(balance_result.scalar())
 
@@ -698,12 +722,19 @@ async def _account_balance_at(
     session: AsyncSession, account_id: uuid.UUID, cutoff: _Date,
     account_currency: str = "",
 ) -> float:
-    """Get balance for a single account at a specific date."""
+    """Get balance for a single account at a specific date.
+    Excludes ignored transactions from the balance calculation."""
     result = await session.execute(
         select(func.coalesce(func.sum(_signed_amount_expr(account_currency)), 0))
+        .outerjoin(Category, Transaction.category_id == Category.id)
         .where(
             Transaction.account_id == account_id,
             Transaction.date <= cutoff,
+            Transaction.is_ignored == False,
+            or_(
+                Transaction.category_id.is_(None),
+                Category.is_ignored == False,
+            ),
         )
     )
     return float(result.scalar() or 0)
@@ -714,20 +745,28 @@ async def _account_daily_balance_series(
     date_from: _Date, date_to: _Date,
     account_currency: str = "",
 ) -> list[dict]:
-    """Build daily balance series for [date_from, date_to] inclusive."""
+    """Build daily balance series for [date_from, date_to] inclusive.
+    Excludes ignored transactions from balance calculations."""
     # Get balance at end of day before range start
     start_balance = await _account_balance_at(session, account_id, date_from - timedelta(days=1), account_currency)
 
     # Get daily deltas within range: group by actual date
+    # Exclude ignored transactions from daily deltas
     result = await session.execute(
         select(
             Transaction.date,
             func.sum(_signed_amount_expr(account_currency)),
         )
+        .outerjoin(Category, Transaction.category_id == Category.id)
         .where(
             Transaction.account_id == account_id,
             Transaction.date >= date_from,
             Transaction.date <= date_to,
+            Transaction.is_ignored == False,
+            or_(
+                Transaction.category_id.is_(None),
+                Category.is_ignored == False,
+            ),
         )
         .group_by(Transaction.date)
     )

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -1070,6 +1070,10 @@ async def sync_connection(
                 )
                 existing_tx = existing.scalar_one_or_none()
                 if existing_tx:
+                    # User-flagged rows are frozen: skip status/bill drift so
+                    # a re-sync can't revive a transaction the user hid.
+                    if existing_tx.is_ignored:
+                        continue
                     if existing_tx.status == "pending" and txn_data.status == "posted":
                         existing_tx.status = "posted"
                     # Self-heal bill linkage: a tx that pre-dates the bills
@@ -1097,6 +1101,8 @@ async def sync_connection(
                 # Pass 2: Fuzzy match against manual transactions
                 fuzzy_match = await _fuzzy_match_manual(session, account.id, txn_data)
                 if fuzzy_match:
+                    if fuzzy_match.is_ignored:
+                        continue
                     fuzzy_match.external_id = txn_data.external_id
                     fuzzy_match.source = "sync"
                     fuzzy_match.raw_data = txn_data.raw_data

--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -766,21 +766,25 @@ async def _account_balance_at(
         if account.type == "credit_card":
             current_bal = -current_bal
         # Subtract activity after cutoff to get the balance AT cutoff
+        # Exclude ignored transactions from balance calculation
         delta_after = await session.scalar(
             select(func.coalesce(func.sum(_signed_balance_expr(account.currency)), 0))
             .where(
                 Transaction.account_id == account.id,
                 Transaction.date > cutoff,
+                Transaction.is_ignored == False,
             )
         )
         return current_bal - float(delta_after or 0)
     else:
         # Manual: sum signed transactions up to cutoff
+        # Exclude ignored transactions from balance calculation
         result = await session.scalar(
             select(func.coalesce(func.sum(_signed_balance_expr(account.currency)), 0))
             .where(
                 Transaction.account_id == account.id,
                 Transaction.date <= cutoff,
+                Transaction.is_ignored == False,
             )
         )
         return float(result or 0)
@@ -842,11 +846,17 @@ async def _daily_deltas(
             func.sum(signed),
         )
         .join(Account, Transaction.account_id == Account.id)
+        .outerjoin(Category, Transaction.category_id == Category.id)
         .where(
             Transaction.user_id == user_id,
             Account.is_closed == False,
             Transaction.date >= start,
             Transaction.date < end,
+            Transaction.is_ignored == False,
+            or_(
+                Transaction.category_id.is_(None),
+                Category.is_ignored == False,
+            ),
         )
         .group_by("day", Account.currency)
     )

--- a/backend/app/services/rule_engine.py
+++ b/backend/app/services/rule_engine.py
@@ -112,4 +112,7 @@ def apply_rule_actions(
             if new_tags not in existing:
                 tx.notes = (existing + " " + new_tags).strip() if existing else new_tags
 
+        elif op == "ignore":
+            tx.is_ignored = True
+
     return category_already_set

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -21,6 +21,8 @@ from app.services import split_service
 from app.services.credit_card_service import apply_effective_date
 from app.services.rule_service import apply_rules_to_transaction
 from app.services.fx_rate_service import stamp_primary_amount, convert as fx_convert
+from app.services._query_filters import counts_as_pnl
+
 
 
 def _apply_fx_override(transaction, amount, amount_primary=None, fx_rate_used=None):
@@ -343,15 +345,22 @@ async def get_transactions(
     # rows). Computed before pagination so it covers the whole result set.
     summary: Optional[dict] = None
     if include_summary:
-        summary_subq = base_query.subquery()
+        ignored_category_ids = select(Category.id).where(Category.is_ignored == True)
+        pnl_subq = base_query.where(
+        Transaction.is_ignored == False,
+        or_(
+            Transaction.category_id.is_(None),
+            Transaction.category_id.not_in(ignored_category_ids),
+        ),
+    ).subquery()
         amount_norm = func.coalesce(
-            summary_subq.c.amount_primary, summary_subq.c.amount
+            pnl_subq.c.amount_primary, pnl_subq.c.amount
         )
         summary_rows = await session.execute(
             select(
-                summary_subq.c.type,
+                pnl_subq.c.type,
                 func.coalesce(func.sum(func.abs(amount_norm)), 0),
-            ).group_by(summary_subq.c.type)
+            ).group_by(pnl_subq.c.type)
         )
         income = Decimal("0")
         expense = Decimal("0")
@@ -419,7 +428,8 @@ async def get_transactions(
         for tx in transactions:
             tx.attachment_count = counts.get(tx.id, 0)
             tx.payee_name = tx.payee_entity.name if tx.payee_entity else None
-
+            if not tx.is_ignored and tx.category and tx.category.is_ignored:
+                tx.is_ignored = True
         # Tag shared rows with the viewer's share + the source group.
         # Owned rows stay as-is. We pre-compute the viewer's linked
         # member ids → group ids once, then look up each transaction's

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -1258,6 +1258,22 @@ async def bulk_add_to_group(
     return {"updated": updated, "skipped": skipped}
 
 
+async def toggle_ignore_transaction(
+    session: AsyncSession, transaction_id: uuid.UUID, user_id: uuid.UUID
+) -> Optional[Transaction]:
+    """Flip the is_ignored flag on a transaction. Acts immediately (no
+    other field is touched) so the edit dialog can offer ignore as a
+    one-click action alongside delete, instead of bundling it into the
+    form's Salvar flow."""
+    transaction = await get_transaction(session, transaction_id, user_id)
+    if not transaction:
+        return None
+    transaction.is_ignored = not transaction.is_ignored
+    await session.commit()
+    await session.refresh(transaction)
+    return transaction
+
+
 async def delete_transaction(
     session: AsyncSession, transaction_id: uuid.UUID, user_id: uuid.UUID
 ) -> bool:

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -21,8 +21,6 @@ from app.services import split_service
 from app.services.credit_card_service import apply_effective_date
 from app.services.rule_service import apply_rules_to_transaction
 from app.services.fx_rate_service import stamp_primary_amount, convert as fx_convert
-from app.services._query_filters import counts_as_pnl
-
 
 
 def _apply_fx_override(transaction, amount, amount_primary=None, fx_rate_used=None):

--- a/backend/tests/test_connection_service.py
+++ b/backend/tests/test_connection_service.py
@@ -599,6 +599,64 @@ async def test_sync_connection_skips_pending(session: AsyncSession, test_user):
     assert result_conn.status == "active"
 
 
+@pytest.mark.asyncio
+async def test_sync_connection_does_not_revive_ignored_transaction(
+    session: AsyncSession, test_user,
+):
+    """Issue #200: a transaction the user flagged is_ignored=True must not be
+    mutated by a subsequent sync, even when Pluggy returns the same external_id
+    with different fields (e.g. pending → posted)."""
+    from app.models.account import Account
+
+    conn = await _make_connection(session, test_user.id, "Ignore Bank")
+    account = Account(
+        id=uuid.uuid4(), user_id=test_user.id, connection_id=conn.id,
+        name="Checking", type="checking",
+        external_id="ign-acc-1",
+        balance=Decimal("0"), currency="BRL",
+    )
+    session.add(account)
+    await session.flush()
+
+    session.add(Transaction(
+        id=uuid.uuid4(), user_id=test_user.id, account_id=account.id,
+        external_id="ign-tx-1", description="DUPLICATE PAYMENT",
+        amount=Decimal("100"), date=date.today(), type="debit",
+        currency="BRL", source="sync", status="pending",
+        is_ignored=True,
+        created_at=datetime.now(timezone.utc),
+    ))
+    await session.commit()
+
+    mock_provider = AsyncMock()
+    mock_provider.refresh_credentials = AsyncMock(return_value={"token": "t"})
+    mock_provider.get_accounts = AsyncMock(return_value=[
+        AccountData(
+            external_id="ign-acc-1", name="Checking",
+            type="checking", balance=Decimal("0"), currency="BRL",
+        ),
+    ])
+    mock_provider.get_transactions = AsyncMock(return_value=[
+        TransactionData(
+            external_id="ign-tx-1", description="DUPLICATE PAYMENT",
+            amount=Decimal("100"), date=date.today(), type="debit",
+            currency="BRL", status="posted",
+        ),
+    ])
+
+    with patch("app.services.connection_service.get_provider", return_value=mock_provider), \
+         patch("app.services.connection_service.detect_transfer_pairs", new_callable=AsyncMock), \
+         patch("app.services.connection_service.stamp_primary_amount", new_callable=AsyncMock), \
+         patch("app.services.connection_service.apply_rules_to_transaction", new_callable=AsyncMock):
+        await sync_connection(session, conn.id, test_user.id)
+
+    refreshed = (await session.execute(
+        select(Transaction).where(Transaction.external_id == "ign-tx-1")
+    )).scalar_one()
+    assert refreshed.is_ignored is True
+    assert refreshed.status == "pending"  # not flipped to posted
+
+
 # ---------------------------------------------------------------------------
 # Installment metadata persistence (issue #14 v1)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_rule_engine.py
+++ b/backend/tests/test_rule_engine.py
@@ -164,6 +164,13 @@ def test_append_notes_no_duplicate():
     assert tx.notes.count("#work") == 1
 
 
+def test_ignore_action_sets_flag():
+    actions = [{"op": "ignore"}]
+    tx = make_tx(is_ignored=False)
+    apply_rule_actions(actions, tx, category_already_set=False)
+    assert tx.is_ignored is True
+
+
 # --- Edge-case: evaluate_conditions ---
 
 def test_not_equals():

--- a/backend/tests/test_transaction_service.py
+++ b/backend/tests/test_transaction_service.py
@@ -18,6 +18,7 @@ from app.services.transaction_service import (
     create_transaction,
     create_transfer,
     delete_transaction,
+    toggle_ignore_transaction,
     get_transaction,
     get_transactions,
     update_transaction,
@@ -496,6 +497,38 @@ async def test_delete_transaction(session: AsyncSession, test_user, txn_account)
 @pytest.mark.asyncio
 async def test_delete_transaction_not_found(session: AsyncSession, test_user):
     assert await delete_transaction(session, uuid.uuid4(), test_user.id) is False
+
+
+@pytest.mark.asyncio
+async def test_toggle_ignore_transaction(session: AsyncSession, test_user, txn_account):
+    txn = Transaction(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        account_id=txn_account.id,
+        description="ToIgnore",
+        amount=Decimal("10"),
+        date=date(2025, 3, 1),
+        type="debit",
+        source="manual",
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(txn)
+    await session.commit()
+
+    # First toggle: false → true
+    result = await toggle_ignore_transaction(session, txn.id, test_user.id)
+    assert result is not None
+    assert result.is_ignored is True
+
+    # Second toggle: true → false
+    result = await toggle_ignore_transaction(session, txn.id, test_user.id)
+    assert result is not None
+    assert result.is_ignored is False
+
+
+@pytest.mark.asyncio
+async def test_toggle_ignore_transaction_not_found(session: AsyncSession, test_user):
+    assert await toggle_ignore_transaction(session, uuid.uuid4(), test_user.id) is None
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -16,7 +16,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog'
-import { AlertTriangle, ChevronDown, ChevronLeft, Download, Paperclip, Upload, X, FileText, Plus, Unlink } from 'lucide-react'
+import { AlertTriangle, ChevronDown, ChevronLeft, Download, Paperclip, Upload, X, FileText, Plus, Unlink, EyeClosed } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -364,6 +364,7 @@ function TransactionForm({
   const pendingFileInputRef = useRef<HTMLInputElement>(null)
   const pendingActionRef = useRef<SaveAction>('save')
   const formRef = useRef<HTMLFormElement>(null)
+  const [isIgnored, setIsIgnored] = useState(seed?.is_ignored ?? false)
 
   const triggerSubmit = (action: SaveAction) => {
     pendingActionRef.current = action
@@ -487,6 +488,7 @@ function TransactionForm({
               category_id: categoryId || null,
               payee_id: payeeId || null,
               notes: notes.trim() || null,
+              is_ignored: isIgnored,
               ...overridePayload,
               ...splitsPayload,
             } as Partial<Transaction>
@@ -500,6 +502,7 @@ function TransactionForm({
               payee_id: payeeId || null,
               account_id: accountId || undefined,
               notes: notes.trim() || null,
+              is_ignored: isIgnored,
               ...fxFields,
               ...overridePayload,
               ...splitsPayload,
@@ -710,6 +713,25 @@ function TransactionForm({
           onChange={(e) => setNotes(e.target.value)}
           placeholder={t('transactions.notesPlaceholder')}
         />
+      </div>
+
+      <div className="flex-col">
+        <div className="flex items-center gap-2"> 
+          <input
+          id="is-ignored"
+          type="checkbox"
+          checked={isIgnored}
+          onChange={(e) => setIsIgnored(e.target.checked)}
+          className="h-4 w-4 rounded border-border accent-primary"
+        />
+          <EyeClosed size={16}/>
+          <label htmlFor="is-ignored" className="text-sm font-medium inline-flex items-center gap-2 cursor-pointer">
+            {t('transactions.ignoreTransfer')}
+          </label>
+        </div>
+        <span className="text-xs text-muted-foreground">
+          ({t('transactions.ignoreTransferHint')})
+        </span>
       </div>
 
       {/* Manual bill-cycle override (issue #92). CC accounts only. Empty

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -16,7 +16,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog'
-import { AlertTriangle, ChevronDown, ChevronLeft, Download, Paperclip, Upload, X, FileText, Plus, Unlink, EyeClosed } from 'lucide-react'
+import { AlertTriangle, ChevronDown, ChevronLeft, Download, Eye, EyeClosed, Paperclip, Upload, X, FileText, Plus, Unlink } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -71,6 +71,7 @@ export function TransactionDialog({
   onSave,
   onDelete,
   onUnlinkTransfer,
+  onIgnoreChanged,
   loading,
   error,
   isSynced = false,
@@ -87,6 +88,7 @@ export function TransactionDialog({
   onSave: (data: Partial<Transaction>, recurringData?: { frequency: string; end_date?: string }, pendingFiles?: File[], action?: SaveAction) => void
   onDelete?: () => void
   onUnlinkTransfer?: (pairId: string) => void
+  onIgnoreChanged?: () => void
   loading: boolean
   error: string | null
   isSynced?: boolean
@@ -157,6 +159,7 @@ export function TransactionDialog({
               onSave={onSave}
               onDelete={onDelete}
               onUnlinkTransfer={onUnlinkTransfer}
+              onIgnoreChanged={onIgnoreChanged}
               onCancel={onClose}
               loading={loading}
               error={error}
@@ -273,6 +276,7 @@ function TransactionForm({
   onSave,
   onDelete,
   onUnlinkTransfer,
+  onIgnoreChanged,
   onCancel,
   loading,
   error,
@@ -290,6 +294,7 @@ function TransactionForm({
   onSave: (data: Partial<Transaction>, recurringData?: { frequency: string; end_date?: string }, pendingFiles?: File[], action?: SaveAction) => void
   onDelete?: () => void
   onUnlinkTransfer?: (pairId: string) => void
+  onIgnoreChanged?: () => void
   onCancel: () => void
   loading: boolean
   error: string | null
@@ -365,6 +370,24 @@ function TransactionForm({
   const pendingActionRef = useRef<SaveAction>('save')
   const formRef = useRef<HTMLFormElement>(null)
   const [isIgnored, setIsIgnored] = useState(seed?.is_ignored ?? false)
+  const [togglingIgnore, setTogglingIgnore] = useState(false)
+
+  const handleToggleIgnore = async () => {
+    if (!seed?.id || togglingIgnore) return
+    setTogglingIgnore(true)
+    try {
+      const updated = await transactionsApi.toggleIgnore(seed.id)
+      setIsIgnored(updated.is_ignored)
+      toast.success(updated.is_ignored
+        ? t('transactions.ignoreSuccess')
+        : t('transactions.unignoreSuccess'))
+      onIgnoreChanged?.()
+    } catch {
+      toast.error(t('common.error'))
+    } finally {
+      setTogglingIgnore(false)
+    }
+  }
 
   const triggerSubmit = (action: SaveAction) => {
     pendingActionRef.current = action
@@ -715,25 +738,6 @@ function TransactionForm({
         />
       </div>
 
-      <div className="flex-col">
-        <div className="flex items-center gap-2"> 
-          <input
-          id="is-ignored"
-          type="checkbox"
-          checked={isIgnored}
-          onChange={(e) => setIsIgnored(e.target.checked)}
-          className="h-4 w-4 rounded border-border accent-primary"
-        />
-          <EyeClosed size={16}/>
-          <label htmlFor="is-ignored" className="text-sm font-medium inline-flex items-center gap-2 cursor-pointer">
-            {t('transactions.ignoreTransfer')}
-          </label>
-        </div>
-        <span className="text-xs text-muted-foreground">
-          ({t('transactions.ignoreTransferHint')})
-        </span>
-      </div>
-
       {/* Manual bill-cycle override (issue #92). CC accounts only. Empty
           input = use auto bucketing (Pluggy bill_id when available, cycle
           math otherwise). Setting the date forces this tx into the bill
@@ -849,13 +853,28 @@ function TransactionForm({
 
       <DialogFooter className={cn(
         'shrink-0 border-t pt-4 mt-2',
-        onDelete ? 'flex justify-between sm:justify-between' : ''
+        (onDelete || seed?.id) ? 'flex justify-between sm:justify-between' : ''
       )}>
-        {onDelete && (
-          <Button type="button" variant="destructive" onClick={onDelete} disabled={loading}>
-            {t('common.delete')}
-          </Button>
-        )}
+        <div className="flex gap-2 items-center">
+          {onDelete && (
+            <Button type="button" variant="destructive" onClick={onDelete} disabled={loading}>
+              {t('common.delete')}
+            </Button>
+          )}
+          {seed?.id && (
+            <Button
+              type="button"
+              variant={isIgnored ? 'secondary' : 'outline'}
+              onClick={handleToggleIgnore}
+              disabled={loading || togglingIgnore}
+              title={t('transactions.ignoreTransferHint')}
+              className="gap-1.5"
+            >
+              {isIgnored ? <Eye size={16} /> : <EyeClosed size={16} />}
+              {isIgnored ? t('transactions.unignoreAction') : t('transactions.ignoreAction')}
+            </Button>
+          )}
+        </div>
         <div className="flex gap-2">
           <Button type="button" variant="outline" onClick={onCancel}>
             {t('common.cancel')}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -300,6 +300,10 @@ export const transactions = {
   delete: async (id: string): Promise<void> => {
     await api.delete(`/transactions/${id}`)
   },
+  toggleIgnore: async (id: string): Promise<Transaction> => {
+    const { data } = await api.patch(`/transactions/${id}/ignore`)
+    return data
+  },
   createTransfer: async (transfer: {
     from_account_id: string
     to_account_id: string

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -300,6 +300,9 @@
     "confirmTransferCategoryDesc": "Transfers come in pairs. You can update only this transaction or apply the same category change to both sides.",
     "confirmTransferCategorySingle": "Only this transaction",
     "confirmTransferCategoryBoth": "Update both",
+    "ignoreTransfer": "Ignore this transaction",
+    "ignoreTransferHint": "Ignored transactions will not show on reports and balance",
+    "ignored": "Ignored",
     "filtersBar": {
       "filters": "Filters",
       "filterBy": "Filter by",
@@ -616,7 +619,10 @@
     "collapseAll": "Collapse all",
     "treatAsTransfer": "Treat as transfer",
     "treatAsTransferDesc": "Transactions in this category won't count as income or expense in reports. Use this for movements between your own accounts (investments, savings deposits, loan repayments).",
-    "treatAsTransferBadge": "Transfer"
+    "treatAsTransferBadge": "Transfer",
+    "ignoreTransfer": "Ignore this transfer",
+    "ignoreTransferDesc": "Ignored transactions won't show on income or expense reports.",
+    "ignoreTransferBadge": "Ignore"
   },
   "groups": {
     "title": "Category Groups",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -303,6 +303,10 @@
     "ignoreTransfer": "Ignore this transaction",
     "ignoreTransferHint": "Ignored transactions will not show on reports and balance",
     "ignored": "Ignored",
+    "ignoreAction": "Ignore",
+    "unignoreAction": "Restore",
+    "ignoreSuccess": "Transaction ignored",
+    "unignoreSuccess": "Transaction restored",
     "filtersBar": {
       "filters": "Filters",
       "filterBy": "Filter by",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -575,6 +575,8 @@
     "setPayee": "Set payee",
     "selectPayee": "Select payee...",
     "appendNotes": "Append tags/notes",
+    "ignoreAction": "Ignore transaction",
+    "ignoreActionHint": "(no value needed)",
     "selectCategory": "Select category...",
     "selectAccount": "Select account...",
     "ruleActive": "Active rule",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -575,6 +575,8 @@
     "setPayee": "Definir beneficiário",
     "selectPayee": "Selecionar beneficiário...",
     "appendNotes": "Adicionar tags/notas",
+    "ignoreAction": "Ignorar transação",
+    "ignoreActionHint": "(sem valor necessário)",
     "selectCategory": "Selecionar categoria...",
     "selectAccount": "Selecionar conta...",
     "ruleActive": "Regra ativa",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -300,6 +300,9 @@
     "confirmTransferCategoryDesc": "Transferências vêm em pares. Você pode atualizar só esta transação ou aplicar a mesma mudança de categoria aos dois lados.",
     "confirmTransferCategorySingle": "Só esta transação",
     "confirmTransferCategoryBoth": "Atualizar ambas",
+    "ignoreTransfer": "Ignorar esta transação",
+    "ignoreTransferHint": "Transações ignoradas não entram nos relatórios",
+    "ignored": "Ignorado",
     "filtersBar": {
       "filters": "Filtros",
       "filterBy": "Filtrar por",
@@ -616,7 +619,10 @@
     "collapseAll": "Recolher tudo",
     "treatAsTransfer": "Tratar como transferência",
     "treatAsTransferDesc": "Transações nesta categoria não contarão como receita ou despesa nos relatórios. Use para movimentações entre suas próprias contas (investimentos, depósitos em poupança, pagamentos de empréstimo).",
-    "treatAsTransferBadge": "Transferência"
+    "treatAsTransferBadge": "Transferência",
+    "ignoreTransfer": "Ignorar Transações",
+    "ignoreTransferDesc": "Transações ignoradas não contarão como receita ou despesa nos relatórios.",
+    "ignoreTransferBadge": "Ignorado"
   },
   "groups": {
     "title": "Grupos de Categorias",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -303,6 +303,10 @@
     "ignoreTransfer": "Ignorar esta transação",
     "ignoreTransferHint": "Transações ignoradas não entram nos relatórios",
     "ignored": "Ignorado",
+    "ignoreAction": "Ignorar",
+    "unignoreAction": "Não ignorar",
+    "ignoreSuccess": "Transação ignorada",
+    "unignoreSuccess": "Transação reativada",
     "filtersBar": {
       "filters": "Filtros",
       "filterBy": "Filtrar por",

--- a/frontend/src/pages/account-detail.tsx
+++ b/frontend/src/pages/account-detail.tsx
@@ -11,7 +11,7 @@ import { toast } from 'sonner'
 import type { CreditCardBill, Transaction } from '@/types'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
-import { ArrowLeft, ArrowLeftRight, CalendarClock, ChevronLeft, ChevronRight, Clock, HelpCircle, Paperclip, Pencil, X } from 'lucide-react'
+import { ArrowLeft, ArrowLeftRight, CalendarClock, ChevronLeft, ChevronRight, Clock, EyeClosed, HelpCircle, Paperclip, Pencil, X } from 'lucide-react'
 import { CategoryIcon } from '@/components/category-icon'
 import { TransactionDialog, extractApiError } from '@/components/transaction-dialog'
 import { TransferDialog } from '@/components/transfer-dialog'
@@ -1353,6 +1353,7 @@ export default function AccountDetailPage() {
                     const isOpening = tx.source === 'opening_balance'
                     const isTransfer = !!tx.transfer_pair_id
                     const isPending = tx.status === 'pending'
+                    const isIgnored = tx.is_ignored
                     return (
                       <tr
                         key={tx.id}
@@ -1386,6 +1387,13 @@ export default function AccountDetailPage() {
                               <span className="ml-2 inline-flex items-center gap-1 text-xs text-amber-600 font-normal bg-amber-50 border border-amber-200 rounded px-1.5 py-0.5">
                                 <Clock className="h-3 w-3" />
                                 {t('transactions.pending')}
+                              </span>
+                            )}
+                            {isIgnored && (
+                              <span className="ml-2 inline-flex items-center gap-1 text-xs text-gray-600 font-normal bg-gray-100 border border-gray-200 rounded px-1.5 py-0.5">
+                                <EyeClosed className="h-3 w-3" />
+                                {t('transactions.ignored')}
+                                <span title={t('transactions.ignoreTransferHint')}><HelpCircle className="h-3 w-3 text-blue-400" /></span>
                               </span>
                             )}
                             {tx.installment_number != null && tx.total_installments != null && (
@@ -1425,8 +1433,8 @@ export default function AccountDetailPage() {
                             <span className="text-muted-foreground">—</span>
                           )}
                         </td>
-                        <td className={`px-3 sm:px-4 py-3 text-right text-xs sm:text-sm font-semibold tabular-nums ${tx.type === 'credit' ? 'text-emerald-600' : 'text-rose-500'}`}>
-                          {mask(`${tx.type === 'credit' ? '+' : '-'}${formatCurrency(Math.abs(Number(tx.amount)), tx.currency, locale)}`)}
+                        <td className={`px-3 sm:px-4 py-3 text-right text-xs sm:text-sm font-semibold tabular-nums ${tx.is_ignored ? 'text-gray-500' : tx.type === 'credit' ? 'text-emerald-600' : 'text-rose-500'}`}>
+                          {mask(`${tx.is_ignored ? ' ' : tx.type === 'credit' ? '+' : '-'}${formatCurrency(Math.abs(Number(tx.amount)), tx.currency, locale)}`)}
                           {tx.currency !== userCurrency && tx.amount_primary != null && (
                             <span className="block text-[10px] text-muted-foreground tabular-nums">
                               {mask(formatCurrency(Math.abs(tx.amount_primary), userCurrency, locale))}

--- a/frontend/src/pages/categories.tsx
+++ b/frontend/src/pages/categories.tsx
@@ -46,6 +46,7 @@ export default function CategoriesPage() {
   const [formIcon, setFormIcon] = useState('circle-help')
   const [formColor, setFormColor] = useState('#6366f1')
   const [formTreatAsTransfer, setFormTreatAsTransfer] = useState(false)
+  const [formIgnoreTransfer, setFormIgnoreTransfer] = useState(false)
   const [groupDialogOpen, setGroupDialogOpen] = useState(false)
   const [editingGroup, setEditingGroup] = useState<CategoryGroup | null>(null)
   const [groupFormIcon, setGroupFormIcon] = useState('folder')
@@ -131,6 +132,14 @@ export default function CategoriesPage() {
             title={t('categories.treatAsTransferDesc')}
           >
             {t('categories.treatAsTransferBadge')}
+          </span>
+        )}
+        {cat.is_ignored && (
+          <span
+            className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-muted text-muted-foreground border border-border shrink-0"
+            title={t('categories.ignoreTransferDesc')}
+          >
+            {t('categories.ignoreTransferBadge')}
           </span>
         )}
       </div>
@@ -262,6 +271,7 @@ export default function CategoriesPage() {
                 color: formData.get('color') as string,
                 group_id: (formData.get('group_id') as string) || null,
                 treat_as_transfer: formTreatAsTransfer,
+                is_ignored: formIgnoreTransfer
               }
               if (editingCat) {
                 updateCatMutation.mutate({ id: editingCat.id, ...data })
@@ -308,6 +318,18 @@ export default function CategoriesPage() {
                 <div className="flex-1 min-w-0">
                   <span className="text-sm font-medium text-foreground">{t('categories.treatAsTransfer')}</span>
                   <p className="text-xs text-muted-foreground mt-0.5">{t('categories.treatAsTransferDesc')}</p>
+                </div>
+              </label>
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={formIgnoreTransfer}
+                  onChange={(e) => setFormIgnoreTransfer(e.target.checked)}
+                  className="h-4 w-4 mt-0.5 rounded border-border shrink-0"
+                />
+                <div className="flex-1 min-w-0">
+                  <span className="text-sm font-medium text-foreground">{t('categories.ignoreTransfer')}</span>
+                  <p className="text-xs text-muted-foreground mt-0.5">{t('categories.ignoreTransferDesc')}</p>
                 </div>
               </label>
             </div>

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -27,7 +27,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
-import { CheckCircle2, CalendarIcon, Paperclip, Target, ArrowUpDown, HelpCircle } from 'lucide-react'
+import { CheckCircle2, CalendarIcon, Paperclip, Target, ArrowUpDown, HelpCircle, EyeClosed } from 'lucide-react'
 import { Link, useNavigate } from 'react-router-dom'
 import { ICON_MAP } from '@/lib/category-icons'
 import { PageHeader } from '@/components/page-header'
@@ -306,6 +306,7 @@ export default function DashboardPage() {
     groupId: string | null
     parentOwnerName: string | null
     groupName: string | null
+    isIgnored: boolean
   }
 
   const TX_PER_PAGE = 10
@@ -344,6 +345,7 @@ export default function DashboardPage() {
         groupId,
         parentOwnerName: isShared ? tx.parent_owner_name ?? null : null,
         groupName: groupId ? groupNameById.get(groupId) ?? null : null,
+        isIgnored: tx.is_ignored
       })
     }
     for (const pt of projectedTxs ?? []) {
@@ -366,6 +368,7 @@ export default function DashboardPage() {
         groupId: null,
         parentOwnerName: null,
         groupName: null,
+        isIgnored: pt.is_ignored
       })
     }
     rows.sort((a, b) => txSortDesc ? b.date.localeCompare(a.date) : a.date.localeCompare(b.date))
@@ -972,6 +975,13 @@ export default function DashboardPage() {
                                   {t('transactions.recurringBadge')}
                                 </span>
                               )}
+                              {row.isIgnored && (
+                                <span className="ml-2 inline-flex items-center gap-1 text-xs text-gray-600 font-normal bg-gray-100 border border-gray-200 rounded px-1.5 py-0.5">
+                                <EyeClosed className="h-3 w-3" />
+                                {t('transactions.ignored')}
+                                <span title={t('transactions.ignoreTransferHint')}><HelpCircle className="h-3 w-3 text-blue-400" /></span>
+                                </span>
+                              )}
                               {row.attachmentCount > 0 && (
                                 <Paperclip size={12} className="text-muted-foreground shrink-0" />
                               )}
@@ -981,8 +991,8 @@ export default function DashboardPage() {
                         </div>
                       </TableCell>
                       <TableCell className="py-2.5 pr-5 text-right">
-                        <span className={`text-sm font-semibold tabular-nums ${row.type === 'credit' ? 'text-emerald-600' : 'text-rose-500'}`}>
-                          {mask(`${row.type === 'credit' ? '+' : '-'}${formatCurrency(Math.abs(row.amount), row.currency, locale)}`)}
+                        <span className={`text-sm font-semibold tabular-nums ${row.isIgnored ? 'text-gray-500' : row.type === 'credit' ? 'text-emerald-600' : 'text-rose-500'}`}>
+                          {mask(`${row.isIgnored ? ' ' : row.type === 'credit' ? '+' : '-'}${formatCurrency(Math.abs(row.amount), row.currency, locale)}`)}
                         </span>
                         {row.isShared && row.parentTotal != null && (
                           <span className="block text-[10px] text-muted-foreground tabular-nums">

--- a/frontend/src/pages/rules.tsx
+++ b/frontend/src/pages/rules.tsx
@@ -107,6 +107,7 @@ function actionSummary(actions: RuleAction[], categories: Category[], payeesList
       return p ? `→ ${t('payees.payee')}: ${p.name}` : `→ ${t('payees.payee')}`
     }
     if (a.op === 'append_notes') return `→ ${t('rules.fieldNotes')}: ${a.value}`
+    if (a.op === 'ignore') return `→ ${t('rules.ignoreAction')}`
     return a.op
   }).join('  ') || t('rules.noActions')
 }
@@ -490,7 +491,13 @@ function RuleDialog({
   }
 
   function updateAction(i: number, field: keyof RuleAction, val: string) {
-    setActions(prev => prev.map((a, idx) => idx === i ? { ...a, [field]: val } : a))
+    setActions(prev => prev.map((a, idx) => {
+      if (idx !== i) return a
+      const next = { ...a, [field]: val }
+      // Switching op clears any stale value (e.g. category UUID → ignore).
+      if (field === 'op') next.value = ''
+      return next
+    }))
   }
 
   function removeAction(i: number) {
@@ -639,8 +646,13 @@ function RuleDialog({
                     <option value="set_category">{t('rules.setCategory')}</option>
                     <option value="set_payee">{t('rules.setPayee')}</option>
                     <option value="append_notes">{t('rules.appendNotes')}</option>
+                    <option value="ignore">{t('rules.ignoreAction')}</option>
                   </select>
-                  {action.op === 'set_category' ? (
+                  {action.op === 'ignore' ? (
+                    <span className="w-0 flex-1 min-w-0 text-sm text-muted-foreground italic">
+                      {t('rules.ignoreActionHint')}
+                    </span>
+                  ) : action.op === 'set_category' ? (
                     <div className="w-0 flex-1 min-w-0">
                       <CategorySelect
                         value={action.value}

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -24,7 +24,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Skeleton } from '@/components/ui/skeleton'
-import { AlertTriangle, ArrowLeftRight, ArrowUp, ArrowDown, Check, Copy, Download, HelpCircle, Info, Paperclip, Users, X } from 'lucide-react'
+import { AlertTriangle, ArrowLeftRight, ArrowUp, ArrowDown, Check, Copy, Download, HelpCircle, Info, Paperclip, Users, X, EyeClosed } from 'lucide-react'
 import type { Transaction } from '@/types'
 import { PageHeader } from '@/components/page-header'
 import { CategoryIcon } from '@/components/category-icon'
@@ -683,11 +683,11 @@ export default function TransactionsPage() {
       <>
         <span
           className={`text-xs md:text-sm font-bold tabular-nums ${
-            tx.type === 'credit' ? 'text-emerald-600' : 'text-rose-500'
+            tx.is_ignored ? 'text-gray-500': tx.type === 'credit' ? 'text-emerald-600' : 'text-rose-500'
           }`}
         >
           {mask(
-            `${tx.type === 'credit' ? '+' : '−'}${formatCurrency(
+            `${tx.is_ignored ? ' ' : tx.type === 'credit' ? '+' : '−'}${formatCurrency(
               Math.abs(displayAmount),
               tx.currency,
               locale,
@@ -757,6 +757,15 @@ export default function TransactionsPage() {
                 <span title={t('transactions.transferTooltip')}><HelpCircle className="h-3 w-3 text-blue-400" /></span>
               </span>
             )}
+            {tx.is_ignored && 
+              (
+              <span className="ml-2 inline-flex items-center gap-1 text-xs text-gray-600 font-normal bg-gray-100 border border-gray-200 rounded px-1.5 py-0.5">
+                <EyeClosed className="h-3 w-3" />
+                {t('transactions.ignored')}
+                <span title={t('transactions.ignoreTransferHint')}><HelpCircle className="h-3 w-3 text-blue-400" /></span>
+              </span>
+                            )
+            }
             {recurringList?.some(r => r.description === tx.description && r.type === tx.type) && (
               <span className="text-[10px] font-semibold uppercase tracking-wide text-primary bg-primary/5 border border-primary/10 px-1.5 py-0.5 rounded-full">
                 {t('transactions.recurringBadge')}

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -1407,6 +1407,7 @@ export default function TransactionsPage() {
         onSave={handleTransactionSave}
         onDelete={editingTx ? () => deleteMutation.mutate(editingTx.id) : undefined}
         onUnlinkTransfer={(pairId) => unlinkTransferMutation.mutate(pairId)}
+        onIgnoreChanged={invalidateAfterTxMutation}
         loading={createMutation.isPending || updateMutation.isPending || deleteMutation.isPending || unlinkTransferMutation.isPending}
         error={createMutation.error || updateMutation.error ? extractApiError(createMutation.error || updateMutation.error) : null}
         isSynced={editingTx?.source === 'sync'}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -45,6 +45,7 @@ export interface Category {
   color: string
   is_system: boolean
   treat_as_transfer: boolean
+  is_ignored: boolean
 }
 
 export interface CategoryGroup {
@@ -165,6 +166,8 @@ export interface Transaction {
   // Display name of the parent's owner (the person who actually paid).
   // Derived per-request from the group's `is_self` member.
   parent_owner_name?: string | null
+  // Flag to exclude this transaction from reports and dashboard aggregations
+  is_ignored: boolean
 }
 
 export type ShareType = 'equal' | 'exact' | 'percent'
@@ -359,6 +362,7 @@ export interface ProjectedTransaction {
   category_name: string | null
   category_icon: string | null
   category_color: string | null
+  is_ignored: boolean
 }
 
 export interface DashboardSummary {


### PR DESCRIPTION
## What

Adds is_ignored flags for transactions and categories. This flag is used as .where(is_ignored) in SQL queries preventing them from being counted towards reports and balance.

## Why

Resolves #200 

## How to Test

Steps to verify the changes work:

1. Create a transaction and set it to Ignored on dialog
2. It shows up on your transaction list with a grey color and won't be counted on balances and reports.
3. You can also assign a category as "ignored" just like "transfer" categories.

## Checklist

- [X] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [X] Frontend builds (`npm run build`)
- [X] Translations updated (if user-facing strings changed)

## Examples:
Main page:
<img width="1138" height="935" alt="image" src="https://github.com/user-attachments/assets/7246c692-e689-41c7-9ebb-636eaa4441e4" />

Transactions:
<img width="1166" height="523" alt="image" src="https://github.com/user-attachments/assets/1db23d51-aed6-4eaa-8221-051d6baeffe9" />

Transaction Dialog:
<img width="613" height="801" alt="image" src="https://github.com/user-attachments/assets/94731458-6516-49c8-abb6-d5faba0b2fb8" />


Accounts: 
<img width="1150" height="892" alt="image" src="https://github.com/user-attachments/assets/476b9703-1b9f-4c9b-9531-339720cf2bbc" />

Category:
<img width="1130" height="453" alt="image" src="https://github.com/user-attachments/assets/b0ec3b27-516e-4bb3-93eb-d1d44c03d72c" />

