### PR TITLE
Networth UI improvements

### DIFF
--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -1,7 +1,9 @@
 import calendar
 import uuid
+from collections import defaultdict
 from datetime import date, timedelta
 from decimal import Decimal
+from typing import Optional
 
 from sqlalchemy import String, select, desc, func, case
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -10,6 +12,7 @@ from app.core.config import get_settings
 from app.models.account import Account
 from app.models.asset import Asset
 from app.models.asset_value import AssetValue
+from app.models.fx_rate import FxRate
 from app.models.transaction import Transaction
 from app.models.category import Category
 from app.models.user import User
@@ -30,7 +33,11 @@ from app.schemas.report import (
     ReportResponse,
     ReportSummary,
 )
-from app.services.asset_service import get_asset_values_at
+from app.services.asset_service import (
+    get_asset_values_at,
+    _load_asset_native_values,
+    _fill_forward_at,
+)
 from app.services.dashboard_service import _get_open_accounts, _account_balance_at
 
 CATEGORY_TREND_TOP_N = 11
@@ -81,6 +88,290 @@ async def _net_worth_at(
             "liabilities": round(liabilities_total, 2),
         },
     )
+
+
+def _compute_signed_amount(
+    tx_type: str,
+    tx_amount: Decimal,
+    tx_currency: str,
+    tx_amount_primary: Optional[Decimal],
+    account_currency: str,
+) -> Decimal:
+    """Python equivalent of _signed_balance_expr(account_currency): credit→+, debit→−.
+    Uses amount_primary when tx currency differs from account currency."""
+    effective = (
+        tx_amount
+        if tx_currency == account_currency
+        else (tx_amount_primary if tx_amount_primary is not None else tx_amount)
+    )
+    return effective if tx_type == "credit" else -effective
+
+
+async def _preload_fx_rates_bulk(
+    session: AsyncSession,
+    currencies: set[str],
+    max_date: date,
+) -> dict[str, list[tuple[date, Decimal]]]:
+    """Load USD-based FX rates for all needed currencies up to max_date in one query.
+    Returns {quote_currency: [(date, rate), ...]} sorted ascending by date."""
+    needed = {c for c in currencies if c != "USD"}
+    if not needed:
+        return {}
+    rows = (await session.execute(
+        select(FxRate.quote_currency, FxRate.date, FxRate.rate)
+        .where(
+            FxRate.base_currency == "USD",
+            FxRate.quote_currency.in_(needed),
+            FxRate.date <= max_date,
+        )
+        .order_by(FxRate.quote_currency, FxRate.date)
+    )).all()
+    cache: dict[str, list[tuple[date, Decimal]]] = {}
+    for ccy, d, rate in rows:
+        cache.setdefault(ccy, []).append((d, rate))
+    return cache
+
+
+def _fx_rate_at_from_cache(
+    cache: dict[str, list[tuple[date, Decimal]]],
+    from_currency: str,
+    to_currency: str,
+    target: date,
+) -> Decimal:
+    """Fill-forward cross-rate lookup from preloaded cache.
+    Uses the same cross-rate formula as fx_rate_service: rate = usd_to_target / usd_to_source.
+    Falls back to 1:1 when no rate is available."""
+    if from_currency == to_currency:
+        return Decimal("1")
+
+    def _usd_to(ccy: str) -> Decimal:
+        if ccy == "USD":
+            return Decimal("1")
+        result = None
+        for d, r in cache.get(ccy, []):
+            if d <= target:
+                result = r
+            else:
+                break
+        return result if result is not None else Decimal("1")
+
+    usd_to_from = _usd_to(from_currency)
+    usd_to_to = _usd_to(to_currency)
+    if usd_to_from == 0:
+        return Decimal("1")
+    return usd_to_to / usd_to_from
+
+
+async def _bulk_account_balances(
+    session: AsyncSession,
+    accounts: list[Account],
+    all_dates: list[date],
+) -> dict[uuid.UUID, dict[date, float]]:
+    """Compute balances for all accounts at all date points using two bulk queries.
+
+    Manual accounts: one query for all transactions up to max_date, then a single
+    pass per account that accumulates a running signed sum as date points advance.
+
+    Connected accounts: one query for transactions after min_date, then backtrack
+    from the provider's authoritative balance using the same running-sum trick.
+
+    Returns {account_id: {date: balance}}.
+    """
+    if not accounts or not all_dates:
+        return {}
+
+    all_dates_sorted = sorted(set(all_dates))
+    min_date = all_dates_sorted[0]
+    max_date = all_dates_sorted[-1]
+
+    manual_accounts = [a for a in accounts if not a.connection_id]
+    connected_accounts = [a for a in accounts if a.connection_id]
+
+    result: dict[uuid.UUID, dict[date, float]] = {a.id: {} for a in accounts}
+
+    # ---- Manual accounts: forward cumulative sum ----
+    if manual_accounts:
+        manual_ids = [a.id for a in manual_accounts]
+        acct_currency = {a.id: a.currency for a in manual_accounts}
+
+        rows = (await session.execute(
+            select(
+                Transaction.account_id,
+                Transaction.date,
+                Transaction.type,
+                Transaction.amount,
+                Transaction.currency,
+                Transaction.amount_primary,
+            )
+            .where(
+                Transaction.account_id.in_(manual_ids),
+                Transaction.date <= max_date,
+                Transaction.is_ignored == False,
+            )
+            .order_by(Transaction.account_id, Transaction.date)
+        )).all()
+
+        txns_by_acct: dict[uuid.UUID, list] = defaultdict(list)
+        for row in rows:
+            txns_by_acct[row[0]].append(row)
+
+        for acct in manual_accounts:
+            txns = txns_by_acct.get(acct.id, [])
+            ccy = acct_currency[acct.id]
+            txn_idx = 0
+            running = Decimal("0")
+            for d in all_dates_sorted:
+                while txn_idx < len(txns) and txns[txn_idx][1] <= d:
+                    row = txns[txn_idx]
+                    running += _compute_signed_amount(row[2], row[3], row[4], row[5], ccy)
+                    txn_idx += 1
+                result[acct.id][d] = float(running)
+
+    # ---- Connected accounts: backtrack from authoritative current balance ----
+    # For any date point P >= min_date, sum(date > P) = total_loaded - running_up_to_P
+    # since all loaded txns satisfy date > min_date, and P >= min_date guarantees
+    # date <= min_date implies date <= P (so no earlier txns are missed).
+    if connected_accounts:
+        connected_ids = [a.id for a in connected_accounts]
+
+        rows = (await session.execute(
+            select(
+                Transaction.account_id,
+                Transaction.date,
+                Transaction.type,
+                Transaction.amount,
+                Transaction.currency,
+                Transaction.amount_primary,
+            )
+            .where(
+                Transaction.account_id.in_(connected_ids),
+                Transaction.date > min_date,
+                Transaction.is_ignored == False,
+            )
+            .order_by(Transaction.account_id, Transaction.date)
+        )).all()
+
+        txns_by_acct2: dict[uuid.UUID, list] = defaultdict(list)
+        for row in rows:
+            txns_by_acct2[row[0]].append(row)
+
+        for acct in connected_accounts:
+            txns = txns_by_acct2.get(acct.id, [])
+            ccy = acct.currency
+            current_bal = float(acct.balance)
+            if acct.type == "credit_card":
+                current_bal = -current_bal
+
+            total_delta = sum(
+                _compute_signed_amount(row[2], row[3], row[4], row[5], ccy)
+                for row in txns
+            )
+
+            txn_idx = 0
+            running_up_to = Decimal("0")
+            for d in all_dates_sorted:
+                while txn_idx < len(txns) and txns[txn_idx][1] <= d:
+                    row = txns[txn_idx]
+                    running_up_to += _compute_signed_amount(row[2], row[3], row[4], row[5], ccy)
+                    txn_idx += 1
+                result[acct.id][d] = current_bal - float(total_delta - running_up_to)
+
+    return result
+
+
+async def _bulk_asset_totals_by_date(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    all_dates: list[date],
+    primary_currency: str,
+    fx_cache: dict[str, list[tuple[date, Decimal]]],
+) -> dict[date, float]:
+    """Compute total asset value (in primary currency) at each date using one bulk query.
+    Returns {date: total}."""
+    asset_result = await session.execute(
+        select(Asset).where(
+            Asset.user_id == user_id,
+            Asset.is_archived == False,
+            Asset.sell_date.is_(None),
+        )
+    )
+    assets = list(asset_result.scalars().all())
+    if not assets:
+        return {d: 0.0 for d in all_dates}
+
+    max_date = max(all_dates)
+    values_map = await _load_asset_native_values(session, assets, up_to_date=max_date)
+
+    totals: dict[date, float] = {}
+    for d in all_dates:
+        total = 0.0
+        for asset in assets:
+            native_val = _fill_forward_at(asset, values_map.get(str(asset.id), []), d)
+            if native_val is None or native_val <= 0:
+                continue
+            rate = _fx_rate_at_from_cache(fx_cache, asset.currency, primary_currency, d)
+            total += float(Decimal(str(native_val)) * rate)
+        totals[d] = total
+    return totals
+
+
+async def _build_net_worth_snapshots_bulk(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    accounts: list[Account],
+    all_dates: list[date],
+    primary_currency: str,
+) -> dict[date, ReportDataPoint]:
+    """Compute net worth snapshots for all dates in a fixed number of queries.
+
+    Replaces the previous O(N_dates × N_accounts) loop with:
+      - 1 FX rates query
+      - 2 transaction queries (manual + connected)
+      - 1 asset values query
+
+    Returns {date: ReportDataPoint}.
+    """
+    if not all_dates:
+        return {}
+
+    currencies: set[str] = {primary_currency}
+    for acct in accounts:
+        currencies.add(acct.currency)
+
+    max_date = max(all_dates)
+    fx_cache = await _preload_fx_rates_bulk(session, currencies, max_date)
+    acct_balances = await _bulk_account_balances(session, accounts, all_dates)
+    asset_totals = await _bulk_asset_totals_by_date(
+        session, user_id, all_dates, primary_currency, fx_cache
+    )
+
+    snapshots: dict[date, ReportDataPoint] = {}
+    for d in all_dates:
+        accounts_total = 0.0
+        liabilities_total = 0.0
+
+        for acct in accounts:
+            bal = acct_balances[acct.id].get(d, 0.0)
+            rate = _fx_rate_at_from_cache(fx_cache, acct.currency, primary_currency, d)
+            converted_val = float(Decimal(str(abs(bal))) * rate)
+            if acct.type == "credit_card" or bal < 0:
+                liabilities_total += converted_val
+            else:
+                accounts_total += converted_val
+
+        assets_total = asset_totals.get(d, 0.0)
+        net_worth = accounts_total + assets_total - liabilities_total
+
+        snapshots[d] = ReportDataPoint(
+            date=d.isoformat(),
+            value=round(net_worth, 2),
+            breakdowns={
+                "accounts": round(accounts_total, 2),
+                "assets": round(assets_total, 2),
+                "liabilities": round(liabilities_total, 2),
+            },
+        )
+    return snapshots
 
 
 def _format_date_label(d: date, interval: str) -> str:
@@ -158,21 +449,29 @@ async def get_net_worth_report(
     user = await session.get(User, user_id)
     primary_currency = user.primary_currency if user else get_settings().default_currency
 
+    accounts = await _get_open_accounts(session, user_id)
     points = _date_points(start, today, interval)
 
-    # Compute snapshot at each date point
+    # Build all snapshots in bulk (includes period start for delta baseline).
+    all_dates = sorted({start} | set(points))
+    snapshots = await _build_net_worth_snapshots_bulk(
+        session, user_id, accounts, all_dates, primary_currency
+    )
+
     trend: list[ReportDataPoint] = []
     for point in points:
-        dp = await _net_worth_at(session, user_id, point, primary_currency)
-        dp.date = _format_date_label(point, interval)
-        trend.append(dp)
+        snap = snapshots[point]
+        trend.append(ReportDataPoint(
+            date=_format_date_label(point, interval),
+            value=snap.value,
+            breakdowns=dict(snap.breakdowns),
+        ))
 
-    # Current snapshot (last point) for summary; baseline at period start for delta
-    current = trend[-1] if trend else ReportDataPoint(
+    _empty = ReportDataPoint(
         date="", value=0, breakdowns={"accounts": 0, "assets": 0, "liabilities": 0}
     )
-    baseline = await _net_worth_at(session, user_id, start, primary_currency)
-    previous = baseline if trend else current
+    current = trend[-1] if trend else _empty
+    previous = snapshots.get(start, _empty) if trend else current
 
     change_amount = current.value - previous.value
     change_percent = (
@@ -230,7 +529,6 @@ async def get_net_worth_report(
         "other": "#6B7280",
     }
     composition: list[ReportCompositionItem] = []
-    accounts = await _get_open_accounts(session, user_id)
     for account in accounts:
         bal = await _account_balance_at(session, account, today)
         converted, _ = await convert(

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -64,13 +64,10 @@ async def _net_worth_at(
             session, Decimal(str(abs(bal))), account.currency, primary_currency, cutoff
         )
         converted_val = float(converted)
-        if account.type == "credit_card":
+        if account.type == "credit_card" or bal < 0:
             liabilities_total += converted_val
         else:
-            if bal < 0:
-                accounts_total -= converted_val
-            else:
-                accounts_total += converted_val
+            accounts_total += converted_val
 
     assets_total = await _asset_value_at(session, user_id, cutoff, primary_currency)
     net_worth = accounts_total + assets_total - liabilities_total
@@ -240,7 +237,7 @@ async def get_net_worth_report(
             session, Decimal(str(abs(bal))), account.currency, primary_currency, today
         )
         converted_val = float(converted)
-        if account.type == "credit_card":
+        if account.type == "credit_card" or bal < 0:
             composition.append(ReportCompositionItem(
                 key=str(account.id),
                 label=get_account_name(account),
@@ -248,15 +245,14 @@ async def get_net_worth_report(
                 color=account_type_colors.get(account.type, "#6B7280"),
                 group="liabilities",
             ))
-        else:
-            if bal > 0:
-                composition.append(ReportCompositionItem(
-                    key=str(account.id),
-                    label=get_account_name(account),
-                    value=round(converted_val, 2),
-                    color=account_type_colors.get(account.type, "#6B7280"),
-                    group="accounts",
-                ))
+        elif bal > 0:
+            composition.append(ReportCompositionItem(
+                key=str(account.id),
+                label=get_account_name(account),
+                value=round(converted_val, 2),
+                color=account_type_colors.get(account.type, "#6B7280"),
+                group="accounts",
+            ))
 
     # Assets
     asset_result = await session.execute(

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -15,8 +15,12 @@ from app.schemas.report import CategoryTrendItem, ReportDataPoint, ReportRespons
 from app.services.report_service import (
     _add_months,
     _asset_value_at,
+    _bulk_account_balances,
+    _build_net_worth_snapshots_bulk,
+    _compute_signed_amount,
     _date_points,
     _format_date_label,
+    _fx_rate_at_from_cache,
     _net_worth_at,
     get_cash_flow_report,
     get_net_worth_report,
@@ -748,11 +752,14 @@ async def test_net_worth_with_assets(session: AsyncSession, test_user: User):
 
 @pytest.mark.asyncio
 async def test_net_worth_negative_manual_balance(session: AsyncSession, test_user: User):
+    """Overdraft (negative manual balance) is routed to liabilities, not accounts."""
     acct = await _make_manual_account(session, test_user.id, "NW Negative")
     await _add_txn(session, test_user.id, acct.id, 1000, "debit", date.today())
 
     dp = await _net_worth_at(session, test_user.id, date.today(), "BRL")
-    assert dp.breakdowns["accounts"] == -1000.0
+    assert dp.breakdowns["accounts"] == 0.0
+    assert dp.breakdowns["liabilities"] == 1000.0
+    assert dp.value == -1000.0
 
 
 # ---------------------------------------------------------------------------
@@ -2104,3 +2111,368 @@ async def test_cash_flow_running_balance_arithmetic(
         assert abs(pt.value - expected) < 0.01, (
             f"Day {d}: got {pt.value}, expected {expected}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Bulk optimization — helper functions
+# ---------------------------------------------------------------------------
+
+
+def test_compute_signed_amount_credit_same_currency():
+    from decimal import Decimal
+    result = _compute_signed_amount("credit", Decimal("100"), "BRL", None, "BRL")
+    assert result == Decimal("100")
+
+
+def test_compute_signed_amount_debit_same_currency():
+    from decimal import Decimal
+    result = _compute_signed_amount("debit", Decimal("100"), "BRL", None, "BRL")
+    assert result == Decimal("-100")
+
+
+def test_compute_signed_amount_foreign_uses_amount_primary():
+    from decimal import Decimal
+    result = _compute_signed_amount("credit", Decimal("100"), "USD", Decimal("500"), "BRL")
+    assert result == Decimal("500")
+
+
+def test_compute_signed_amount_foreign_fallback_to_amount():
+    from decimal import Decimal
+    result = _compute_signed_amount("debit", Decimal("100"), "USD", None, "BRL")
+    assert result == Decimal("-100")
+
+
+def test_fx_rate_at_from_cache_same_currency():
+    from decimal import Decimal
+    assert _fx_rate_at_from_cache({}, "BRL", "BRL", date.today()) == Decimal("1")
+
+
+def test_fx_rate_at_from_cache_fill_forward():
+    from decimal import Decimal
+    cache = {"BRL": [(date(2025, 1, 1), Decimal("5.0")), (date(2025, 6, 1), Decimal("6.0"))]}
+    # On 2025-03-15: fill-forward gives 5.0 (2025-01-01 is the latest on or before)
+    rate = _fx_rate_at_from_cache(cache, "USD", "BRL", date(2025, 3, 15))
+    assert rate == Decimal("5.0")
+    # On 2025-07-01: fill-forward gives 6.0
+    rate2 = _fx_rate_at_from_cache(cache, "USD", "BRL", date(2025, 7, 1))
+    assert rate2 == Decimal("6.0")
+
+
+def test_fx_rate_at_from_cache_cross_rate():
+    from decimal import Decimal
+    # USD→BRL = 5.0, USD→EUR = 0.5  →  EUR→BRL = 5.0/0.5 = 10.0
+    cache = {
+        "BRL": [(date(2025, 1, 1), Decimal("5.0"))],
+        "EUR": [(date(2025, 1, 1), Decimal("0.5"))],
+    }
+    rate = _fx_rate_at_from_cache(cache, "EUR", "BRL", date(2025, 6, 1))
+    assert rate == Decimal("10.0")
+
+
+def test_fx_rate_at_from_cache_no_rate_falls_back_to_1():
+    from decimal import Decimal
+    rate = _fx_rate_at_from_cache({}, "EUR", "BRL", date(2025, 1, 1))
+    assert rate == Decimal("1")
+
+
+# ---------------------------------------------------------------------------
+# Bulk optimization — _bulk_account_balances
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_balances_manual_account_forward_sum(
+    session: AsyncSession, test_user: User
+):
+    """Manual account: running sum matches sequential _account_balance_at at each point."""
+    acct = await _make_manual_account(session, test_user.id, "Bulk Manual")
+    today = date.today()
+    d1 = today - timedelta(days=60)
+    d2 = today - timedelta(days=30)
+    await _add_txn(session, test_user.id, acct.id, 1000, "credit", d1)
+    await _add_txn(session, test_user.id, acct.id, 500, "debit", d2)
+    await _add_txn(session, test_user.id, acct.id, 200, "credit", today)
+
+    date_points = [d1 - timedelta(days=1), d1, d2, today]
+    bulk = await _bulk_account_balances(session, [acct], date_points)
+
+    # Before any transactions: 0
+    assert bulk[acct.id][d1 - timedelta(days=1)] == 0.0
+    assert bulk[acct.id][d1] == pytest.approx(1000.0)
+    assert bulk[acct.id][d2] == pytest.approx(500.0)
+    assert bulk[acct.id][today] == pytest.approx(700.0)
+
+
+@pytest.mark.asyncio
+async def test_bulk_balances_connected_account_backtrack(
+    session: AsyncSession, test_user: User
+):
+    """Connected account: bulk backtrack matches sequential _account_balance_at."""
+    conn = BankConnection(
+        id=uuid.uuid4(), user_id=test_user.id, provider="test",
+        external_id="ext-bulk-conn", institution_name="Test",
+        credentials={}, status="active",
+        last_sync_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(conn)
+    await session.flush()
+
+    acct = Account(
+        id=uuid.uuid4(), user_id=test_user.id, connection_id=conn.id,
+        name="Bulk Connected", type="checking",
+        balance=Decimal("3000"),  # authoritative current balance
+        currency="BRL",
+    )
+    session.add(acct)
+    await session.commit()
+
+    today = date.today()
+    d_start = today - timedelta(days=60)
+    d_mid = today - timedelta(days=30)
+
+    # Transaction after d_start: +500 credit
+    await _add_txn(session, test_user.id, acct.id, 500, "credit", d_mid)
+    # Transaction after d_mid: -200 debit
+    await _add_txn(session, test_user.id, acct.id, 200, "debit", today)
+
+    date_points = [d_start, d_mid, today]
+    bulk = await _bulk_account_balances(session, [acct], date_points)
+
+    # Compare with sequential
+    from app.services.dashboard_service import _account_balance_at
+    for d in date_points:
+        seq_bal = await _account_balance_at(session, acct, d)
+        assert abs(bulk[acct.id][d] - seq_bal) < 0.01, f"Mismatch at {d}: bulk={bulk[acct.id][d]}, seq={seq_bal}"
+
+
+@pytest.mark.asyncio
+async def test_bulk_balances_connected_credit_card(
+    session: AsyncSession, test_user: User
+):
+    """Connected CC: balance is negated from account.balance and backtracked."""
+    conn = BankConnection(
+        id=uuid.uuid4(), user_id=test_user.id, provider="test",
+        external_id="ext-bulk-cc", institution_name="CC Bank",
+        credentials={}, status="active",
+        last_sync_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(conn)
+    await session.flush()
+
+    cc = Account(
+        id=uuid.uuid4(), user_id=test_user.id, connection_id=conn.id,
+        name="Bulk CC", type="credit_card",
+        balance=Decimal("1000"),  # bank says $1000 outstanding
+        currency="BRL",
+    )
+    session.add(cc)
+    await session.commit()
+
+    today = date.today()
+    d_start = today - timedelta(days=30)
+    # A purchase 10 days ago (debit → more debt)
+    await _add_txn(session, test_user.id, cc.id, 200, "debit", today - timedelta(days=10))
+
+    date_points = [d_start, today]
+    bulk = await _bulk_account_balances(session, [cc], date_points)
+
+    from app.services.dashboard_service import _account_balance_at
+    for d in date_points:
+        seq_bal = await _account_balance_at(session, cc, d)
+        assert abs(bulk[cc.id][d] - seq_bal) < 0.01
+
+
+@pytest.mark.asyncio
+async def test_bulk_balances_ignored_transactions_excluded(
+    session: AsyncSession, test_user: User
+):
+    """is_ignored transactions must not affect balance."""
+    acct = await _make_manual_account(session, test_user.id, "Bulk Ignored")
+    today = date.today()
+    await _add_txn(session, test_user.id, acct.id, 1000, "credit", today)
+
+    # Add an ignored transaction directly
+    txn = Transaction(
+        id=uuid.uuid4(), user_id=test_user.id, account_id=acct.id,
+        description="Ignored", amount=Decimal("999"),
+        date=today, type="credit", source="manual", currency="BRL",
+        is_ignored=True,
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(txn)
+    await session.commit()
+
+    bulk = await _bulk_account_balances(session, [acct], [today])
+    assert bulk[acct.id][today] == pytest.approx(1000.0)
+
+
+# ---------------------------------------------------------------------------
+# Bulk optimization — _build_net_worth_snapshots_bulk vs sequential parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_snapshots_parity_manual_account(
+    session: AsyncSession, test_user: User
+):
+    """Bulk snapshots match sequential _net_worth_at for a simple manual account."""
+    acct = await _make_manual_account(session, test_user.id, "Parity Manual")
+    today = date.today()
+    d_past = today - timedelta(days=45)
+    await _add_txn(session, test_user.id, acct.id, 5000, "credit", d_past)
+    await _add_txn(session, test_user.id, acct.id, 1000, "debit", today - timedelta(days=10))
+
+    from app.services.dashboard_service import _get_open_accounts
+    accounts = await _get_open_accounts(session, test_user.id)
+    date_points = [d_past - timedelta(days=1), d_past, today - timedelta(days=10), today]
+
+    bulk = await _build_net_worth_snapshots_bulk(session, test_user.id, accounts, date_points, "BRL")
+    for d in date_points:
+        seq = await _net_worth_at(session, test_user.id, d, "BRL")
+        assert abs(bulk[d].value - seq.value) < 0.01, f"value mismatch at {d}"
+        assert abs(bulk[d].breakdowns["accounts"] - seq.breakdowns["accounts"]) < 0.01
+        assert abs(bulk[d].breakdowns["liabilities"] - seq.breakdowns["liabilities"]) < 0.01
+
+
+@pytest.mark.asyncio
+async def test_bulk_snapshots_parity_credit_card(
+    session: AsyncSession, test_user: User
+):
+    """Bulk snapshots match sequential for CC (always in liabilities)."""
+    checking = await _make_manual_account(session, test_user.id, "Parity Check")
+    await _add_txn(session, test_user.id, checking.id, 8000, "credit", date.today() - timedelta(days=5))
+
+    conn = BankConnection(
+        id=uuid.uuid4(), user_id=test_user.id, provider="test",
+        external_id="ext-par-cc", institution_name="CCBank",
+        credentials={}, status="active",
+        last_sync_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(conn)
+    await session.flush()
+    cc = Account(
+        id=uuid.uuid4(), user_id=test_user.id, connection_id=conn.id,
+        name="Parity CC", type="credit_card",
+        balance=Decimal("1500"), currency="BRL",
+    )
+    session.add(cc)
+    await session.commit()
+
+    await _add_txn(session, test_user.id, cc.id, 300, "debit", date.today())
+
+    from app.services.dashboard_service import _get_open_accounts
+    accounts = await _get_open_accounts(session, test_user.id)
+    today = date.today()
+    date_points = [today - timedelta(days=7), today]
+
+    bulk = await _build_net_worth_snapshots_bulk(session, test_user.id, accounts, date_points, "BRL")
+    for d in date_points:
+        seq = await _net_worth_at(session, test_user.id, d, "BRL")
+        assert abs(bulk[d].value - seq.value) < 0.01, f"net worth mismatch at {d}"
+        assert abs(bulk[d].breakdowns["liabilities"] - seq.breakdowns["liabilities"]) < 0.01
+
+
+@pytest.mark.asyncio
+async def test_bulk_snapshots_parity_overdraft(
+    session: AsyncSession, test_user: User
+):
+    """Bulk correctly routes overdraft checking account to liabilities."""
+    acct = await _make_manual_account(session, test_user.id, "Parity Overdraft")
+    today = date.today()
+    await _add_txn(session, test_user.id, acct.id, 500, "debit", today)
+
+    from app.services.dashboard_service import _get_open_accounts
+    accounts = await _get_open_accounts(session, test_user.id)
+    bulk = await _build_net_worth_snapshots_bulk(session, test_user.id, accounts, [today], "BRL")
+    seq = await _net_worth_at(session, test_user.id, today, "BRL")
+
+    assert bulk[today].breakdowns["accounts"] == 0.0
+    assert abs(bulk[today].breakdowns["liabilities"] - seq.breakdowns["liabilities"]) < 0.01
+    assert abs(bulk[today].value - seq.value) < 0.01
+
+
+@pytest.mark.asyncio
+async def test_bulk_snapshots_parity_with_asset(
+    session: AsyncSession, test_user: User
+):
+    """Bulk asset totals match sequential for a simple asset with a value entry."""
+    acct = await _make_manual_account(session, test_user.id, "Parity Asset Check")
+    await _add_txn(session, test_user.id, acct.id, 2000, "credit", date.today() - timedelta(days=5))
+
+    asset = Asset(
+        id=uuid.uuid4(), user_id=test_user.id, name="Parity House",
+        type="real_estate", currency="BRL",
+        purchase_price=Decimal("100000"),
+        purchase_date=date.today() - timedelta(days=30),
+    )
+    session.add(asset)
+    await session.commit()
+
+    from app.services.dashboard_service import _get_open_accounts
+    accounts = await _get_open_accounts(session, test_user.id)
+    today = date.today()
+    date_points = [today - timedelta(days=30), today]
+
+    bulk = await _build_net_worth_snapshots_bulk(session, test_user.id, accounts, date_points, "BRL")
+    for d in date_points:
+        seq = await _net_worth_at(session, test_user.id, d, "BRL")
+        assert abs(bulk[d].breakdowns["assets"] - seq.breakdowns["assets"]) < 0.01
+        assert abs(bulk[d].value - seq.value) < 0.01
+
+
+@pytest.mark.asyncio
+async def test_bulk_snapshots_multi_point_parity(
+    session: AsyncSession, test_user: User
+):
+    """Bulk results match sequential across many date points (monthly over 6 months)."""
+    from app.services.report_service import _date_points
+    from app.services.dashboard_service import _get_open_accounts
+
+    acct = await _make_manual_account(session, test_user.id, "Multi Point")
+    today = date.today()
+    # Seed a handful of transactions spread over 6 months
+    for offset_days, amt, typ in [
+        (150, 3000, "credit"),
+        (120, 500, "debit"),
+        (90, 1000, "credit"),
+        (60, 200, "debit"),
+        (30, 800, "credit"),
+        (0, 100, "debit"),
+    ]:
+        await _add_txn(session, test_user.id, acct.id, amt, typ, today - timedelta(days=offset_days))
+
+    start = today.replace(day=1) - timedelta(days=6 * 30)
+    start = start.replace(day=1)
+    points = _date_points(start, today, "monthly")
+    all_dates = sorted({start} | set(points))
+
+    accounts = await _get_open_accounts(session, test_user.id)
+    bulk = await _build_net_worth_snapshots_bulk(session, test_user.id, accounts, all_dates, "BRL")
+
+    for d in all_dates:
+        seq = await _net_worth_at(session, test_user.id, d, "BRL")
+        assert abs(bulk[d].value - seq.value) < 0.01, f"Mismatch at {d}: bulk={bulk[d].value}, seq={seq.value}"
+
+
+@pytest.mark.asyncio
+async def test_get_net_worth_report_uses_bulk_path(
+    session: AsyncSession, test_user: User
+):
+    """get_net_worth_report produces the same results as the sequential approach."""
+    acct = await _make_manual_account(session, test_user.id, "Report Bulk")
+    today = date.today()
+    await _add_txn(session, test_user.id, acct.id, 10000, "credit", today - timedelta(days=60), source="opening_balance")
+    await _add_txn(session, test_user.id, acct.id, 2000, "debit", today - timedelta(days=30))
+    await _add_txn(session, test_user.id, acct.id, 1500, "credit", today)
+
+    report = await get_net_worth_report(session, test_user.id, months=3, interval="monthly")
+
+    assert report.meta.type == "net_worth"
+    assert len(report.trend) > 0
+    # Last point should reflect 10000 - 2000 + 1500 = 9500
+    last_point = report.trend[-1]
+    assert abs(last_point.value - 9500.0) < 0.01
+    assert abs(report.summary.primary_value - 9500.0) < 0.01

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -863,7 +863,8 @@
     "byExpenses": "By Expenses",
     "other": "Other",
     "uncategorized": "Uncategorized",
-    "categoryTrends": "Category Trends"
+    "categoryTrends": "Category Trends",
+    "current": "Current"
   },
   "payees": {
     "title": "Payees",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -866,6 +866,8 @@
     "categoryTrends": "Category Trends",
     "current": "Current",
     "accountsAndAssets": "Accounts and Assets",
+    "whatYouHave": "You own",
+    "whatYouOwe": "You owe",
     "change": "Change"
   },
   "payees": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -864,7 +864,8 @@
     "other": "Other",
     "uncategorized": "Uncategorized",
     "categoryTrends": "Category Trends",
-    "current": "Current"
+    "current": "Current",
+    "accountsAndAssets": "Accounts and Assets"
   },
   "payees": {
     "title": "Payees",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -868,6 +868,8 @@
     "accountsAndAssets": "Accounts and Assets",
     "whatYouHave": "You own",
     "whatYouOwe": "You owe",
+    "whatYouOwned": "You owned",
+    "whatYouOwed": "You owed",
     "change": "Change"
   },
   "payees": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -865,7 +865,8 @@
     "uncategorized": "Uncategorized",
     "categoryTrends": "Category Trends",
     "current": "Current",
-    "accountsAndAssets": "Accounts and Assets"
+    "accountsAndAssets": "Accounts and Assets",
+    "change": "Change"
   },
   "payees": {
     "title": "Payees",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -863,7 +863,8 @@
     "byExpenses": "Por Despesa",
     "other": "Outros",
     "uncategorized": "Sem categoria",
-    "categoryTrends": "Tendência por Categoria"
+    "categoryTrends": "Tendência por Categoria",
+    "current": "Atual"
   },
   "payees": {
     "title": "Beneficiários",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -868,6 +868,8 @@
     "accountsAndAssets": "Contas e Ativos",
     "whatYouHave": "Você tem",
     "whatYouOwe": "Você deve",
+    "whatYouOwned": "Você tinha",
+    "whatYouOwed": "Você devia",
     "change": "Variação"
   },
   "payees": {

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -864,7 +864,8 @@
     "other": "Outros",
     "uncategorized": "Sem categoria",
     "categoryTrends": "Tendência por Categoria",
-    "current": "Atual"
+    "current": "Atual",
+    "accountsAndAssets": "Contas e Ativos"
   },
   "payees": {
     "title": "Beneficiários",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -866,6 +866,8 @@
     "categoryTrends": "Tendência por Categoria",
     "current": "Atual",
     "accountsAndAssets": "Contas e Ativos",
+    "whatYouHave": "Você tem",
+    "whatYouOwe": "Você deve",
     "change": "Variação"
   },
   "payees": {

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -865,7 +865,8 @@
     "uncategorized": "Sem categoria",
     "categoryTrends": "Tendência por Categoria",
     "current": "Atual",
-    "accountsAndAssets": "Contas e Ativos"
+    "accountsAndAssets": "Contas e Ativos",
+    "change": "Variação"
   },
   "payees": {
     "title": "Beneficiários",

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -89,7 +89,7 @@ function buildGroupGradient(baseHex: string, count: number): string[] {
   })
 }
 
-const COMPOSITION_TOP_N = 10
+const COMPOSITION_MIN_PCT = 0.03
 
 type RangeOption = { key: string; months: number }
 
@@ -160,6 +160,7 @@ export default function ReportsPage() {
   const [sparklineView, setSparklineView] = useState<'byExpenses' | 'byIncome'>('byExpenses')
   const [sparklinePage, setSparklinePage] = useState(0)
   const [selectedNWBar, setSelectedNWBar] = useState<{ accounts: number; assets: number; liabilities: number; value: number; date: string; index: number } | null>(null)
+  const [nwPieView, setNwPieView] = useState<'accountsAssets' | 'liabilities'>('accountsAssets')
 
   const currentTab = REPORT_TABS.find((tab) => tab.key === activeTab) ?? REPORT_TABS[0]
 
@@ -252,13 +253,13 @@ export default function ReportsPage() {
   const nwDetailTotalAccounts = nwDetailAccounts.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
   const nwDetailTotalAssets = nwDetailAssets.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
   const nwDetailTotalLiabs = nwDetailLiabs.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
-  const nwBarsAccounts = nwDetailAccounts.slice(0, COMPOSITION_TOP_N)
-  const nwBarsAssets = nwDetailAssets.slice(0, COMPOSITION_TOP_N)
-  const nwBarsLiabs = nwDetailLiabs.slice(0, COMPOSITION_TOP_N)
+  const nwBarsAccounts = nwDetailAccounts.filter((c: ReportCompositionItem) => nwDetailTotalAccounts > 0 && c.value / nwDetailTotalAccounts >= COMPOSITION_MIN_PCT)
+  const nwBarsAssets = nwDetailAssets.filter((c: ReportCompositionItem) => nwDetailTotalAssets > 0 && c.value / nwDetailTotalAssets >= COMPOSITION_MIN_PCT)
+  const nwBarsLiabs = nwDetailLiabs.filter((c: ReportCompositionItem) => nwDetailTotalLiabs > 0 && c.value / nwDetailTotalLiabs >= COMPOSITION_MIN_PCT)
 
-  const accountsGradient = buildGroupGradient(colorMap['accounts'] || '#6366F1', COMPOSITION_TOP_N)
-  const assetsGradient = buildGroupGradient(colorMap['assets'] || '#F59E0B', COMPOSITION_TOP_N)
-  const liabsGradient = buildGroupGradient(colorMap['liabilities'] || '#F43F5E', COMPOSITION_TOP_N)
+  const accountsGradient = buildGroupGradient(colorMap['accounts'] || '#6366F1', Math.max(1, nwBarsAccounts.length))
+  const assetsGradient = buildGroupGradient(colorMap['assets'] || '#F59E0B', Math.max(1, nwBarsAssets.length))
+  const liabsGradient = buildGroupGradient(colorMap['liabilities'] || '#F43F5E', Math.max(1, nwBarsLiabs.length))
 
   const lastNWIndex = netWorthSummaryData.length - 1
   const isCurrentNW = selectedNWBar == null || selectedNWBar.index === lastNWIndex
@@ -291,8 +292,8 @@ export default function ReportsPage() {
       .filter((d) => d.value > 0)
       .sort((a, b) => b.value - a.value)
       .map((d, i) => ({ ...d, color: gradient[i] ?? gradient[gradient.length - 1] ?? '#6B7280' }))
-    const top = sorted.slice(0, COMPOSITION_TOP_N)
-    const otherValue = sorted.slice(COMPOSITION_TOP_N).reduce((s, d) => s + d.value, 0)
+    const top = sorted.filter((d) => selected > 0 && d.value / selected >= COMPOSITION_MIN_PCT)
+    const otherValue = sorted.filter((d) => selected <= 0 || d.value / selected < COMPOSITION_MIN_PCT).reduce((s, d) => s + d.value, 0)
     if (otherValue > 0) top.push({ name: t('reports.other'), value: otherValue, color: gradient[gradient.length - 1] ?? '#6B7280' })
     return top
   })
@@ -312,8 +313,8 @@ export default function ReportsPage() {
     .sort((a, b) => b.value - a.value)
     .map((d, i) => ({ ...d, color: liabsGradient[i] ?? liabsGradient[liabsGradient.length - 1] ?? '#6B7280' }))
   const nwPieBOuter: NWPieItem[] = (() => {
-    const top = nwPieBOuterSorted.slice(0, COMPOSITION_TOP_N)
-    const otherValue = nwPieBOuterSorted.slice(COMPOSITION_TOP_N).reduce((s, d) => s + d.value, 0)
+    const top = nwPieBOuterSorted.filter((d) => selectedLiabs > 0 && d.value / selectedLiabs >= COMPOSITION_MIN_PCT)
+    const otherValue = nwPieBOuterSorted.filter((d) => selectedLiabs <= 0 || d.value / selectedLiabs < COMPOSITION_MIN_PCT).reduce((s, d) => s + d.value, 0)
     if (otherValue > 0) top.push({ name: t('reports.other'), value: otherValue, color: liabsGradient[liabsGradient.length - 1] ?? '#6B7280' })
     return top
   })()
@@ -356,7 +357,7 @@ export default function ReportsPage() {
       const p = nwDetailTotalAccounts > 0 ? item.value / nwDetailTotalAccounts : 0
       row[`acct_${item.key}`] = Math.round(aTotal * p * 100) / 100
     })
-    if (nwDetailAccounts.length > COMPOSITION_TOP_N) {
+    if (nwDetailAccounts.length > nwBarsAccounts.length) {
       const topSum = nwBarsAccounts.reduce((s, item) => s + Math.round(aTotal * (nwDetailTotalAccounts > 0 ? item.value / nwDetailTotalAccounts : 0) * 100) / 100, 0)
       row['acct_others'] = Math.round((aTotal - topSum) * 100) / 100
     }
@@ -364,7 +365,7 @@ export default function ReportsPage() {
       const p = nwDetailTotalAssets > 0 ? item.value / nwDetailTotalAssets : 0
       row[`asset_${item.key}`] = Math.round(sTotal * p * 100) / 100
     })
-    if (nwDetailAssets.length > COMPOSITION_TOP_N) {
+    if (nwDetailAssets.length > nwBarsAssets.length) {
       const topSum = nwBarsAssets.reduce((s, item) => s + Math.round(sTotal * (nwDetailTotalAssets > 0 ? item.value / nwDetailTotalAssets : 0) * 100) / 100, 0)
       row['asset_others'] = Math.round((sTotal - topSum) * 100) / 100
     }
@@ -372,7 +373,7 @@ export default function ReportsPage() {
       const p = nwDetailTotalLiabs > 0 ? item.value / nwDetailTotalLiabs : 0
       row[`liab_${item.key}`] = -Math.round(lTotal * p * 100) / 100
     })
-    if (nwDetailLiabs.length > COMPOSITION_TOP_N) {
+    if (nwDetailLiabs.length > nwBarsLiabs.length) {
       const topSum = nwBarsLiabs.reduce((s, item) => s + Math.round(lTotal * (nwDetailTotalLiabs > 0 ? item.value / nwDetailTotalLiabs : 0) * 100) / 100, 0)
       row['liab_others'] = -Math.round((lTotal - topSum) * 100) / 100
     }
@@ -398,10 +399,11 @@ export default function ReportsPage() {
       items = composition.filter((c) => c.group === 'expenses')
     }
 
-    // Sort descending, take top N, bucket the rest into "Other"
+    // Sort descending, group items below threshold into "Other"
     const sorted = [...items].sort((a, b) => b.value - a.value)
-    const top = sorted.slice(0, COMPOSITION_TOP_N)
-    const rest = sorted.slice(COMPOSITION_TOP_N)
+    const donutTotal = sorted.reduce((sum, c) => sum + c.value, 0)
+    const top = sorted.filter((c) => donutTotal > 0 && c.value / donutTotal >= COMPOSITION_MIN_PCT)
+    const rest = sorted.filter((c) => donutTotal <= 0 || c.value / donutTotal < COMPOSITION_MIN_PCT)
     const otherValue = rest.reduce((sum, c) => sum + c.value, 0)
 
     const result = top.map((c) => ({
@@ -769,8 +771,8 @@ export default function ReportsPage() {
                   }}
                 />
                 {/* Invisible base lifts delta bars to float from prev → current value */}
-                <Bar dataKey="_deltaBase" stackId="nwdelta" fillOpacity={0} stroke="none" maxBarSize={14} isAnimationActive={false} legendType="none" />
-                <Bar dataKey="_deltaSize" stackId="nwdelta" maxBarSize={14} radius={[2, 2, 2, 2]} isAnimationActive={false} legendType="none">
+                <Bar dataKey="_deltaBase" stackId="nwdelta" fillOpacity={0} stroke="none" maxBarSize={28} isAnimationActive={false} legendType="none" />
+                <Bar dataKey="_deltaSize" stackId="nwdelta" maxBarSize={28} radius={[2, 2, 2, 2]} isAnimationActive={false} legendType="none">
                   {nwTrendData.map((entry, i) => (
                     <Cell
                       key={i}
@@ -800,79 +802,106 @@ export default function ReportsPage() {
       </div>
 
       {meta?.type === 'net_worth' && (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-          {/* Composition card — two nested pie charts, synced to selected bar */}
-          <div className="bg-card rounded-xl border border-border shadow-sm">
-            <div className="px-5 pt-4 pb-3 flex items-start justify-between">
+        <div className="bg-card rounded-xl border border-border shadow-sm">
+          {/* Merged header */}
+          <div className="px-5 pt-4 pb-2 flex items-center justify-between">
+            <div className="flex items-center gap-4">
               <div>
-                <p className="text-sm font-semibold text-foreground">{t('reports.composition')}</p>
+                <p className="text-sm font-semibold text-foreground">{t('reports.evolution')}</p>
                 <span className="text-xs text-muted-foreground">{nwPeriodLabel}</span>
               </div>
-              <div className="text-right">
-                <p className="text-[10px] text-muted-foreground leading-tight">{t('reports.netWorth')}</p>
-                <p className="text-sm font-bold text-foreground tabular-nums">
-                  {mask(formatCompact(selectedNWBar ? selectedNWBar.value : (summary?.primary_value ?? 0), userCurrency, locale))}
-                </p>
-              </div>
             </div>
-            <div className="pb-4">
-              {isLoading ? (
-                <div className="px-4" style={{ height: 180 }}>
-                  <Skeleton className="h-full w-full" />
-                </div>
-              ) : (
-                <div className="flex flex-row items-start justify-around px-1 gap-1">
-                  {/* Pie A: Accounts + Assets */}
-                  <div className="relative flex flex-col items-center gap-1 hover:z-10">
-                    <p className="text-[11px] font-medium text-muted-foreground">{t('reports.accountsAndAssets')}</p>
-                    {nwPieAInner.length > 0 ? (
-                      <div className="relative" style={{ width: 148, height: 148 }}>
-                        <div
-                          className="absolute inset-0"
-                          style={{
-                            transform: compositionView === 'detailed' ? 'scale(1)' : 'scale(1.458)',
-                            transition: 'transform 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
-                            transformOrigin: 'center',
-                            zIndex: 1,
-                          }}
+            <div className="text-right">
+              <p className="text-[10px] text-muted-foreground leading-tight uppercase tracking-wider">{t('reports.netWorth')}</p>
+              <p className="text-xl font-bold text-foreground tabular-nums">
+                {mask(formatCurrency(selectedNWBar ? selectedNWBar.value : (summary?.primary_value ?? 0), userCurrency, locale))}
+              </p>
+            </div>
+          </div>
+          {/* Inner grid: pies right (col-start-3), evolution left (col-span-2 col-start-1) */}
+          <div className="grid grid-cols-1 lg:grid-cols-3">
+            {/* Pies — right 1 col */}
+            <div className="lg:col-start-3 lg:row-start-1 lg:border-l lg:border-border">
+              <div className="pb-4">
+                {isLoading ? (
+                  <div className="px-4" style={{ height: 180 }}>
+                    <Skeleton className="h-full w-full" />
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-center gap-2 pt-3 px-4">
+                    <div className="relative z-10 inline-flex flex-col gap-2">
+                      {/* Summary / Detailed toggle */}
+                      <div className="flex rounded-lg border border-border bg-muted/30 overflow-hidden">
+                        {(['summary', 'detailed'] as const).map((opt) => (
+                          <button
+                            key={opt}
+                            onClick={() => setCompositionView(opt)}
+                            className={`flex-1 px-2.5 py-1 text-[11px] font-semibold transition-colors ${
+                              compositionView === opt
+                                ? 'bg-primary text-primary-foreground'
+                                : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                            }`}
+                          >
+                            {t(`reports.${opt}`)}
+                          </button>
+                        ))}
+                      </div>
+                      {/* What you have / What you owe toggle */}
+                      <div className="flex rounded-lg border border-border bg-muted/30 overflow-hidden">
+                        <button
+                          onClick={() => setNwPieView('accountsAssets')}
+                          className={`flex-1 px-2.5 py-1 text-[11px] font-semibold transition-colors ${
+                            nwPieView === 'accountsAssets'
+                              ? 'bg-primary text-primary-foreground'
+                              : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                          }`}
                         >
+                          {t('reports.whatYouHave')}
+                        </button>
+                        <button
+                          onClick={() => setNwPieView('liabilities')}
+                          className={`flex-1 px-2.5 py-1 text-[11px] font-semibold transition-colors ${
+                            nwPieView === 'liabilities'
+                              ? 'bg-primary text-primary-foreground'
+                              : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                          }`}
+                        >
+                          {t('reports.whatYouOwe')}
+                        </button>
+                      </div>
+                    </div>
+                    {/* Single pie with center value */}
+                    {(() => {
+                      const isAccAssets = nwPieView === 'accountsAssets'
+                      const innerData = isAccAssets ? nwPieAInner : nwPieBInner
+                      const outerData = isAccAssets ? nwPieAOuter : nwPieBOuter
+                      const centerValue = isAccAssets ? selectedAccounts + selectedAssets : selectedLiabs
+                      if (innerData.length === 0) return (
+                        <p className="text-muted-foreground text-xs text-center py-10">{t('reports.noData')}</p>
+                      )
+                      return (
+                        <div className="relative" style={{ width: 190, height: 190 }}>
                           <ResponsiveContainer width="100%" height="100%">
                             <PieChart>
                               <Pie
-                                data={compositionView === 'detailed' ? nwPieAOuter : []}
-                                innerRadius={52}
-                                outerRadius={70}
-                                paddingAngle={0}
+                                data={compositionView === 'detailed' ? outerData : innerData}
+                                innerRadius={55}
+                                outerRadius={85}
+                                paddingAngle={2}
                                 dataKey="value"
                                 stroke="var(--card)"
                                 strokeWidth={1}
                                 animationBegin={0}
                                 animationDuration={500}
                               >
-                                {nwPieAOuter.map((entry, idx) => (
-                                  <Cell key={idx} fill={entry.color} />
-                                ))}
-                              </Pie>
-                              <Pie
-                                data={nwPieAInner}
-                                innerRadius={28}
-                                outerRadius={48}
-                                paddingAngle={0}
-                                dataKey="value"
-                                stroke="var(--card)"
-                                strokeWidth={1}
-                                animationBegin={50}
-                                animationDuration={500}
-                              >
-                                {nwPieAInner.map((entry, idx) => (
+                                {(compositionView === 'detailed' ? outerData : innerData).map((entry, idx) => (
                                   <Cell key={idx} fill={entry.color} />
                                 ))}
                               </Pie>
                               <Tooltip
                                 formatter={(value?: number, name?: string) => {
                                   const v = value ?? 0
-                                  const total = selectedAccounts + selectedAssets
-                                  const pct = total > 0 ? ((v / total) * 100).toFixed(1) : '0'
+                                  const pct = centerValue > 0 ? ((v / centerValue) * 100).toFixed(1) : '0'
                                   return [privacyMode ? MASK : `${formatCurrency(v, userCurrency, locale)} (${pct}%)`, name]
                                 }}
                                 contentStyle={{ ...tooltipStyle, zIndex: 10 }}
@@ -881,133 +910,26 @@ export default function ReportsPage() {
                               />
                             </PieChart>
                           </ResponsiveContainer>
+                          <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none" style={{ zIndex: 2 }}>
+                            <span className="text-[10px] text-muted-foreground leading-tight">
+                              {isAccAssets ? t('reports.whatYouHave') : t('reports.whatYouOwe')}
+                            </span>
+                            <span className="text-base font-bold text-foreground tabular-nums">
+                              {mask(formatCompact(centerValue, userCurrency, locale))}
+                            </span>
+                          </div>
                         </div>
-                        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                          <span className="text-[10px] font-bold text-foreground tabular-nums">
-                            {mask(formatCompact(selectedAccounts + selectedAssets, userCurrency, locale))}
-                          </span>
-                        </div>
-                      </div>
-                    ) : (
-                      <p className="text-muted-foreground text-xs text-center py-10">{t('reports.noData')}</p>
-                    )}
+                      )
+                    })()}
                   </div>
-
-                  {/* Pie B: Liabilities */}
-                  <div className="relative flex flex-col items-center gap-1 hover:z-10">
-                    <p className="text-[11px] font-medium text-muted-foreground">{t('reports.liabilities')}</p>
-                    {nwPieBInner.length > 0 ? (
-                      <div className="relative" style={{ width: 148, height: 148 }}>
-                        <div
-                          className="absolute inset-0"
-                          style={{
-                            transform: compositionView === 'detailed' ? 'scale(1)' : 'scale(1.458)',
-                            transition: 'transform 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
-                            transformOrigin: 'center',
-                            zIndex: 1,
-                          }}
-                        >
-                          <ResponsiveContainer width="100%" height="100%">
-                            <PieChart>
-                              <Pie
-                                data={compositionView === 'detailed' ? nwPieBOuter : []}
-                                innerRadius={52}
-                                outerRadius={70}
-                                paddingAngle={0}
-                                dataKey="value"
-                                stroke="var(--card)"
-                                strokeWidth={1}
-                                animationBegin={0}
-                                animationDuration={500}
-                              >
-                                {nwPieBOuter.map((entry, idx) => (
-                                  <Cell key={idx} fill={entry.color} />
-                                ))}
-                              </Pie>
-                              <Pie
-                                data={nwPieBInner}
-                                innerRadius={28}
-                                outerRadius={48}
-                                paddingAngle={0}
-                                dataKey="value"
-                                stroke="var(--card)"
-                                strokeWidth={1}
-                                animationBegin={50}
-                                animationDuration={500}
-                              >
-                                {nwPieBInner.map((entry, idx) => (
-                                  <Cell key={idx} fill={entry.color} />
-                                ))}
-                              </Pie>
-                              <Tooltip
-                                formatter={(value?: number, name?: string) => {
-                                  const v = value ?? 0
-                                  const pct = selectedLiabs > 0 ? ((v / selectedLiabs) * 100).toFixed(1) : '0'
-                                  return [privacyMode ? MASK : `${formatCurrency(v, userCurrency, locale)} (${pct}%)`, name]
-                                }}
-                                contentStyle={{ ...tooltipStyle, zIndex: 10 }}
-                                itemStyle={tooltipItemStyle}
-                                wrapperStyle={{ zIndex: 10 }}
-                              />
-                            </PieChart>
-                          </ResponsiveContainer>
-                        </div>
-                        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                          <span className="text-[10px] font-bold text-foreground tabular-nums">
-                            {mask(formatCompact(selectedLiabs, userCurrency, locale))}
-                          </span>
-                        </div>
-                      </div>
-                    ) : (
-                      <p className="text-muted-foreground text-xs text-center py-10">{t('reports.noData')}</p>
-                    )}
-                  </div>
-                </div>
               )}
             </div>
           </div>
 
-          {/* Evolution chart */}
-          <div className="lg:col-span-2 bg-card rounded-xl border border-border shadow-sm">
-            <div className="px-5 pt-4 pb-2 flex items-center justify-between">
-              <div className="flex items-center gap-4">
-                <p className="text-sm font-semibold text-foreground">{t('reports.evolution')}</p>
-                {compositionView === 'summary' && (
-                  <div className="hidden sm:flex items-center gap-3">
-                    {[
-                      { key: 'accounts', color: colorMap['accounts'] || '#6366F1' },
-                      { key: 'assets', color: colorMap['assets'] || '#F59E0B' },
-                      { key: 'liabilities', color: colorMap['liabilities'] || '#F43F5E' },
-                    ].map(({ key, color }) => (
-                      <div key={key} className="flex items-center gap-1.5">
-                        <div className="w-2 h-2 rounded-full" style={{ backgroundColor: color }} />
-                        <span className="text-[11px] text-muted-foreground">{t(`reports.${key}`)}</span>
-                      </div>
-                    ))}
-                    <div className="flex items-center gap-1.5">
-                      <div className="w-3 h-0 border-t-2 border-dashed" style={{ borderColor: '#10B981' }} />
-                      <span className="text-[11px] text-muted-foreground">{t('reports.netWorth')}</span>
-                    </div>
-                  </div>
-                )}
-              </div>
-              <div className="flex items-center rounded-lg border border-border bg-muted/30 overflow-hidden">
-                {(['summary', 'detailed'] as const).map((opt) => (
-                  <button
-                    key={opt}
-                    onClick={() => setCompositionView(opt)}
-                    className={`px-2.5 py-1 text-[11px] font-semibold transition-colors ${
-                      compositionView === opt
-                        ? 'bg-primary text-primary-foreground'
-                        : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
-                    }`}
-                  >
-                    {t(`reports.${opt}`)}
-                  </button>
-                ))}
-              </div>
-            </div>
+          {/* Evolution chart — left 2 cols */}
+          <div className="lg:col-span-2 lg:row-start-1 lg:col-start-1">
             {compositionView === 'summary' ? (
+              <>
               <div className="px-1 pb-4" style={{ height: 320 }}>
                 {isLoading ? (
                   <div className="px-4"><Skeleton className="h-full w-full" /></div>
@@ -1073,17 +995,17 @@ export default function ReportsPage() {
                         }}
                       />
                       <ReferenceLine y={0} stroke="var(--border)" strokeDasharray="3 3" />
-                      <Bar dataKey="accounts" stackId="stack" fill={colorMap['accounts'] || '#6366F1'} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleSummaryBarClick}>
+                      <Bar dataKey="accounts" stackId="stack" fill={colorMap['accounts'] || '#6366F1'} maxBarSize={64} radius={[0, 0, 0, 0]} onClick={handleSummaryBarClick}>
                         {netWorthSummaryData.map((_: unknown, i: number) => (
                           <Cell key={i} fill={colorMap['accounts'] || '#6366F1'} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                         ))}
                       </Bar>
-                      <Bar dataKey="assets" stackId="stack" fill={colorMap['assets'] || '#F59E0B'} maxBarSize={32} radius={[4, 4, 0, 0]} onClick={handleSummaryBarClick}>
+                      <Bar dataKey="assets" stackId="stack" fill={colorMap['assets'] || '#F59E0B'} maxBarSize={64} radius={[4, 4, 0, 0]} onClick={handleSummaryBarClick}>
                         {netWorthSummaryData.map((_: unknown, i: number) => (
                           <Cell key={i} fill={colorMap['assets'] || '#F59E0B'} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                         ))}
                       </Bar>
-                      <Bar dataKey="liabilitiesNeg" stackId="stack" fill={colorMap['liabilities'] || '#F43F5E'} maxBarSize={32} radius={[4, 4, 0, 0]} onClick={handleSummaryBarClick}>
+                      <Bar dataKey="liabilitiesNeg" stackId="stack" fill={colorMap['liabilities'] || '#F43F5E'} maxBarSize={64} radius={[4, 4, 0, 0]} onClick={handleSummaryBarClick}>
                         {netWorthSummaryData.map((_: unknown, i: number) => (
                           <Cell key={i} fill={colorMap['liabilities'] || '#F43F5E'} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                         ))}
@@ -1103,8 +1025,28 @@ export default function ReportsPage() {
                   <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
                 )}
               </div>
+              {!isLoading && netWorthSummaryData.length > 0 && (
+                <div className="px-5 pb-4 flex flex-wrap gap-x-3 gap-y-1.5">
+                  {[
+                    { key: 'accounts', color: colorMap['accounts'] || '#6366F1' },
+                    { key: 'assets', color: colorMap['assets'] || '#F59E0B' },
+                    { key: 'liabilities', color: colorMap['liabilities'] || '#F43F5E' },
+                  ].map(({ key, color }) => (
+                    <div key={key} className="flex items-center gap-1.5">
+                      <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
+                      <span className="text-[11px] text-muted-foreground">{t(`reports.${key}`)}</span>
+                    </div>
+                  ))}
+                  <div className="flex items-center gap-1.5">
+                    <div className="w-3 h-0 border-t-2 border-dashed shrink-0" style={{ borderColor: '#10B981' }} />
+                    <span className="text-[11px] text-muted-foreground">{t('reports.netWorth')}</span>
+                  </div>
+                </div>
+              )}
+              </>
             ) : (
-              <div className="px-1 pb-4" style={{ height: 320 }}>
+              <>
+              <div className="px-1 pb-2" style={{ height: 300 }}>
                 {isLoading ? (
                   <div className="px-4"><Skeleton className="h-full w-full" /></div>
                 ) : netWorthDetailedData.length > 0 ? (
@@ -1193,17 +1135,17 @@ export default function ReportsPage() {
                       {nwBarsAccounts.map((item: ReportCompositionItem, idx: number) => {
                         const color = accountsGradient[idx] ?? accountsGradient[accountsGradient.length - 1]
                         return (
-                          <Bar key={`acct_${item.key}`} dataKey={`acct_${item.key}`} stackId="stack" fill={color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                          <Bar key={`acct_${item.key}`} dataKey={`acct_${item.key}`} stackId="stack" fill={color} maxBarSize={64} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
                             {netWorthDetailedData.map((_: unknown, i: number) => (
                               <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                             ))}
                           </Bar>
                         )
                       })}
-                      {nwDetailAccounts.length > COMPOSITION_TOP_N && (() => {
+                      {nwDetailAccounts.length > nwBarsAccounts.length && (() => {
                         const color = accountsGradient[accountsGradient.length - 1] ?? '#6B7280'
                         return (
-                          <Bar key="acct_others" dataKey="acct_others" stackId="stack" fill={color} maxBarSize={32} radius={nwBarsAssets.length === 0 && nwDetailLiabs.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                          <Bar key="acct_others" dataKey="acct_others" stackId="stack" fill={color} maxBarSize={64} radius={nwBarsAssets.length === 0 && nwDetailLiabs.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]} onClick={handleDetailedBarClick}>
                             {netWorthDetailedData.map((_: unknown, i: number) => (
                               <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                             ))}
@@ -1213,17 +1155,17 @@ export default function ReportsPage() {
                       {nwBarsAssets.map((item: ReportCompositionItem, idx: number) => {
                         const color = assetsGradient[idx] ?? assetsGradient[assetsGradient.length - 1]
                         return (
-                          <Bar key={`asset_${item.key}`} dataKey={`asset_${item.key}`} stackId="stack" fill={color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                          <Bar key={`asset_${item.key}`} dataKey={`asset_${item.key}`} stackId="stack" fill={color} maxBarSize={64} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
                             {netWorthDetailedData.map((_: unknown, i: number) => (
                               <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                             ))}
                           </Bar>
                         )
                       })}
-                      {nwDetailAssets.length > COMPOSITION_TOP_N && (() => {
+                      {nwDetailAssets.length > nwBarsAssets.length && (() => {
                         const color = assetsGradient[assetsGradient.length - 1] ?? '#6B7280'
                         return (
-                          <Bar key="asset_others" dataKey="asset_others" stackId="stack" fill={color} maxBarSize={32} radius={nwDetailLiabs.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                          <Bar key="asset_others" dataKey="asset_others" stackId="stack" fill={color} maxBarSize={64} radius={nwDetailLiabs.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]} onClick={handleDetailedBarClick}>
                             {netWorthDetailedData.map((_: unknown, i: number) => (
                               <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                             ))}
@@ -1233,17 +1175,17 @@ export default function ReportsPage() {
                       {nwBarsLiabs.map((item: ReportCompositionItem, idx: number) => {
                         const color = liabsGradient[idx] ?? liabsGradient[liabsGradient.length - 1]
                         return (
-                          <Bar key={`liab_${item.key}`} dataKey={`liab_${item.key}`} stackId="stack" fill={color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                          <Bar key={`liab_${item.key}`} dataKey={`liab_${item.key}`} stackId="stack" fill={color} maxBarSize={64} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
                             {netWorthDetailedData.map((_: unknown, i: number) => (
                               <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                             ))}
                           </Bar>
                         )
                       })}
-                      {nwDetailLiabs.length > COMPOSITION_TOP_N && (() => {
+                      {nwDetailLiabs.length > nwBarsLiabs.length && (() => {
                         const color = liabsGradient[liabsGradient.length - 1] ?? '#6B7280'
                         return (
-                          <Bar key="liab_others" dataKey="liab_others" stackId="stack" fill={color} maxBarSize={32} radius={[4, 4, 0, 0]} onClick={handleDetailedBarClick}>
+                          <Bar key="liab_others" dataKey="liab_others" stackId="stack" fill={color} maxBarSize={64} radius={[4, 4, 0, 0]} onClick={handleDetailedBarClick}>
                             {netWorthDetailedData.map((_: unknown, i: number) => (
                               <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                             ))}
@@ -1265,7 +1207,53 @@ export default function ReportsPage() {
                   <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
                 )}
               </div>
+              {!isLoading && netWorthDetailedData.length > 0 && (
+                <div className="px-5 pb-4 flex flex-wrap gap-x-3 gap-y-1.5">
+                  {nwBarsAccounts.map((item, idx) => (
+                    <div key={`acct_${item.key}`} className="flex items-center gap-1.5">
+                      <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: accountsGradient[idx] ?? accountsGradient[accountsGradient.length - 1] }} />
+                      <span className="text-[11px] text-muted-foreground">{item.label.length > 22 ? item.label.slice(0, 22) + '…' : item.label}</span>
+                    </div>
+                  ))}
+                  {nwDetailAccounts.length > nwBarsAccounts.length && (
+                    <div className="flex items-center gap-1.5">
+                      <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: accountsGradient[accountsGradient.length - 1] ?? '#6B7280' }} />
+                      <span className="text-[11px] text-muted-foreground">{t('reports.other')}</span>
+                    </div>
+                  )}
+                  {nwBarsAssets.map((item, idx) => (
+                    <div key={`asset_${item.key}`} className="flex items-center gap-1.5">
+                      <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: assetsGradient[idx] ?? assetsGradient[assetsGradient.length - 1] }} />
+                      <span className="text-[11px] text-muted-foreground">{item.label.length > 22 ? item.label.slice(0, 22) + '…' : item.label}</span>
+                    </div>
+                  ))}
+                  {nwDetailAssets.length > nwBarsAssets.length && (
+                    <div className="flex items-center gap-1.5">
+                      <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: assetsGradient[assetsGradient.length - 1] ?? '#6B7280' }} />
+                      <span className="text-[11px] text-muted-foreground">{t('reports.other')}</span>
+                    </div>
+                  )}
+                  {nwBarsLiabs.map((item, idx) => (
+                    <div key={`liab_${item.key}`} className="flex items-center gap-1.5">
+                      <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: liabsGradient[idx] ?? liabsGradient[liabsGradient.length - 1] }} />
+                      <span className="text-[11px] text-muted-foreground">{item.label.length > 22 ? item.label.slice(0, 22) + '…' : item.label}</span>
+                    </div>
+                  ))}
+                  {nwDetailLiabs.length > nwBarsLiabs.length && (
+                    <div className="flex items-center gap-1.5">
+                      <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: liabsGradient[liabsGradient.length - 1] ?? '#6B7280' }} />
+                      <span className="text-[11px] text-muted-foreground">{t('reports.other')}</span>
+                    </div>
+                  )}
+                  <div className="flex items-center gap-1.5">
+                    <div className="w-3 h-0 border-t-2 border-dashed" style={{ borderColor: '#10B981' }} />
+                    <span className="text-[11px] text-muted-foreground">{t('reports.netWorth')}</span>
+                  </div>
+                </div>
+              )}
+              </>
             )}
+          </div>
           </div>
         </div>
       )}

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -805,14 +805,11 @@ export default function ReportsPage() {
         <div className="bg-card rounded-xl border border-border shadow-sm">
           {/* Merged header */}
           <div className="px-5 pt-4 pb-2 flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <div>
-                <p className="text-sm font-semibold text-foreground">{t('reports.evolution')}</p>
-                <span className="text-xs text-muted-foreground">{nwPeriodLabel}</span>
-              </div>
-            </div>
+            <p className="text-sm font-semibold text-foreground">{t('reports.evolution')}</p>
             <div className="text-right">
-              <p className="text-[10px] text-muted-foreground leading-tight uppercase tracking-wider">{t('reports.netWorth')}</p>
+              <p className="text-[10px] text-muted-foreground leading-tight uppercase tracking-wider">
+                {`${t('reports.netWorth')} · ${nwPeriodLabel}`}
+              </p>
               <p className="text-xl font-bold text-foreground tabular-nums">
                 {mask(formatCurrency(selectedNWBar ? selectedNWBar.value : (summary?.primary_value ?? 0), userCurrency, locale))}
               </p>
@@ -858,7 +855,7 @@ export default function ReportsPage() {
                               : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
                           }`}
                         >
-                          {t('reports.whatYouHave')}
+                          {isCurrentNW ? t('reports.whatYouHave') : t('reports.whatYouOwned')}
                         </button>
                         <button
                           onClick={() => setNwPieView('liabilities')}
@@ -868,7 +865,7 @@ export default function ReportsPage() {
                               : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
                           }`}
                         >
-                          {t('reports.whatYouOwe')}
+                          {isCurrentNW ? t('reports.whatYouOwe') : t('reports.whatYouOwed')}
                         </button>
                       </div>
                     </div>
@@ -914,7 +911,9 @@ export default function ReportsPage() {
                           </ResponsiveContainer>
                           <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none" style={{ zIndex: 2 }}>
                             <span className="text-[10px] text-muted-foreground leading-tight">
-                              {isAccAssets ? t('reports.whatYouHave') : t('reports.whatYouOwe')}
+                              {isAccAssets
+                                ? (isCurrentNW ? t('reports.whatYouHave') : t('reports.whatYouOwned'))
+                                : (isCurrentNW ? t('reports.whatYouOwe') : t('reports.whatYouOwed'))}
                             </span>
                             <span className="text-base font-bold text-foreground tabular-nums">
                               {mask(formatCompact(centerValue, userCurrency, locale))}
@@ -1027,25 +1026,7 @@ export default function ReportsPage() {
                   <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
                 )}
               </div>
-              {!isLoading && netWorthSummaryData.length > 0 && (
-                <div className="px-5 pb-4 flex flex-wrap gap-x-3 gap-y-1.5">
-                  {[
-                    { key: 'accounts', color: colorMap['accounts'] || '#6366F1' },
-                    { key: 'assets', color: colorMap['assets'] || '#F59E0B' },
-                    { key: 'liabilities', color: colorMap['liabilities'] || '#F43F5E' },
-                  ].map(({ key, color }) => (
-                    <div key={key} className="flex items-center gap-1.5">
-                      <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
-                      <span className="text-[11px] text-muted-foreground">{t(`reports.${key}`)}</span>
-                    </div>
-                  ))}
-                  <div className="flex items-center gap-1.5">
-                    <div className="w-3 h-0 border-t-2 border-dashed shrink-0" style={{ borderColor: '#10B981' }} />
-                    <span className="text-[11px] text-muted-foreground">{t('reports.netWorth')}</span>
-                  </div>
-                </div>
-              )}
-              </>
+</>
             ) : (
               <>
               <div className="px-1 pb-2" style={{ height: 300 }}>
@@ -1209,8 +1190,32 @@ export default function ReportsPage() {
                   <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
                 )}
               </div>
-              {!isLoading && netWorthDetailedData.length > 0 && (
-                <div className="px-5 pb-4 flex flex-wrap gap-x-3 gap-y-1.5">
+</>
+            )}
+          </div>
+
+          {/* Legend — spans full widget width */}
+          {!isLoading && (compositionView === 'summary' ? netWorthSummaryData.length > 0 : netWorthDetailedData.length > 0) && (
+            <div className="lg:col-span-3 px-5 pt-3 pb-4 border-t border-border flex flex-wrap gap-x-3 gap-y-1.5">
+              {compositionView === 'summary' ? (
+                <>
+                  {[
+                    { key: 'accounts', color: colorMap['accounts'] || '#6366F1' },
+                    { key: 'assets', color: colorMap['assets'] || '#F59E0B' },
+                    { key: 'liabilities', color: colorMap['liabilities'] || '#F43F5E' },
+                  ].map(({ key, color }) => (
+                    <div key={key} className="flex items-center gap-1.5">
+                      <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
+                      <span className="text-[11px] text-muted-foreground">{t(`reports.${key}`)}</span>
+                    </div>
+                  ))}
+                  <div className="flex items-center gap-1.5">
+                    <div className="w-3 h-0 border-t-2 border-dashed shrink-0" style={{ borderColor: '#10B981' }} />
+                    <span className="text-[11px] text-muted-foreground">{t('reports.netWorth')}</span>
+                  </div>
+                </>
+              ) : (
+                <>
                   {nwBarsAccounts.map((item, idx) => (
                     <div key={`acct_${item.key}`} className="flex items-center gap-1.5">
                       <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: accountsGradient[idx] ?? accountsGradient[accountsGradient.length - 1] }} />
@@ -1248,14 +1253,13 @@ export default function ReportsPage() {
                     </div>
                   )}
                   <div className="flex items-center gap-1.5">
-                    <div className="w-3 h-0 border-t-2 border-dashed" style={{ borderColor: '#10B981' }} />
+                    <div className="w-3 h-0 border-t-2 border-dashed shrink-0" style={{ borderColor: '#10B981' }} />
                     <span className="text-[11px] text-muted-foreground">{t('reports.netWorth')}</span>
                   </div>
-                </div>
+                </>
               )}
-              </>
-            )}
-          </div>
+            </div>
+          )}
           </div>
         </div>
       )}

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -833,6 +833,7 @@ export default function ReportsPage() {
                             transform: compositionView === 'detailed' ? 'scale(1)' : 'scale(1.458)',
                             transition: 'transform 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
                             transformOrigin: 'center',
+                            zIndex: 1,
                           }}
                         >
                           <ResponsiveContainer width="100%" height="100%">
@@ -903,6 +904,7 @@ export default function ReportsPage() {
                             transform: compositionView === 'detailed' ? 'scale(1)' : 'scale(1.458)',
                             transition: 'transform 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
                             transformOrigin: 'center',
+                            zIndex: 1,
                           }}
                         >
                           <ResponsiveContainer width="100%" height="100%">

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -768,51 +768,60 @@ export default function ReportsPage() {
                     <p className="text-[11px] font-medium text-muted-foreground">{t('reports.accountsAndAssets')}</p>
                     {nwPieAInner.length > 0 ? (
                       <div className="relative" style={{ width: 148, height: 148 }}>
-                        <ResponsiveContainer width="100%" height="100%">
-                          <PieChart>
-                            <Pie
-                              data={nwPieAOuter}
-                              innerRadius={52}
-                              outerRadius={70}
-                              paddingAngle={0}
-                              dataKey="value"
-                              stroke="var(--card)"
-                              strokeWidth={1}
-                              animationBegin={50}
-                              animationDuration={500}
-                            >
-                              {nwPieAOuter.map((entry, idx) => (
-                                <Cell key={idx} fill={entry.color} />
-                              ))}
-                            </Pie>
-                            <Pie
-                              data={nwPieAInner}
-                              innerRadius={28}
-                              outerRadius={48}
-                              paddingAngle={0}
-                              dataKey="value"
-                              stroke="var(--card)"
-                              strokeWidth={1}
-                              animationBegin={50}
-                              animationDuration={500}
-                            >
-                              {nwPieAInner.map((entry, idx) => (
-                                <Cell key={idx} fill={entry.color} />
-                              ))}
-                            </Pie>
-                            <Tooltip
-                              formatter={(value?: number, name?: string) => {
-                                const v = value ?? 0
-                                const total = selectedAccounts + selectedAssets
-                                const pct = total > 0 ? ((v / total) * 100).toFixed(1) : '0'
-                                return [privacyMode ? MASK : `${formatCurrency(v, userCurrency, locale)} (${pct}%)`, name]
-                              }}
-                              contentStyle={{ ...tooltipStyle, zIndex: 10 }}
-                              itemStyle={tooltipItemStyle}
-                              wrapperStyle={{ zIndex: 10 }}
-                            />
-                          </PieChart>
-                        </ResponsiveContainer>
+                        <div
+                          className="absolute inset-0"
+                          style={{
+                            transform: compositionView === 'detailed' ? 'scale(1)' : 'scale(1.458)',
+                            transition: 'transform 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
+                            transformOrigin: 'center',
+                          }}
+                        >
+                          <ResponsiveContainer width="100%" height="100%">
+                            <PieChart>
+                              <Pie
+                                data={compositionView === 'detailed' ? nwPieAOuter : []}
+                                innerRadius={52}
+                                outerRadius={70}
+                                paddingAngle={0}
+                                dataKey="value"
+                                stroke="var(--card)"
+                                strokeWidth={1}
+                                animationBegin={0}
+                                animationDuration={500}
+                              >
+                                {nwPieAOuter.map((entry, idx) => (
+                                  <Cell key={idx} fill={entry.color} />
+                                ))}
+                              </Pie>
+                              <Pie
+                                data={nwPieAInner}
+                                innerRadius={28}
+                                outerRadius={48}
+                                paddingAngle={0}
+                                dataKey="value"
+                                stroke="var(--card)"
+                                strokeWidth={1}
+                                animationBegin={50}
+                                animationDuration={500}
+                              >
+                                {nwPieAInner.map((entry, idx) => (
+                                  <Cell key={idx} fill={entry.color} />
+                                ))}
+                              </Pie>
+                              <Tooltip
+                                formatter={(value?: number, name?: string) => {
+                                  const v = value ?? 0
+                                  const total = selectedAccounts + selectedAssets
+                                  const pct = total > 0 ? ((v / total) * 100).toFixed(1) : '0'
+                                  return [privacyMode ? MASK : `${formatCurrency(v, userCurrency, locale)} (${pct}%)`, name]
+                                }}
+                                contentStyle={{ ...tooltipStyle, zIndex: 10 }}
+                                itemStyle={tooltipItemStyle}
+                                wrapperStyle={{ zIndex: 10 }}
+                              />
+                            </PieChart>
+                          </ResponsiveContainer>
+                        </div>
                         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
                           <span className="text-[10px] font-bold text-foreground tabular-nums">
                             {mask(formatCompact(selectedAccounts + selectedAssets, userCurrency, locale))}
@@ -829,50 +838,59 @@ export default function ReportsPage() {
                     <p className="text-[11px] font-medium text-muted-foreground">{t('reports.liabilities')}</p>
                     {nwPieBInner.length > 0 ? (
                       <div className="relative" style={{ width: 148, height: 148 }}>
-                        <ResponsiveContainer width="100%" height="100%">
-                          <PieChart>
-                            <Pie
-                              data={nwPieBOuter}
-                              innerRadius={52}
-                              outerRadius={70}
-                              paddingAngle={0}
-                              dataKey="value"
-                              stroke="var(--card)"
-                              strokeWidth={1}
-                              animationBegin={50}
-                              animationDuration={500}
-                            >
-                              {nwPieBOuter.map((entry, idx) => (
-                                <Cell key={idx} fill={entry.color} />
-                              ))}
-                            </Pie>
-                            <Pie
-                              data={nwPieBInner}
-                              innerRadius={28}
-                              outerRadius={48}
-                              paddingAngle={0}
-                              dataKey="value"
-                              stroke="var(--card)"
-                              strokeWidth={1}
-                              animationBegin={50}
-                              animationDuration={500}
-                            >
-                              {nwPieBInner.map((entry, idx) => (
-                                <Cell key={idx} fill={entry.color} />
-                              ))}
-                            </Pie>
-                            <Tooltip
-                              formatter={(value?: number, name?: string) => {
-                                const v = value ?? 0
-                                const pct = selectedLiabs > 0 ? ((v / selectedLiabs) * 100).toFixed(1) : '0'
-                                return [privacyMode ? MASK : `${formatCurrency(v, userCurrency, locale)} (${pct}%)`, name]
-                              }}
-                              contentStyle={{ ...tooltipStyle, zIndex: 10 }}
-                              itemStyle={tooltipItemStyle}
-                              wrapperStyle={{ zIndex: 10 }}
-                            />
-                          </PieChart>
-                        </ResponsiveContainer>
+                        <div
+                          className="absolute inset-0"
+                          style={{
+                            transform: compositionView === 'detailed' ? 'scale(1)' : 'scale(1.458)',
+                            transition: 'transform 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
+                            transformOrigin: 'center',
+                          }}
+                        >
+                          <ResponsiveContainer width="100%" height="100%">
+                            <PieChart>
+                              <Pie
+                                data={compositionView === 'detailed' ? nwPieBOuter : []}
+                                innerRadius={52}
+                                outerRadius={70}
+                                paddingAngle={0}
+                                dataKey="value"
+                                stroke="var(--card)"
+                                strokeWidth={1}
+                                animationBegin={0}
+                                animationDuration={500}
+                              >
+                                {nwPieBOuter.map((entry, idx) => (
+                                  <Cell key={idx} fill={entry.color} />
+                                ))}
+                              </Pie>
+                              <Pie
+                                data={nwPieBInner}
+                                innerRadius={28}
+                                outerRadius={48}
+                                paddingAngle={0}
+                                dataKey="value"
+                                stroke="var(--card)"
+                                strokeWidth={1}
+                                animationBegin={50}
+                                animationDuration={500}
+                              >
+                                {nwPieBInner.map((entry, idx) => (
+                                  <Cell key={idx} fill={entry.color} />
+                                ))}
+                              </Pie>
+                              <Tooltip
+                                formatter={(value?: number, name?: string) => {
+                                  const v = value ?? 0
+                                  const pct = selectedLiabs > 0 ? ((v / selectedLiabs) * 100).toFixed(1) : '0'
+                                  return [privacyMode ? MASK : `${formatCurrency(v, userCurrency, locale)} (${pct}%)`, name]
+                                }}
+                                contentStyle={{ ...tooltipStyle, zIndex: 10 }}
+                                itemStyle={tooltipItemStyle}
+                                wrapperStyle={{ zIndex: 10 }}
+                              />
+                            </PieChart>
+                          </ResponsiveContainer>
+                        </div>
                         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
                           <span className="text-[10px] font-bold text-foreground tabular-nums">
                             {mask(formatCompact(selectedLiabs, userCurrency, locale))}

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -23,7 +23,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { PageHeader } from '@/components/page-header'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
-import type { ReportResponse, CategoryTrendItem } from '@/types'
+import type { ReportResponse, CategoryTrendItem, ReportCompositionItem } from '@/types'
 
 function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
   return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
@@ -154,6 +154,11 @@ export default function ReportsPage() {
     colorMap[b.key] = b.color
   }
 
+  const netWorthSummaryData = chartData.map((d) => ({
+    ...d,
+    liabilitiesNeg: -((d.liabilities as number) ?? 0),
+  }))
+
   const changePrefix = (summary?.change_amount ?? 0) >= 0 ? '+' : ''
   const changeColor = (summary?.change_amount ?? 0) >= 0 ? 'text-emerald-600' : 'text-rose-500'
 
@@ -175,6 +180,33 @@ export default function ReportsPage() {
 
   // Build donut data based on composition view
   const composition = data?.composition ?? []
+
+  const nwDetailAccounts = composition.filter((c: ReportCompositionItem) => c.group === 'accounts')
+  const nwDetailAssets = composition.filter((c: ReportCompositionItem) => c.group === 'assets')
+  const nwDetailLiabs = composition.filter((c: ReportCompositionItem) => c.group === 'liabilities')
+  const nwDetailTotalAccounts = nwDetailAccounts.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
+  const nwDetailTotalAssets = nwDetailAssets.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
+  const nwDetailTotalLiabs = nwDetailLiabs.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
+
+  const netWorthDetailedData: Record<string, string | number>[] = meta?.type !== 'net_worth' ? [] : chartData.map((d: Record<string, string | number>) => {
+    const aTotal = (d.accounts as number) ?? 0
+    const sTotal = (d.assets as number) ?? 0
+    const lTotal = (d.liabilities as number) ?? 0
+    const row: Record<string, string | number> = { date: d.date as string, value: d.value as number }
+    nwDetailAccounts.forEach((item) => {
+      const p = nwDetailTotalAccounts > 0 ? item.value / nwDetailTotalAccounts : 0
+      row[`acct_${item.key}`] = Math.round(aTotal * p * 100) / 100
+    })
+    nwDetailAssets.forEach((item) => {
+      const p = nwDetailTotalAssets > 0 ? item.value / nwDetailTotalAssets : 0
+      row[`asset_${item.key}`] = Math.round(sTotal * p * 100) / 100
+    })
+    nwDetailLiabs.forEach((item) => {
+      const p = nwDetailTotalLiabs > 0 ? item.value / nwDetailTotalLiabs : 0
+      row[`liab_${item.key}`] = -Math.round(lTotal * p * 100) / 100
+    })
+    return row
+  })
 
   const donutData = (() => {
     if (compositionView === 'summary' || composition.length === 0) {
@@ -555,7 +587,239 @@ export default function ReportsPage() {
         </div>
       </div>
 
-      {/* Breakdown: Donut + Grouped Bar */}
+      {meta?.type === 'net_worth' && (
+        <div className="bg-card rounded-xl border border-border shadow-sm">
+          <div className="px-5 pt-4 pb-2 flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <p className="text-sm font-semibold text-foreground">{t('reports.evolution')}</p>
+              {compositionView === 'summary' && (
+                <div className="hidden sm:flex items-center gap-3">
+                  {[
+                    { key: 'accounts', color: colorMap['accounts'] || '#6366F1' },
+                    { key: 'assets', color: colorMap['assets'] || '#F59E0B' },
+                    { key: 'liabilities', color: colorMap['liabilities'] || '#F43F5E' },
+                  ].map(({ key, color }) => (
+                    <div key={key} className="flex items-center gap-1.5">
+                      <div className="w-2 h-2 rounded-full" style={{ backgroundColor: color }} />
+                      <span className="text-[11px] text-muted-foreground">{t(`reports.${key}`)}</span>
+                    </div>
+                  ))}
+                  <div className="flex items-center gap-1.5">
+                    <div className="w-3 h-0 border-t-2 border-dashed" style={{ borderColor: '#10B981' }} />
+                    <span className="text-[11px] text-muted-foreground">{t('reports.netWorth')}</span>
+                  </div>
+                </div>
+              )}
+            </div>
+            <div className="flex items-center rounded-lg border border-border bg-muted/30 overflow-hidden">
+              {(['summary', 'detailed'] as const).map((opt) => (
+                <button
+                  key={opt}
+                  onClick={() => setCompositionView(opt)}
+                  className={`px-2.5 py-1 text-[11px] font-semibold transition-colors ${
+                    compositionView === opt
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                  }`}
+                >
+                  {t(`reports.${opt}`)}
+                </button>
+              ))}
+            </div>
+          </div>
+          {compositionView === 'summary' ? (
+            <div className="px-1 pb-4" style={{ height: 320 }}>
+              {isLoading ? (
+                <div className="px-4"><Skeleton className="h-full w-full" /></div>
+              ) : netWorthSummaryData.length > 0 ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <ComposedChart data={netWorthSummaryData} stackOffset="sign" margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
+                      axisLine={false}
+                      tickLine={false}
+                      interval="preserveStartEnd"
+                    />
+                    <YAxis
+                      tickFormatter={(v) => {
+                        if (privacyMode) return ''
+                        if (v === 0) return '0'
+                        return formatCompact(v, userCurrency, locale)
+                      }}
+                      tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
+                      axisLine={false}
+                      tickLine={false}
+                      width={64}
+                      tickCount={5}
+                    />
+                    <Tooltip
+                      content={({ active, payload, label }) => {
+                        if (!active || !payload) return null
+                        const liabEntry = payload.find((p) => p.dataKey === 'liabilitiesNeg')
+                        const netEntry = payload.find((p) => p.dataKey === 'value')
+                        return (
+                          <div style={tooltipStyle} className="px-3 py-2">
+                            <p className="text-xs font-medium mb-1">{label}</p>
+                            {payload
+                              .filter((p) => p.dataKey !== 'liabilitiesNeg' && p.dataKey !== 'value' && (p.value as number) !== 0)
+                              .map((p) => (
+                                <p key={p.dataKey as string} className="text-xs" style={{ color: p.color }}>
+                                  {t(`reports.${p.dataKey}`, { defaultValue: String(p.name) })}:{' '}
+                                  {privacyMode ? MASK : formatCurrency(p.value as number, userCurrency, locale)}
+                                </p>
+                              ))
+                            }
+                            {liabEntry && (liabEntry.value as number) !== 0 && (
+                              <p className="text-xs" style={{ color: '#F43F5E' }}>
+                                {t('reports.liabilities')}:{' '}
+                                {privacyMode ? MASK : formatCurrency(-(liabEntry.value as number), userCurrency, locale)}
+                              </p>
+                            )}
+                            {netEntry && (
+                              <p className="text-xs font-semibold mt-1" style={{ color: '#10B981' }}>
+                                {t('reports.netWorth')}:{' '}
+                                {privacyMode ? MASK : formatCurrency(netEntry.value as number, userCurrency, locale)}
+                              </p>
+                            )}
+                          </div>
+                        )
+                      }}
+                    />
+                    <ReferenceLine y={0} stroke="var(--border)" strokeDasharray="3 3" />
+                    <Bar dataKey="accounts" stackId="stack" fill={colorMap['accounts'] || '#6366F1'} maxBarSize={32} radius={[0, 0, 0, 0]} />
+                    <Bar dataKey="assets" stackId="stack" fill={colorMap['assets'] || '#F59E0B'} maxBarSize={32} radius={[4, 4, 0, 0]} />
+                    <Bar dataKey="liabilitiesNeg" stackId="stack" fill={colorMap['liabilities'] || '#F43F5E'} maxBarSize={32} radius={[4, 4, 0, 0]} />
+                    <Line
+                      type="monotone"
+                      dataKey="value"
+                      stroke="#10B981"
+                      strokeWidth={2}
+                      strokeDasharray="6 3"
+                      dot={false}
+                      activeDot={{ r: 4, fill: '#10B981' }}
+                    />
+                  </ComposedChart>
+                </ResponsiveContainer>
+              ) : (
+                <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
+              )}
+            </div>
+          ) : (
+            <div className="px-1 pb-4" style={{ height: 320 }}>
+              {isLoading ? (
+                <div className="px-4"><Skeleton className="h-full w-full" /></div>
+              ) : netWorthDetailedData.length > 0 ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <ComposedChart data={netWorthDetailedData} stackOffset="sign" margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
+                      axisLine={false}
+                      tickLine={false}
+                      interval="preserveStartEnd"
+                    />
+                    <YAxis
+                      tickFormatter={(v) => {
+                        if (privacyMode) return ''
+                        if (v === 0) return '0'
+                        return formatCompact(v, userCurrency, locale)
+                      }}
+                      tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
+                      axisLine={false}
+                      tickLine={false}
+                      width={64}
+                      tickCount={5}
+                    />
+                    <Tooltip
+                      content={({ active, payload, label }: { active?: boolean; payload?: { dataKey?: string | number; value?: number; color?: string }[]; label?: string }) => {
+                        if (!active || !payload) return null
+                        const findLabel = (dk: string) =>
+                          composition.find((c: ReportCompositionItem) => c.key === dk.replace(/^(acct_|asset_|liab_)/, ''))?.label ?? dk
+                        const acctEntries = payload.filter((p) => String(p.dataKey).startsWith('acct_') && (p.value ?? 0) !== 0)
+                        const assetEntries = payload.filter((p) => String(p.dataKey).startsWith('asset_') && (p.value ?? 0) !== 0)
+                        const liabEntries = payload.filter((p) => String(p.dataKey).startsWith('liab_') && (p.value ?? 0) !== 0)
+                        const netEntry = payload.find((p) => p.dataKey === 'value')
+                        return (
+                          <div style={tooltipStyle} className="px-3 py-2 max-w-[220px]">
+                            <p className="text-xs font-medium mb-1">{label}</p>
+                            {acctEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.accounts')}</p>}
+                            {acctEntries.map((p) => (
+                              <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
+                                {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(p.value ?? 0, userCurrency, locale)}
+                              </p>
+                            ))}
+                            {assetEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.assets')}</p>}
+                            {assetEntries.map((p) => (
+                              <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
+                                {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(p.value ?? 0, userCurrency, locale)}
+                              </p>
+                            ))}
+                            {liabEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.liabilities')}</p>}
+                            {liabEntries.map((p) => (
+                              <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
+                                {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(-(p.value ?? 0), userCurrency, locale)}
+                              </p>
+                            ))}
+                            {netEntry && (
+                              <p className="text-xs font-semibold mt-1 pt-1 border-t border-border" style={{ color: '#10B981' }}>
+                                {t('reports.netWorth')}: {privacyMode ? MASK : formatCurrency(netEntry.value ?? 0, userCurrency, locale)}
+                              </p>
+                            )}
+                          </div>
+                        )
+                      }}
+                    />
+                    <ReferenceLine y={0} stroke="var(--border)" strokeDasharray="3 3" />
+                    {nwDetailAccounts.map((item: ReportCompositionItem, idx: number) => (
+                      <Bar
+                        key={`acct_${item.key}`}
+                        dataKey={`acct_${item.key}`}
+                        stackId="stack"
+                        fill={item.color}
+                        maxBarSize={32}
+                        radius={idx === nwDetailAccounts.length - 1 && nwDetailAssets.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+                      />
+                    ))}
+                    {nwDetailAssets.map((item: ReportCompositionItem, idx: number) => (
+                      <Bar
+                        key={`asset_${item.key}`}
+                        dataKey={`asset_${item.key}`}
+                        stackId="stack"
+                        fill={item.color}
+                        maxBarSize={32}
+                        radius={idx === nwDetailAssets.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+                      />
+                    ))}
+                    {nwDetailLiabs.map((item: ReportCompositionItem, idx: number) => (
+                      <Bar
+                        key={`liab_${item.key}`}
+                        dataKey={`liab_${item.key}`}
+                        stackId="stack"
+                        fill={item.color}
+                        maxBarSize={32}
+                        radius={idx === nwDetailLiabs.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+                      />
+                    ))}
+                    <Line
+                      type="monotone"
+                      dataKey="value"
+                      stroke="#10B981"
+                      strokeWidth={2}
+                      strokeDasharray="6 3"
+                      dot={false}
+                      activeDot={{ r: 4, fill: '#10B981' }}
+                    />
+                  </ComposedChart>
+                </ResponsiveContainer>
+              ) : (
+                <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+      {!isLoading && meta?.type !== 'net_worth' && (
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
         {/* Donut Chart — Current Composition */}
         <div className="bg-card rounded-xl border border-border shadow-sm">
@@ -899,6 +1163,7 @@ export default function ReportsPage() {
           )}
         </div>
       </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -38,6 +38,57 @@ function formatCompact(value: number, currency = 'USD', locale = 'en-US') {
   }).format(value)
 }
 
+function hexToHsl(hex: string): [number, number, number] {
+  const r = parseInt(hex.slice(1, 3), 16) / 255
+  const g = parseInt(hex.slice(3, 5), 16) / 255
+  const b = parseInt(hex.slice(5, 7), 16) / 255
+  const max = Math.max(r, g, b), min = Math.min(r, g, b)
+  let h = 0
+  const l = (max + min) / 2
+  const d = max - min
+  const s = d === 0 ? 0 : l > 0.5 ? d / (2 - max - min) : d / (max + min)
+  if (d !== 0) {
+    if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6
+    else if (max === g) h = ((b - r) / d + 2) / 6
+    else h = ((r - g) / d + 4) / 6
+  }
+  return [h * 360, s * 100, l * 100]
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  h /= 360; s /= 100; l /= 100
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+  const p = 2 * l - q
+  const hue2rgb = (t: number) => {
+    if (t < 0) t += 1
+    if (t > 1) t -= 1
+    if (t < 1 / 6) return p + (q - p) * 6 * t
+    if (t < 1 / 2) return q
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
+    return p
+  }
+  const rv = s === 0 ? l : hue2rgb(h + 1 / 3)
+  const gv = s === 0 ? l : hue2rgb(h)
+  const bv = s === 0 ? l : hue2rgb(h - 1 / 3)
+  return '#' + [rv, gv, bv].map((x) => Math.round(x * 255).toString(16).padStart(2, '0')).join('')
+}
+
+// Returns `count` colors from most vivid → most muted.
+// The endpoint shifts hue by +50° and retains half the saturation so each
+// group fades toward its own distinct soft color instead of a shared gray.
+function buildGroupGradient(baseHex: string, count: number): string[] {
+  if (count <= 0) return []
+  if (count === 1) return [baseHex]
+  const [h, s, l] = hexToHsl(baseHex)
+  const targetH = h + 50
+  const targetS = s * 0.50
+  const targetL = Math.min(l + 18, 80)
+  return Array.from({ length: count }, (_, i) => {
+    const t = i / (count - 1)
+    return hslToHex(h + (targetH - h) * t, s + (targetS - s) * t, l + (targetL - l) * t)
+  })
+}
+
 const COMPOSITION_TOP_N = 10
 
 type RangeOption = { key: string; months: number }
@@ -205,6 +256,10 @@ export default function ReportsPage() {
   const nwBarsAssets = nwDetailAssets.slice(0, COMPOSITION_TOP_N)
   const nwBarsLiabs = nwDetailLiabs.slice(0, COMPOSITION_TOP_N)
 
+  const accountsGradient = buildGroupGradient(colorMap['accounts'] || '#6366F1', COMPOSITION_TOP_N)
+  const assetsGradient = buildGroupGradient(colorMap['assets'] || '#F59E0B', COMPOSITION_TOP_N)
+  const liabsGradient = buildGroupGradient(colorMap['liabilities'] || '#F43F5E', COMPOSITION_TOP_N)
+
   const lastNWIndex = netWorthSummaryData.length - 1
   const isCurrentNW = selectedNWBar == null || selectedNWBar.index === lastNWIndex
   const nwPeriodLabel = isCurrentNW ? t('reports.current') : selectedNWBar!.date
@@ -225,19 +280,20 @@ export default function ReportsPage() {
   const nwPieAOuter: NWPieItem[] = nwPieAInner.flatMap((group) => {
     const isAccounts = group.name === t('reports.accounts')
     const items = isAccounts ? nwDetailAccounts : nwDetailAssets
+    const gradient = isAccounts ? accountsGradient : assetsGradient
     const total = isAccounts ? nwDetailTotalAccounts : nwDetailTotalAssets
     const selected = isAccounts ? selectedAccounts : selectedAssets
     const sorted = items
       .map((item: ReportCompositionItem) => ({
         name: item.label,
         value: total > 0 ? (item.value / total) * selected : 0,
-        color: item.color,
       }))
       .filter((d) => d.value > 0)
       .sort((a, b) => b.value - a.value)
+      .map((d, i) => ({ ...d, color: gradient[i] ?? gradient[gradient.length - 1] ?? '#6B7280' }))
     const top = sorted.slice(0, COMPOSITION_TOP_N)
     const otherValue = sorted.slice(COMPOSITION_TOP_N).reduce((s, d) => s + d.value, 0)
-    if (otherValue > 0) top.push({ name: t('reports.other'), value: otherValue, color: '#6B7280' })
+    if (otherValue > 0) top.push({ name: t('reports.other'), value: otherValue, color: gradient[gradient.length - 1] ?? '#6B7280' })
     return top
   })
 
@@ -247,15 +303,18 @@ export default function ReportsPage() {
   ].filter((d) => d.value > 0)
 
   // Outer ring: individual liability items, proportionally scaled
-  const nwPieBOuterSorted: NWPieItem[] = nwDetailLiabs.map((item: ReportCompositionItem) => ({
-    name: item.label,
-    value: nwDetailTotalLiabs > 0 ? (item.value / nwDetailTotalLiabs) * selectedLiabs : 0,
-    color: item.color,
-  })).filter((d: NWPieItem) => d.value > 0).sort((a: NWPieItem, b: NWPieItem) => b.value - a.value)
+  const nwPieBOuterSorted: NWPieItem[] = nwDetailLiabs
+    .map((item: ReportCompositionItem) => ({
+      name: item.label,
+      value: nwDetailTotalLiabs > 0 ? (item.value / nwDetailTotalLiabs) * selectedLiabs : 0,
+    }))
+    .filter((d) => d.value > 0)
+    .sort((a, b) => b.value - a.value)
+    .map((d, i) => ({ ...d, color: liabsGradient[i] ?? liabsGradient[liabsGradient.length - 1] ?? '#6B7280' }))
   const nwPieBOuter: NWPieItem[] = (() => {
     const top = nwPieBOuterSorted.slice(0, COMPOSITION_TOP_N)
     const otherValue = nwPieBOuterSorted.slice(COMPOSITION_TOP_N).reduce((s, d) => s + d.value, 0)
-    if (otherValue > 0) top.push({ name: t('reports.other'), value: otherValue, color: '#6B7280' })
+    if (otherValue > 0) top.push({ name: t('reports.other'), value: otherValue, color: liabsGradient[liabsGradient.length - 1] ?? '#6B7280' })
     return top
   })()
 
@@ -1129,48 +1188,66 @@ export default function ReportsPage() {
                         }}
                       />
                       <ReferenceLine y={0} stroke="var(--border)" strokeDasharray="3 3" />
-                      {nwBarsAccounts.map((item: ReportCompositionItem, idx: number) => (
-                        <Bar key={`acct_${item.key}`} dataKey={`acct_${item.key}`} stackId="stack" fill={item.color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
-                          {netWorthDetailedData.map((_: unknown, i: number) => (
-                            <Cell key={i} fill={item.color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
-                          ))}
-                        </Bar>
-                      ))}
-                      {nwDetailAccounts.length > COMPOSITION_TOP_N && (
-                        <Bar key="acct_others" dataKey="acct_others" stackId="stack" fill="#6B7280" maxBarSize={32} radius={nwBarsAssets.length === 0 && nwDetailLiabs.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]} onClick={handleDetailedBarClick}>
-                          {netWorthDetailedData.map((_: unknown, i: number) => (
-                            <Cell key={i} fill="#6B7280" opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
-                          ))}
-                        </Bar>
-                      )}
-                      {nwBarsAssets.map((item: ReportCompositionItem, idx: number) => (
-                        <Bar key={`asset_${item.key}`} dataKey={`asset_${item.key}`} stackId="stack" fill={item.color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
-                          {netWorthDetailedData.map((_: unknown, i: number) => (
-                            <Cell key={i} fill={item.color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
-                          ))}
-                        </Bar>
-                      ))}
-                      {nwDetailAssets.length > COMPOSITION_TOP_N && (
-                        <Bar key="asset_others" dataKey="asset_others" stackId="stack" fill="#6B7280" maxBarSize={32} radius={nwDetailLiabs.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]} onClick={handleDetailedBarClick}>
-                          {netWorthDetailedData.map((_: unknown, i: number) => (
-                            <Cell key={i} fill="#6B7280" opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
-                          ))}
-                        </Bar>
-                      )}
-                      {nwBarsLiabs.map((item: ReportCompositionItem, idx: number) => (
-                        <Bar key={`liab_${item.key}`} dataKey={`liab_${item.key}`} stackId="stack" fill={item.color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
-                          {netWorthDetailedData.map((_: unknown, i: number) => (
-                            <Cell key={i} fill={item.color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
-                          ))}
-                        </Bar>
-                      ))}
-                      {nwDetailLiabs.length > COMPOSITION_TOP_N && (
-                        <Bar key="liab_others" dataKey="liab_others" stackId="stack" fill="#6B7280" maxBarSize={32} radius={[4, 4, 0, 0]} onClick={handleDetailedBarClick}>
-                          {netWorthDetailedData.map((_: unknown, i: number) => (
-                            <Cell key={i} fill="#6B7280" opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
-                          ))}
-                        </Bar>
-                      )}
+                      {nwBarsAccounts.map((item: ReportCompositionItem, idx: number) => {
+                        const color = accountsGradient[idx] ?? accountsGradient[accountsGradient.length - 1]
+                        return (
+                          <Bar key={`acct_${item.key}`} dataKey={`acct_${item.key}`} stackId="stack" fill={color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                            {netWorthDetailedData.map((_: unknown, i: number) => (
+                              <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                            ))}
+                          </Bar>
+                        )
+                      })}
+                      {nwDetailAccounts.length > COMPOSITION_TOP_N && (() => {
+                        const color = accountsGradient[accountsGradient.length - 1] ?? '#6B7280'
+                        return (
+                          <Bar key="acct_others" dataKey="acct_others" stackId="stack" fill={color} maxBarSize={32} radius={nwBarsAssets.length === 0 && nwDetailLiabs.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                            {netWorthDetailedData.map((_: unknown, i: number) => (
+                              <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                            ))}
+                          </Bar>
+                        )
+                      })()}
+                      {nwBarsAssets.map((item: ReportCompositionItem, idx: number) => {
+                        const color = assetsGradient[idx] ?? assetsGradient[assetsGradient.length - 1]
+                        return (
+                          <Bar key={`asset_${item.key}`} dataKey={`asset_${item.key}`} stackId="stack" fill={color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                            {netWorthDetailedData.map((_: unknown, i: number) => (
+                              <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                            ))}
+                          </Bar>
+                        )
+                      })}
+                      {nwDetailAssets.length > COMPOSITION_TOP_N && (() => {
+                        const color = assetsGradient[assetsGradient.length - 1] ?? '#6B7280'
+                        return (
+                          <Bar key="asset_others" dataKey="asset_others" stackId="stack" fill={color} maxBarSize={32} radius={nwDetailLiabs.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                            {netWorthDetailedData.map((_: unknown, i: number) => (
+                              <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                            ))}
+                          </Bar>
+                        )
+                      })()}
+                      {nwBarsLiabs.map((item: ReportCompositionItem, idx: number) => {
+                        const color = liabsGradient[idx] ?? liabsGradient[liabsGradient.length - 1]
+                        return (
+                          <Bar key={`liab_${item.key}`} dataKey={`liab_${item.key}`} stackId="stack" fill={color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                            {netWorthDetailedData.map((_: unknown, i: number) => (
+                              <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                            ))}
+                          </Bar>
+                        )
+                      })}
+                      {nwDetailLiabs.length > COMPOSITION_TOP_N && (() => {
+                        const color = liabsGradient[liabsGradient.length - 1] ?? '#6B7280'
+                        return (
+                          <Bar key="liab_others" dataKey="liab_others" stackId="stack" fill={color} maxBarSize={32} radius={[4, 4, 0, 0]} onClick={handleDetailedBarClick}>
+                            {netWorthDetailedData.map((_: unknown, i: number) => (
+                              <Cell key={i} fill={color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                            ))}
+                          </Bar>
+                        )
+                      })()}
                       <Line
                         type="monotone"
                         dataKey="value"

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -38,7 +38,7 @@ function formatCompact(value: number, currency = 'USD', locale = 'en-US') {
   }).format(value)
 }
 
-const COMPOSITION_TOP_N = 6
+const COMPOSITION_TOP_N = 10
 
 type RangeOption = { key: string; months: number }
 
@@ -201,6 +201,9 @@ export default function ReportsPage() {
   const nwDetailTotalAccounts = nwDetailAccounts.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
   const nwDetailTotalAssets = nwDetailAssets.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
   const nwDetailTotalLiabs = nwDetailLiabs.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
+  const nwBarsAccounts = nwDetailAccounts.slice(0, COMPOSITION_TOP_N)
+  const nwBarsAssets = nwDetailAssets.slice(0, COMPOSITION_TOP_N)
+  const nwBarsLiabs = nwDetailLiabs.slice(0, COMPOSITION_TOP_N)
 
   const lastNWIndex = netWorthSummaryData.length - 1
   const isCurrentNW = selectedNWBar == null || selectedNWBar.index === lastNWIndex
@@ -224,7 +227,7 @@ export default function ReportsPage() {
     const items = isAccounts ? nwDetailAccounts : nwDetailAssets
     const total = isAccounts ? nwDetailTotalAccounts : nwDetailTotalAssets
     const selected = isAccounts ? selectedAccounts : selectedAssets
-    return items
+    const sorted = items
       .map((item: ReportCompositionItem) => ({
         name: item.label,
         value: total > 0 ? (item.value / total) * selected : 0,
@@ -232,6 +235,10 @@ export default function ReportsPage() {
       }))
       .filter((d) => d.value > 0)
       .sort((a, b) => b.value - a.value)
+    const top = sorted.slice(0, COMPOSITION_TOP_N)
+    const otherValue = sorted.slice(COMPOSITION_TOP_N).reduce((s, d) => s + d.value, 0)
+    if (otherValue > 0) top.push({ name: t('reports.other'), value: otherValue, color: '#6B7280' })
+    return top
   })
 
   // Inner ring: liabilities group total
@@ -240,11 +247,17 @@ export default function ReportsPage() {
   ].filter((d) => d.value > 0)
 
   // Outer ring: individual liability items, proportionally scaled
-  const nwPieBOuter: NWPieItem[] = nwDetailLiabs.map((item: ReportCompositionItem) => ({
+  const nwPieBOuterSorted: NWPieItem[] = nwDetailLiabs.map((item: ReportCompositionItem) => ({
     name: item.label,
     value: nwDetailTotalLiabs > 0 ? (item.value / nwDetailTotalLiabs) * selectedLiabs : 0,
     color: item.color,
   })).filter((d: NWPieItem) => d.value > 0).sort((a: NWPieItem, b: NWPieItem) => b.value - a.value)
+  const nwPieBOuter: NWPieItem[] = (() => {
+    const top = nwPieBOuterSorted.slice(0, COMPOSITION_TOP_N)
+    const otherValue = nwPieBOuterSorted.slice(COMPOSITION_TOP_N).reduce((s, d) => s + d.value, 0)
+    if (otherValue > 0) top.push({ name: t('reports.other'), value: otherValue, color: '#6B7280' })
+    return top
+  })()
 
   type NWBarState = { accounts: number; assets: number; liabilities: number; value: number; date: string; index: number } | null
 
@@ -268,9 +281,9 @@ export default function ReportsPage() {
     if (!row) return
     setSelectedNWBar((prev: NWBarState) => {
       if (prev?.index === index) return null
-      const accounts = nwDetailAccounts.reduce((s: number, it: ReportCompositionItem) => s + ((row[`acct_${it.key}`] as number) ?? 0), 0)
-      const assets = nwDetailAssets.reduce((s: number, it: ReportCompositionItem) => s + ((row[`asset_${it.key}`] as number) ?? 0), 0)
-      const liabilities = Math.abs(nwDetailLiabs.reduce((s: number, it: ReportCompositionItem) => s + ((row[`liab_${it.key}`] as number) ?? 0), 0))
+      const accounts = nwBarsAccounts.reduce((s: number, it: ReportCompositionItem) => s + ((row[`acct_${it.key}`] as number) ?? 0), 0) + ((row['acct_others'] as number) ?? 0)
+      const assets = nwBarsAssets.reduce((s: number, it: ReportCompositionItem) => s + ((row[`asset_${it.key}`] as number) ?? 0), 0) + ((row['asset_others'] as number) ?? 0)
+      const liabilities = Math.abs(nwBarsLiabs.reduce((s: number, it: ReportCompositionItem) => s + ((row[`liab_${it.key}`] as number) ?? 0), 0) + ((row['liab_others'] as number) ?? 0))
       return { accounts, assets, liabilities, value: (row.value as number) ?? 0, date: row.date as string, index }
     })
   }
@@ -280,18 +293,30 @@ export default function ReportsPage() {
     const sTotal = (d.assets as number) ?? 0
     const lTotal = (d.liabilities as number) ?? 0
     const row: Record<string, string | number> = { date: d.date as string, value: d.value as number }
-    nwDetailAccounts.forEach((item) => {
+    nwBarsAccounts.forEach((item) => {
       const p = nwDetailTotalAccounts > 0 ? item.value / nwDetailTotalAccounts : 0
       row[`acct_${item.key}`] = Math.round(aTotal * p * 100) / 100
     })
-    nwDetailAssets.forEach((item) => {
+    if (nwDetailAccounts.length > COMPOSITION_TOP_N) {
+      const topSum = nwBarsAccounts.reduce((s, item) => s + Math.round(aTotal * (nwDetailTotalAccounts > 0 ? item.value / nwDetailTotalAccounts : 0) * 100) / 100, 0)
+      row['acct_others'] = Math.round((aTotal - topSum) * 100) / 100
+    }
+    nwBarsAssets.forEach((item) => {
       const p = nwDetailTotalAssets > 0 ? item.value / nwDetailTotalAssets : 0
       row[`asset_${item.key}`] = Math.round(sTotal * p * 100) / 100
     })
-    nwDetailLiabs.forEach((item) => {
+    if (nwDetailAssets.length > COMPOSITION_TOP_N) {
+      const topSum = nwBarsAssets.reduce((s, item) => s + Math.round(sTotal * (nwDetailTotalAssets > 0 ? item.value / nwDetailTotalAssets : 0) * 100) / 100, 0)
+      row['asset_others'] = Math.round((sTotal - topSum) * 100) / 100
+    }
+    nwBarsLiabs.forEach((item) => {
       const p = nwDetailTotalLiabs > 0 ? item.value / nwDetailTotalLiabs : 0
       row[`liab_${item.key}`] = -Math.round(lTotal * p * 100) / 100
     })
+    if (nwDetailLiabs.length > COMPOSITION_TOP_N) {
+      const topSum = nwBarsLiabs.reduce((s, item) => s + Math.round(lTotal * (nwDetailTotalLiabs > 0 ? item.value / nwDetailTotalLiabs : 0) * 100) / 100, 0)
+      row['liab_others'] = -Math.round((lTotal - topSum) * 100) / 100
+    }
     return row
   })
 
@@ -1033,8 +1058,11 @@ export default function ReportsPage() {
                       <Tooltip
                         content={({ active, payload, label }: { active?: boolean; payload?: { dataKey?: string | number; value?: number; color?: string }[]; label?: string }) => {
                           if (!active || !payload) return null
-                          const findLabel = (dk: string) =>
-                            composition.find((c: ReportCompositionItem) => c.key === dk.replace(/^(acct_|asset_|liab_)/, ''))?.label ?? dk
+                          const findLabel = (dk: string) => {
+                            if (dk.endsWith('_others')) return t('reports.other')
+                            const label = composition.find((c: ReportCompositionItem) => c.key === dk.replace(/^(acct_|asset_|liab_)/, ''))?.label ?? dk
+                            return label.length > 40 ? label.slice(0, 40) + '…' : label
+                          }
                           const acctEntries = payload.filter((p) => String(p.dataKey).startsWith('acct_') && (p.value ?? 0) !== 0).sort((a, b) => Math.abs(b.value ?? 0) - Math.abs(a.value ?? 0))
                           const assetEntries = payload.filter((p) => String(p.dataKey).startsWith('asset_') && (p.value ?? 0) !== 0).sort((a, b) => Math.abs(b.value ?? 0) - Math.abs(a.value ?? 0))
                           const liabEntries = payload.filter((p) => String(p.dataKey).startsWith('liab_') && (p.value ?? 0) !== 0).sort((a, b) => Math.abs(b.value ?? 0) - Math.abs(a.value ?? 0))
@@ -1083,51 +1111,48 @@ export default function ReportsPage() {
                         }}
                       />
                       <ReferenceLine y={0} stroke="var(--border)" strokeDasharray="3 3" />
-                      {nwDetailAccounts.map((item: ReportCompositionItem, idx: number) => (
-                        <Bar
-                          key={`acct_${item.key}`}
-                          dataKey={`acct_${item.key}`}
-                          stackId="stack"
-                          fill={item.color}
-                          maxBarSize={32}
-                          radius={idx === nwDetailAccounts.length - 1 && nwDetailAssets.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
-                          onClick={handleDetailedBarClick}
-                        >
+                      {nwBarsAccounts.map((item: ReportCompositionItem, idx: number) => (
+                        <Bar key={`acct_${item.key}`} dataKey={`acct_${item.key}`} stackId="stack" fill={item.color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
                           {netWorthDetailedData.map((_: unknown, i: number) => (
                             <Cell key={i} fill={item.color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                           ))}
                         </Bar>
                       ))}
-                      {nwDetailAssets.map((item: ReportCompositionItem, idx: number) => (
-                        <Bar
-                          key={`asset_${item.key}`}
-                          dataKey={`asset_${item.key}`}
-                          stackId="stack"
-                          fill={item.color}
-                          maxBarSize={32}
-                          radius={idx === nwDetailAssets.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
-                          onClick={handleDetailedBarClick}
-                        >
+                      {nwDetailAccounts.length > COMPOSITION_TOP_N && (
+                        <Bar key="acct_others" dataKey="acct_others" stackId="stack" fill="#6B7280" maxBarSize={32} radius={nwBarsAssets.length === 0 && nwDetailLiabs.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                          {netWorthDetailedData.map((_: unknown, i: number) => (
+                            <Cell key={i} fill="#6B7280" opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                          ))}
+                        </Bar>
+                      )}
+                      {nwBarsAssets.map((item: ReportCompositionItem, idx: number) => (
+                        <Bar key={`asset_${item.key}`} dataKey={`asset_${item.key}`} stackId="stack" fill={item.color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
                           {netWorthDetailedData.map((_: unknown, i: number) => (
                             <Cell key={i} fill={item.color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                           ))}
                         </Bar>
                       ))}
-                      {nwDetailLiabs.map((item: ReportCompositionItem, idx: number) => (
-                        <Bar
-                          key={`liab_${item.key}`}
-                          dataKey={`liab_${item.key}`}
-                          stackId="stack"
-                          fill={item.color}
-                          maxBarSize={32}
-                          radius={idx === nwDetailLiabs.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
-                          onClick={handleDetailedBarClick}
-                        >
+                      {nwDetailAssets.length > COMPOSITION_TOP_N && (
+                        <Bar key="asset_others" dataKey="asset_others" stackId="stack" fill="#6B7280" maxBarSize={32} radius={nwDetailLiabs.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]} onClick={handleDetailedBarClick}>
+                          {netWorthDetailedData.map((_: unknown, i: number) => (
+                            <Cell key={i} fill="#6B7280" opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                          ))}
+                        </Bar>
+                      )}
+                      {nwBarsLiabs.map((item: ReportCompositionItem, idx: number) => (
+                        <Bar key={`liab_${item.key}`} dataKey={`liab_${item.key}`} stackId="stack" fill={item.color} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleDetailedBarClick}>
                           {netWorthDetailedData.map((_: unknown, i: number) => (
                             <Cell key={i} fill={item.color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
                           ))}
                         </Bar>
                       ))}
+                      {nwDetailLiabs.length > COMPOSITION_TOP_N && (
+                        <Bar key="liab_others" dataKey="liab_others" stackId="stack" fill="#6B7280" maxBarSize={32} radius={[4, 4, 0, 0]} onClick={handleDetailedBarClick}>
+                          {netWorthDetailedData.map((_: unknown, i: number) => (
+                            <Cell key={i} fill="#6B7280" opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                          ))}
+                        </Bar>
+                      )}
                       <Line
                         type="monotone"
                         dataKey="value"

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -210,7 +210,7 @@ export default function ReportsPage() {
   const netWorthSummaryData = chartData.map((d) => ({
     ...d,
     liabilitiesNeg: -((d.liabilities as number) ?? 0),
-  }))
+  })) as (Record<string, string | number> & { liabilitiesNeg: number })[]
 
   const nwTrendData = chartData.map((d, i) => {
     const current = d.value as number
@@ -222,7 +222,7 @@ export default function ReportsPage() {
       _deltaSize: i > 0 ? Math.abs(delta) : 0,
       _delta: delta,
     }
-  })
+  }) as (Record<string, string | number> & { _deltaBase: number; _deltaSize: number; _delta: number })[]
 
   const changePrefix = (summary?.change_amount ?? 0) >= 0 ? '+' : ''
   const changeColor = (summary?.change_amount ?? 0) >= 0 ? 'text-emerald-600' : 'text-rose-500'
@@ -1135,7 +1135,7 @@ export default function ReportsPage() {
                         tickCount={5}
                       />
                       <Tooltip
-                        content={({ active, payload, label }: { active?: boolean; payload?: { dataKey?: string | number; value?: number; color?: string }[]; label?: string }) => {
+                        content={({ active, payload, label }: { active?: boolean; payload?: readonly { dataKey?: string | number; value?: number; color?: string }[]; label?: string | number }) => {
                           if (!active || !payload) return null
                           const findLabel = (dk: string) => {
                             if (dk.endsWith('_others')) return t('reports.other')

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
 import {
@@ -194,36 +194,42 @@ export default function ReportsPage() {
   const trend = data?.trend ?? []
   const meta = data?.meta
 
-  const chartData = trend.map((dp) => ({
-    date: dp.date,
-    value: dp.value,
-    ...dp.breakdowns,
-  } as Record<string, string | number>))
+  const chartData = useMemo(
+    () => trend.map((dp) => ({ date: dp.date, value: dp.value, ...dp.breakdowns } as Record<string, string | number>)),
+    [trend]
+  )
 
   const allBreakdowns = summary?.breakdowns ?? []
-  const breakdownData = allBreakdowns.filter((b) => b.value > 0)
+  const breakdownData = useMemo(() => allBreakdowns.filter((b) => b.value > 0), [allBreakdowns])
 
-  const colorMap: Record<string, string> = {}
-  for (const b of allBreakdowns) {
-    colorMap[b.key] = b.color
-  }
+  const colorMap = useMemo(() => {
+    const map: Record<string, string> = {}
+    for (const b of allBreakdowns) map[b.key] = b.color
+    return map
+  }, [allBreakdowns])
 
-  const netWorthSummaryData = chartData.map((d) => ({
-    ...d,
-    liabilitiesNeg: -((d.liabilities as number) ?? 0),
-  })) as (Record<string, string | number> & { liabilitiesNeg: number })[]
-
-  const nwTrendData = chartData.map((d, i) => {
-    const current = d.value as number
-    const prev = i > 0 ? (chartData[i - 1].value as number) : current
-    const delta = current - prev
-    return {
+  const netWorthSummaryData = useMemo(
+    () => chartData.map((d) => ({
       ...d,
-      _deltaBase: i > 0 ? Math.min(prev, current) : current,
-      _deltaSize: i > 0 ? Math.abs(delta) : 0,
-      _delta: delta,
-    }
-  }) as (Record<string, string | number> & { _deltaBase: number; _deltaSize: number; _delta: number })[]
+      liabilitiesNeg: -((d.liabilities as number) ?? 0),
+    })) as (Record<string, string | number> & { liabilitiesNeg: number })[],
+    [chartData]
+  )
+
+  const nwTrendData = useMemo(
+    () => chartData.map((d, i) => {
+      const current = d.value as number
+      const prev = i > 0 ? (chartData[i - 1].value as number) : current
+      const delta = current - prev
+      return {
+        ...d,
+        _deltaBase: i > 0 ? Math.min(prev, current) : current,
+        _deltaSize: i > 0 ? Math.abs(delta) : 0,
+        _delta: delta,
+      }
+    }) as (Record<string, string | number> & { _deltaBase: number; _deltaSize: number; _delta: number })[],
+    [chartData]
+  )
 
   const changePrefix = (summary?.change_amount ?? 0) >= 0 ? '+' : ''
   const changeColor = (summary?.change_amount ?? 0) >= 0 ? 'text-emerald-600' : 'text-rose-500'
@@ -244,22 +250,70 @@ export default function ReportsPage() {
     ? ['summary', 'byIncome', 'byExpenses'] as const
     : ['summary', 'detailed'] as const
 
-  // Build donut data based on composition view
   const composition = data?.composition ?? []
 
-  const nwDetailAccounts = composition.filter((c: ReportCompositionItem) => c.group === 'accounts').sort((a, b) => b.value - a.value)
-  const nwDetailAssets = composition.filter((c: ReportCompositionItem) => c.group === 'assets').sort((a, b) => b.value - a.value)
-  const nwDetailLiabs = composition.filter((c: ReportCompositionItem) => c.group === 'liabilities').sort((a, b) => b.value - a.value)
-  const nwDetailTotalAccounts = nwDetailAccounts.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
-  const nwDetailTotalAssets = nwDetailAssets.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
-  const nwDetailTotalLiabs = nwDetailLiabs.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
-  const nwBarsAccounts = nwDetailAccounts.filter((c: ReportCompositionItem) => nwDetailTotalAccounts > 0 && c.value / nwDetailTotalAccounts >= COMPOSITION_MIN_PCT)
-  const nwBarsAssets = nwDetailAssets.filter((c: ReportCompositionItem) => nwDetailTotalAssets > 0 && c.value / nwDetailTotalAssets >= COMPOSITION_MIN_PCT)
-  const nwBarsLiabs = nwDetailLiabs.filter((c: ReportCompositionItem) => nwDetailTotalLiabs > 0 && c.value / nwDetailTotalLiabs >= COMPOSITION_MIN_PCT)
+  // All composition-derived values — only recompute when composition or colorMap changes
+  const {
+    nwDetailAccounts, nwDetailAssets, nwDetailLiabs,
+    nwDetailTotalAccounts, nwDetailTotalAssets, nwDetailTotalLiabs,
+    nwBarsAccounts, nwBarsAssets, nwBarsLiabs,
+    accountsGradient, assetsGradient, liabsGradient,
+  } = useMemo(() => {
+    const nwDetailAccounts = composition.filter((c: ReportCompositionItem) => c.group === 'accounts').sort((a, b) => b.value - a.value)
+    const nwDetailAssets = composition.filter((c: ReportCompositionItem) => c.group === 'assets').sort((a, b) => b.value - a.value)
+    const nwDetailLiabs = composition.filter((c: ReportCompositionItem) => c.group === 'liabilities').sort((a, b) => b.value - a.value)
+    const nwDetailTotalAccounts = nwDetailAccounts.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
+    const nwDetailTotalAssets = nwDetailAssets.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
+    const nwDetailTotalLiabs = nwDetailLiabs.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
+    const nwBarsAccounts = nwDetailAccounts.filter((c: ReportCompositionItem) => nwDetailTotalAccounts > 0 && c.value / nwDetailTotalAccounts >= COMPOSITION_MIN_PCT)
+    const nwBarsAssets = nwDetailAssets.filter((c: ReportCompositionItem) => nwDetailTotalAssets > 0 && c.value / nwDetailTotalAssets >= COMPOSITION_MIN_PCT)
+    const nwBarsLiabs = nwDetailLiabs.filter((c: ReportCompositionItem) => nwDetailTotalLiabs > 0 && c.value / nwDetailTotalLiabs >= COMPOSITION_MIN_PCT)
+    const accountsGradient = buildGroupGradient(colorMap['accounts'] || '#6366F1', Math.max(1, nwBarsAccounts.length))
+    const assetsGradient = buildGroupGradient(colorMap['assets'] || '#F59E0B', Math.max(1, nwBarsAssets.length))
+    const liabsGradient = buildGroupGradient(colorMap['liabilities'] || '#F43F5E', Math.max(1, nwBarsLiabs.length))
+    return {
+      nwDetailAccounts, nwDetailAssets, nwDetailLiabs,
+      nwDetailTotalAccounts, nwDetailTotalAssets, nwDetailTotalLiabs,
+      nwBarsAccounts, nwBarsAssets, nwBarsLiabs,
+      accountsGradient, assetsGradient, liabsGradient,
+    }
+  }, [composition, colorMap])
 
-  const accountsGradient = buildGroupGradient(colorMap['accounts'] || '#6366F1', Math.max(1, nwBarsAccounts.length))
-  const assetsGradient = buildGroupGradient(colorMap['assets'] || '#F59E0B', Math.max(1, nwBarsAssets.length))
-  const liabsGradient = buildGroupGradient(colorMap['liabilities'] || '#F43F5E', Math.max(1, nwBarsLiabs.length))
+  // Detailed chart data — O(points × accounts), does NOT depend on selectedNWBar
+  const netWorthDetailedData = useMemo(
+    (): Record<string, string | number>[] => meta?.type !== 'net_worth' ? [] : chartData.map((d: Record<string, string | number>) => {
+      const aTotal = (d.accounts as number) ?? 0
+      const sTotal = (d.assets as number) ?? 0
+      const lTotal = (d.liabilities as number) ?? 0
+      const row: Record<string, string | number> = { date: d.date as string, value: d.value as number }
+      nwBarsAccounts.forEach((item) => {
+        const p = nwDetailTotalAccounts > 0 ? item.value / nwDetailTotalAccounts : 0
+        row[`acct_${item.key}`] = Math.round(aTotal * p * 100) / 100
+      })
+      if (nwDetailAccounts.length > nwBarsAccounts.length) {
+        const topSum = nwBarsAccounts.reduce((s, item) => s + Math.round(aTotal * (nwDetailTotalAccounts > 0 ? item.value / nwDetailTotalAccounts : 0) * 100) / 100, 0)
+        row['acct_others'] = Math.round((aTotal - topSum) * 100) / 100
+      }
+      nwBarsAssets.forEach((item) => {
+        const p = nwDetailTotalAssets > 0 ? item.value / nwDetailTotalAssets : 0
+        row[`asset_${item.key}`] = Math.round(sTotal * p * 100) / 100
+      })
+      if (nwDetailAssets.length > nwBarsAssets.length) {
+        const topSum = nwBarsAssets.reduce((s, item) => s + Math.round(sTotal * (nwDetailTotalAssets > 0 ? item.value / nwDetailTotalAssets : 0) * 100) / 100, 0)
+        row['asset_others'] = Math.round((sTotal - topSum) * 100) / 100
+      }
+      nwBarsLiabs.forEach((item) => {
+        const p = nwDetailTotalLiabs > 0 ? item.value / nwDetailTotalLiabs : 0
+        row[`liab_${item.key}`] = -Math.round(lTotal * p * 100) / 100
+      })
+      if (nwDetailLiabs.length > nwBarsLiabs.length) {
+        const topSum = nwBarsLiabs.reduce((s, item) => s + Math.round(lTotal * (nwDetailTotalLiabs > 0 ? item.value / nwDetailTotalLiabs : 0) * 100) / 100, 0)
+        row['liab_others'] = -Math.round((lTotal - topSum) * 100) / 100
+      }
+      return row
+    }),
+    [chartData, meta?.type, nwBarsAccounts, nwBarsAssets, nwBarsLiabs, nwDetailAccounts, nwDetailAssets, nwDetailLiabs, nwDetailTotalAccounts, nwDetailTotalAssets, nwDetailTotalLiabs]
+  )
 
   const lastNWIndex = netWorthSummaryData.length - 1
   const isCurrentNW = selectedNWBar == null || selectedNWBar.index === lastNWIndex
@@ -270,58 +324,56 @@ export default function ReportsPage() {
   const selectedLiabs = selectedNWBar ? selectedNWBar.liabilities : nwDetailTotalLiabs
 
   type NWPieItem = { name: string; value: number; color: string }
+  type NWBarState = { accounts: number; assets: number; liabilities: number; value: number; date: string; index: number } | null
 
-  // Inner ring: group-level totals for Accounts + Assets chart
-  const nwPieAInner: NWPieItem[] = [
-    { name: t('reports.accounts'), value: selectedAccounts, color: colorMap['accounts'] || '#6366F1' },
-    { name: t('reports.assets'), value: selectedAssets, color: colorMap['assets'] || '#F59E0B' },
-  ].filter((d) => d.value > 0).sort((a, b) => b.value - a.value)
+  // Pie data — only recomputes when selected period or composition changes
+  const { nwPieAInner, nwPieAOuter, nwPieBInner, nwPieBOuter } = useMemo(() => {
+    const nwPieAInner: NWPieItem[] = [
+      { name: t('reports.accounts'), value: selectedAccounts, color: colorMap['accounts'] || '#6366F1' },
+      { name: t('reports.assets'), value: selectedAssets, color: colorMap['assets'] || '#F59E0B' },
+    ].filter((d) => d.value > 0).sort((a, b) => b.value - a.value)
 
-  // Outer ring: items grouped to match inner ring order, sorted by value within each group
-  const nwPieAOuter: NWPieItem[] = nwPieAInner.flatMap((group) => {
-    const isAccounts = group.name === t('reports.accounts')
-    const items = isAccounts ? nwDetailAccounts : nwDetailAssets
-    const gradient = isAccounts ? accountsGradient : assetsGradient
-    const total = isAccounts ? nwDetailTotalAccounts : nwDetailTotalAssets
-    const selected = isAccounts ? selectedAccounts : selectedAssets
-    const sorted = items
+    const nwPieAOuter: NWPieItem[] = nwPieAInner.flatMap((group) => {
+      const isAccounts = group.name === t('reports.accounts')
+      const items = isAccounts ? nwDetailAccounts : nwDetailAssets
+      const gradient = isAccounts ? accountsGradient : assetsGradient
+      const total = isAccounts ? nwDetailTotalAccounts : nwDetailTotalAssets
+      const selected = isAccounts ? selectedAccounts : selectedAssets
+      const sorted = items
+        .map((item: ReportCompositionItem) => ({
+          name: item.label,
+          value: total > 0 ? (item.value / total) * selected : 0,
+        }))
+        .filter((d) => d.value > 0)
+        .sort((a, b) => b.value - a.value)
+        .map((d, i) => ({ ...d, color: gradient[i] ?? gradient[gradient.length - 1] ?? '#6B7280' }))
+      const top = sorted.filter((d) => selected > 0 && d.value / selected >= COMPOSITION_MIN_PCT)
+      const otherValue = sorted.filter((d) => selected <= 0 || d.value / selected < COMPOSITION_MIN_PCT).reduce((s, d) => s + d.value, 0)
+      if (otherValue > 0) top.push({ name: t('reports.other'), value: otherValue, color: gradient[gradient.length - 1] ?? '#6B7280' })
+      return top
+    })
+
+    const nwPieBInner: NWPieItem[] = [
+      { name: t('reports.liabilities'), value: selectedLiabs, color: colorMap['liabilities'] || '#F43F5E' },
+    ].filter((d) => d.value > 0)
+
+    const sorted: NWPieItem[] = nwDetailLiabs
       .map((item: ReportCompositionItem) => ({
         name: item.label,
-        value: total > 0 ? (item.value / total) * selected : 0,
+        value: nwDetailTotalLiabs > 0 ? (item.value / nwDetailTotalLiabs) * selectedLiabs : 0,
       }))
       .filter((d) => d.value > 0)
       .sort((a, b) => b.value - a.value)
-      .map((d, i) => ({ ...d, color: gradient[i] ?? gradient[gradient.length - 1] ?? '#6B7280' }))
-    const top = sorted.filter((d) => selected > 0 && d.value / selected >= COMPOSITION_MIN_PCT)
-    const otherValue = sorted.filter((d) => selected <= 0 || d.value / selected < COMPOSITION_MIN_PCT).reduce((s, d) => s + d.value, 0)
-    if (otherValue > 0) top.push({ name: t('reports.other'), value: otherValue, color: gradient[gradient.length - 1] ?? '#6B7280' })
-    return top
-  })
-
-  // Inner ring: liabilities group total
-  const nwPieBInner: NWPieItem[] = [
-    { name: t('reports.liabilities'), value: selectedLiabs, color: colorMap['liabilities'] || '#F43F5E' },
-  ].filter((d) => d.value > 0)
-
-  // Outer ring: individual liability items, proportionally scaled
-  const nwPieBOuterSorted: NWPieItem[] = nwDetailLiabs
-    .map((item: ReportCompositionItem) => ({
-      name: item.label,
-      value: nwDetailTotalLiabs > 0 ? (item.value / nwDetailTotalLiabs) * selectedLiabs : 0,
-    }))
-    .filter((d) => d.value > 0)
-    .sort((a, b) => b.value - a.value)
-    .map((d, i) => ({ ...d, color: liabsGradient[i] ?? liabsGradient[liabsGradient.length - 1] ?? '#6B7280' }))
-  const nwPieBOuter: NWPieItem[] = (() => {
-    const top = nwPieBOuterSorted.filter((d) => selectedLiabs > 0 && d.value / selectedLiabs >= COMPOSITION_MIN_PCT)
-    const otherValue = nwPieBOuterSorted.filter((d) => selectedLiabs <= 0 || d.value / selectedLiabs < COMPOSITION_MIN_PCT).reduce((s, d) => s + d.value, 0)
+      .map((d, i) => ({ ...d, color: liabsGradient[i] ?? liabsGradient[liabsGradient.length - 1] ?? '#6B7280' }))
+    const top = sorted.filter((d) => selectedLiabs > 0 && d.value / selectedLiabs >= COMPOSITION_MIN_PCT)
+    const otherValue = sorted.filter((d) => selectedLiabs <= 0 || d.value / selectedLiabs < COMPOSITION_MIN_PCT).reduce((s, d) => s + d.value, 0)
     if (otherValue > 0) top.push({ name: t('reports.other'), value: otherValue, color: liabsGradient[liabsGradient.length - 1] ?? '#6B7280' })
-    return top
-  })()
+    const nwPieBOuter = top
 
-  type NWBarState = { accounts: number; assets: number; liabilities: number; value: number; date: string; index: number } | null
+    return { nwPieAInner, nwPieAOuter, nwPieBInner, nwPieBOuter }
+  }, [selectedAccounts, selectedAssets, selectedLiabs, nwDetailAccounts, nwDetailAssets, nwDetailLiabs, nwDetailTotalAccounts, nwDetailTotalAssets, nwDetailTotalLiabs, accountsGradient, assetsGradient, liabsGradient, colorMap, t])
 
-  const handleSummaryBarClick = (_data: unknown, index: number) => {
+  const handleSummaryBarClick = useCallback((_data: unknown, index: number) => {
     const row = netWorthSummaryData[index]
     if (!row) return
     setSelectedNWBar((prev: NWBarState) =>
@@ -334,9 +386,9 @@ export default function ReportsPage() {
         index,
       }
     )
-  }
+  }, [netWorthSummaryData])
 
-  const handleDetailedBarClick = (_data: unknown, index: number) => {
+  const handleDetailedBarClick = useCallback((_data: unknown, index: number) => {
     const row = netWorthDetailedData[index]
     if (!row) return
     setSelectedNWBar((prev: NWBarState) => {
@@ -346,41 +398,9 @@ export default function ReportsPage() {
       const liabilities = Math.abs(nwBarsLiabs.reduce((s: number, it: ReportCompositionItem) => s + ((row[`liab_${it.key}`] as number) ?? 0), 0) + ((row['liab_others'] as number) ?? 0))
       return { accounts, assets, liabilities, value: (row.value as number) ?? 0, date: row.date as string, index }
     })
-  }
+  }, [netWorthDetailedData, nwBarsAccounts, nwBarsAssets, nwBarsLiabs])
 
-  const netWorthDetailedData: Record<string, string | number>[] = meta?.type !== 'net_worth' ? [] : chartData.map((d: Record<string, string | number>) => {
-    const aTotal = (d.accounts as number) ?? 0
-    const sTotal = (d.assets as number) ?? 0
-    const lTotal = (d.liabilities as number) ?? 0
-    const row: Record<string, string | number> = { date: d.date as string, value: d.value as number }
-    nwBarsAccounts.forEach((item) => {
-      const p = nwDetailTotalAccounts > 0 ? item.value / nwDetailTotalAccounts : 0
-      row[`acct_${item.key}`] = Math.round(aTotal * p * 100) / 100
-    })
-    if (nwDetailAccounts.length > nwBarsAccounts.length) {
-      const topSum = nwBarsAccounts.reduce((s, item) => s + Math.round(aTotal * (nwDetailTotalAccounts > 0 ? item.value / nwDetailTotalAccounts : 0) * 100) / 100, 0)
-      row['acct_others'] = Math.round((aTotal - topSum) * 100) / 100
-    }
-    nwBarsAssets.forEach((item) => {
-      const p = nwDetailTotalAssets > 0 ? item.value / nwDetailTotalAssets : 0
-      row[`asset_${item.key}`] = Math.round(sTotal * p * 100) / 100
-    })
-    if (nwDetailAssets.length > nwBarsAssets.length) {
-      const topSum = nwBarsAssets.reduce((s, item) => s + Math.round(sTotal * (nwDetailTotalAssets > 0 ? item.value / nwDetailTotalAssets : 0) * 100) / 100, 0)
-      row['asset_others'] = Math.round((sTotal - topSum) * 100) / 100
-    }
-    nwBarsLiabs.forEach((item) => {
-      const p = nwDetailTotalLiabs > 0 ? item.value / nwDetailTotalLiabs : 0
-      row[`liab_${item.key}`] = -Math.round(lTotal * p * 100) / 100
-    })
-    if (nwDetailLiabs.length > nwBarsLiabs.length) {
-      const topSum = nwBarsLiabs.reduce((s, item) => s + Math.round(lTotal * (nwDetailTotalLiabs > 0 ? item.value / nwDetailTotalLiabs : 0) * 100) / 100, 0)
-      row['liab_others'] = -Math.round((lTotal - topSum) * 100) / 100
-    }
-    return row
-  })
-
-  const donutData = (() => {
+  const donutData = useMemo(() => {
     if (compositionView === 'summary' || composition.length === 0) {
       const excludedKeys = new Set(['netIncome', 'startingBalance', 'endingBalance'])
       return breakdownData
@@ -399,7 +419,6 @@ export default function ReportsPage() {
       items = composition.filter((c) => c.group === 'expenses')
     }
 
-    // Sort descending, group items below threshold into "Other"
     const sorted = [...items].sort((a, b) => b.value - a.value)
     const donutTotal = sorted.reduce((sum, c) => sum + c.value, 0)
     const top = sorted.filter((c) => donutTotal > 0 && c.value / donutTotal >= COMPOSITION_MIN_PCT)
@@ -415,7 +434,7 @@ export default function ReportsPage() {
       result.push({ name: t('reports.other'), value: Math.round(otherValue * 100) / 100, color: '#6B7280' })
     }
     return result
-  })()
+  }, [compositionView, composition, breakdownData, t])
 
   return (
     <div>

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -194,11 +194,43 @@ export default function ReportsPage() {
   const isCurrentNW = selectedNWBar == null || selectedNWBar.index === lastNWIndex
   const nwPeriodLabel = isCurrentNW ? t('reports.current') : selectedNWBar!.date
 
-  const nwDonutData = [
-    { name: t('reports.accounts'), value: selectedNWBar ? selectedNWBar.accounts : nwDetailTotalAccounts, color: colorMap['accounts'] || '#6366F1' },
-    { name: t('reports.assets'), value: selectedNWBar ? selectedNWBar.assets : nwDetailTotalAssets, color: colorMap['assets'] || '#F59E0B' },
-    { name: t('reports.liabilities'), value: selectedNWBar ? selectedNWBar.liabilities : nwDetailTotalLiabs, color: colorMap['liabilities'] || '#F43F5E' },
+  const selectedAccounts = selectedNWBar ? selectedNWBar.accounts : nwDetailTotalAccounts
+  const selectedAssets = selectedNWBar ? selectedNWBar.assets : nwDetailTotalAssets
+  const selectedLiabs = selectedNWBar ? selectedNWBar.liabilities : nwDetailTotalLiabs
+
+  type NWPieItem = { name: string; value: number; color: string }
+
+  // Inner ring: group-level totals for Accounts + Assets chart
+  const nwPieAInner: NWPieItem[] = [
+    { name: t('reports.accounts'), value: selectedAccounts, color: colorMap['accounts'] || '#6366F1' },
+    { name: t('reports.assets'), value: selectedAssets, color: colorMap['assets'] || '#F59E0B' },
   ].filter((d) => d.value > 0)
+
+  // Outer ring: individual items, proportionally scaled to the selected period
+  const nwPieAOuter: NWPieItem[] = [
+    ...nwDetailAccounts.map((item: ReportCompositionItem) => ({
+      name: item.label,
+      value: nwDetailTotalAccounts > 0 ? (item.value / nwDetailTotalAccounts) * selectedAccounts : 0,
+      color: item.color,
+    })),
+    ...nwDetailAssets.map((item: ReportCompositionItem) => ({
+      name: item.label,
+      value: nwDetailTotalAssets > 0 ? (item.value / nwDetailTotalAssets) * selectedAssets : 0,
+      color: item.color,
+    })),
+  ].filter((d) => d.value > 0)
+
+  // Inner ring: liabilities group total
+  const nwPieBInner: NWPieItem[] = [
+    { name: t('reports.liabilities'), value: selectedLiabs, color: colorMap['liabilities'] || '#F43F5E' },
+  ].filter((d) => d.value > 0)
+
+  // Outer ring: individual liability items, proportionally scaled
+  const nwPieBOuter: NWPieItem[] = nwDetailLiabs.map((item: ReportCompositionItem) => ({
+    name: item.label,
+    value: nwDetailTotalLiabs > 0 ? (item.value / nwDetailTotalLiabs) * selectedLiabs : 0,
+    color: item.color,
+  })).filter((d: NWPieItem) => d.value > 0)
 
   type NWBarState = { accounts: number; assets: number; liabilities: number; value: number; date: string; index: number } | null
 
@@ -630,75 +662,144 @@ export default function ReportsPage() {
 
       {meta?.type === 'net_worth' && (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-          {/* Composition donut — mirrors selected bar or falls back to current snapshot */}
+          {/* Composition card — two nested pie charts, synced to selected bar */}
           <div className="bg-card rounded-xl border border-border shadow-sm">
-            <div className="px-5 pt-4 pb-2 flex items-baseline gap-2">
-              <p className="text-sm font-semibold text-foreground">{t('reports.composition')}</p>
-              <span className="text-xs text-muted-foreground">{nwPeriodLabel}</span>
+            <div className="px-5 pt-4 pb-3 flex items-start justify-between">
+              <div>
+                <p className="text-sm font-semibold text-foreground">{t('reports.composition')}</p>
+                <span className="text-xs text-muted-foreground">{nwPeriodLabel}</span>
+              </div>
+              <div className="text-right">
+                <p className="text-[10px] text-muted-foreground leading-tight">{t('reports.netWorth')}</p>
+                <p className="text-sm font-bold text-foreground tabular-nums">
+                  {mask(formatCompact(selectedNWBar ? selectedNWBar.value : (summary?.primary_value ?? 0), userCurrency, locale))}
+                </p>
+              </div>
             </div>
-            <div className="px-1 pb-4">
+            <div className="pb-4">
               {isLoading ? (
-                <div className="px-4" style={{ height: 200 }}>
+                <div className="px-4" style={{ height: 180 }}>
                   <Skeleton className="h-full w-full" />
                 </div>
-              ) : nwDonutData.length > 0 ? (
-                <div className="flex flex-col items-center">
-                  <div className="relative" style={{ width: 200, height: 200 }}>
-                    <ResponsiveContainer width="100%" height="100%">
-                      <PieChart>
-                        <Pie
-                          data={nwDonutData}
-                          cx="50%"
-                          cy="50%"
-                          innerRadius={55}
-                          outerRadius={85}
-                          paddingAngle={3}
-                          dataKey="value"
-                          strokeWidth={0}
-                          animationBegin={50}
-                          animationDuration={500}
-                        >
-                          {nwDonutData.map((entry, idx) => (
-                            <Cell key={idx} fill={entry.color} />
-                          ))}
-                        </Pie>
-                        <Tooltip
-                          formatter={(value?: number, name?: string) => {
-                            const v = value ?? 0
-                            const total = nwDonutData.reduce((s, d) => s + d.value, 0)
-                            const pct = total > 0 ? ((v / total) * 100).toFixed(1) : '0'
-                            return [
-                              privacyMode ? MASK : `${formatCurrency(v, userCurrency, locale)} (${pct}%)`,
-                              name,
-                            ]
-                          }}
-                          contentStyle={{ ...tooltipStyle, zIndex: 10 }}
-                          itemStyle={tooltipItemStyle}
-                          wrapperStyle={{ zIndex: 10 }}
-                          offset={20}
-                        />
-                      </PieChart>
-                    </ResponsiveContainer>
-                    <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none" style={{ zIndex: 0 }}>
-                      <span className="text-[10px] text-muted-foreground">
-                        {selectedNWBar ? selectedNWBar.date : t('reports.netWorth')}
-                      </span>
-                      <span className="text-base font-bold text-foreground tabular-nums">
-                        {mask(formatCompact(selectedNWBar ? selectedNWBar.value : (summary?.primary_value ?? 0), userCurrency, locale))}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="flex flex-wrap justify-center gap-x-3 gap-y-1 px-3 mt-1">
-                    {nwDonutData.map((d) => (
-                      <div key={d.name} className="flex items-center gap-1.5">
-                        <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: d.color }} />
-                        <span className="text-[11px] text-muted-foreground whitespace-nowrap">{d.name}</span>
+              ) : (
+                <div className="flex flex-row items-start justify-around px-1 gap-1">
+                  {/* Pie A: Accounts + Assets */}
+                  <div className="flex flex-col items-center gap-1">
+                    <p className="text-[11px] font-medium text-muted-foreground">{t('reports.accountsAndAssets')}</p>
+                    {nwPieAInner.length > 0 ? (
+                      <div className="relative" style={{ width: 148, height: 148 }}>
+                        <ResponsiveContainer width="100%" height="100%">
+                          <PieChart>
+                            <Pie
+                              data={nwPieAOuter}
+                              innerRadius={52}
+                              outerRadius={70}
+                              paddingAngle={1}
+                              dataKey="value"
+                              strokeWidth={0}
+                              animationBegin={50}
+                              animationDuration={500}
+                            >
+                              {nwPieAOuter.map((entry, idx) => (
+                                <Cell key={idx} fill={entry.color} />
+                              ))}
+                            </Pie>
+                            <Pie
+                              data={nwPieAInner}
+                              innerRadius={28}
+                              outerRadius={48}
+                              paddingAngle={2}
+                              dataKey="value"
+                              strokeWidth={0}
+                              animationBegin={50}
+                              animationDuration={500}
+                            >
+                              {nwPieAInner.map((entry, idx) => (
+                                <Cell key={idx} fill={entry.color} />
+                              ))}
+                            </Pie>
+                            <Tooltip
+                              formatter={(value?: number, name?: string) => {
+                                const v = value ?? 0
+                                const total = selectedAccounts + selectedAssets
+                                const pct = total > 0 ? ((v / total) * 100).toFixed(1) : '0'
+                                return [privacyMode ? MASK : `${formatCurrency(v, userCurrency, locale)} (${pct}%)`, name]
+                              }}
+                              contentStyle={{ ...tooltipStyle, zIndex: 10 }}
+                              itemStyle={tooltipItemStyle}
+                              wrapperStyle={{ zIndex: 10 }}
+                            />
+                          </PieChart>
+                        </ResponsiveContainer>
+                        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                          <span className="text-[10px] font-bold text-foreground tabular-nums">
+                            {mask(formatCompact(selectedAccounts + selectedAssets, userCurrency, locale))}
+                          </span>
+                        </div>
                       </div>
-                    ))}
+                    ) : (
+                      <p className="text-muted-foreground text-xs text-center py-10">{t('reports.noData')}</p>
+                    )}
+                  </div>
+
+                  {/* Pie B: Liabilities */}
+                  <div className="flex flex-col items-center gap-1">
+                    <p className="text-[11px] font-medium text-muted-foreground">{t('reports.liabilities')}</p>
+                    {nwPieBInner.length > 0 ? (
+                      <div className="relative" style={{ width: 148, height: 148 }}>
+                        <ResponsiveContainer width="100%" height="100%">
+                          <PieChart>
+                            <Pie
+                              data={nwPieBOuter}
+                              innerRadius={52}
+                              outerRadius={70}
+                              paddingAngle={1}
+                              dataKey="value"
+                              strokeWidth={0}
+                              animationBegin={50}
+                              animationDuration={500}
+                            >
+                              {nwPieBOuter.map((entry, idx) => (
+                                <Cell key={idx} fill={entry.color} />
+                              ))}
+                            </Pie>
+                            <Pie
+                              data={nwPieBInner}
+                              innerRadius={28}
+                              outerRadius={48}
+                              paddingAngle={0}
+                              dataKey="value"
+                              strokeWidth={0}
+                              animationBegin={50}
+                              animationDuration={500}
+                            >
+                              {nwPieBInner.map((entry, idx) => (
+                                <Cell key={idx} fill={entry.color} />
+                              ))}
+                            </Pie>
+                            <Tooltip
+                              formatter={(value?: number, name?: string) => {
+                                const v = value ?? 0
+                                const pct = selectedLiabs > 0 ? ((v / selectedLiabs) * 100).toFixed(1) : '0'
+                                return [privacyMode ? MASK : `${formatCurrency(v, userCurrency, locale)} (${pct}%)`, name]
+                              }}
+                              contentStyle={{ ...tooltipStyle, zIndex: 10 }}
+                              itemStyle={tooltipItemStyle}
+                              wrapperStyle={{ zIndex: 10 }}
+                            />
+                          </PieChart>
+                        </ResponsiveContainer>
+                        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                          <span className="text-[10px] font-bold text-foreground tabular-nums">
+                            {mask(formatCompact(selectedLiabs, userCurrency, locale))}
+                          </span>
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="text-muted-foreground text-xs text-center py-10">{t('reports.noData')}</p>
+                    )}
                   </div>
                 </div>
-              ) : (
-                <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
               )}
             </div>
           </div>

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -829,7 +829,7 @@ export default function ReportsPage() {
                   </div>
                 ) : (
                   <div className="flex flex-col items-center gap-2 pt-3 px-4">
-                    <div className="relative z-10 inline-flex flex-col gap-2">
+                    <div className="relative z-10 inline-flex flex-col gap-2 self-end">
                       {/* Summary / Detailed toggle */}
                       <div className="flex rounded-lg border border-border bg-muted/30 overflow-hidden">
                         {(['summary', 'detailed'] as const).map((opt) => (

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -823,7 +823,7 @@ export default function ReportsPage() {
               ) : (
                 <div className="flex flex-row items-start justify-around px-1 gap-1">
                   {/* Pie A: Accounts + Assets */}
-                  <div className="flex flex-col items-center gap-1">
+                  <div className="relative flex flex-col items-center gap-1 hover:z-10">
                     <p className="text-[11px] font-medium text-muted-foreground">{t('reports.accountsAndAssets')}</p>
                     {nwPieAInner.length > 0 ? (
                       <div className="relative" style={{ width: 148, height: 148 }}>
@@ -894,7 +894,7 @@ export default function ReportsPage() {
                   </div>
 
                   {/* Pie B: Liabilities */}
-                  <div className="flex flex-col items-center gap-1">
+                  <div className="relative flex flex-col items-center gap-1 hover:z-10">
                     <p className="text-[11px] font-medium text-muted-foreground">{t('reports.liabilities')}</p>
                     {nwPieBInner.length > 0 ? (
                       <div className="relative" style={{ width: 148, height: 148 }}>

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -108,6 +108,7 @@ export default function ReportsPage() {
   const [compositionView, setCompositionView] = useState<string>('summary')
   const [sparklineView, setSparklineView] = useState<'byExpenses' | 'byIncome'>('byExpenses')
   const [sparklinePage, setSparklinePage] = useState(0)
+  const [selectedNWBar, setSelectedNWBar] = useState<{ accounts: number; assets: number; liabilities: number; value: number; date: string; index: number } | null>(null)
 
   const currentTab = REPORT_TABS.find((tab) => tab.key === activeTab) ?? REPORT_TABS[0]
 
@@ -119,6 +120,7 @@ export default function ReportsPage() {
     setActiveTab(key)
     setCompositionView('summary')
     setSparklinePage(0)
+    setSelectedNWBar(null)
     // Clamp months/interval to options supported by the new tab
     const nextRanges = key === 'cash_flow' ? FORWARD_RANGE_OPTIONS : HISTORICAL_RANGE_OPTIONS
     if (!nextRanges.some((r) => r.months === months)) {
@@ -187,6 +189,45 @@ export default function ReportsPage() {
   const nwDetailTotalAccounts = nwDetailAccounts.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
   const nwDetailTotalAssets = nwDetailAssets.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
   const nwDetailTotalLiabs = nwDetailLiabs.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
+
+  const lastNWIndex = netWorthSummaryData.length - 1
+  const isCurrentNW = selectedNWBar == null || selectedNWBar.index === lastNWIndex
+  const nwPeriodLabel = isCurrentNW ? t('reports.current') : selectedNWBar!.date
+
+  const nwDonutData = [
+    { name: t('reports.accounts'), value: selectedNWBar ? selectedNWBar.accounts : nwDetailTotalAccounts, color: colorMap['accounts'] || '#6366F1' },
+    { name: t('reports.assets'), value: selectedNWBar ? selectedNWBar.assets : nwDetailTotalAssets, color: colorMap['assets'] || '#F59E0B' },
+    { name: t('reports.liabilities'), value: selectedNWBar ? selectedNWBar.liabilities : nwDetailTotalLiabs, color: colorMap['liabilities'] || '#F43F5E' },
+  ].filter((d) => d.value > 0)
+
+  type NWBarState = { accounts: number; assets: number; liabilities: number; value: number; date: string; index: number } | null
+
+  const handleSummaryBarClick = (_data: unknown, index: number) => {
+    const row = netWorthSummaryData[index]
+    if (!row) return
+    setSelectedNWBar((prev: NWBarState) =>
+      prev?.index === index ? null : {
+        accounts: (row.accounts as number) ?? 0,
+        assets: (row.assets as number) ?? 0,
+        liabilities: Math.abs((row.liabilitiesNeg as number) ?? 0),
+        value: (row.value as number) ?? 0,
+        date: row.date as string,
+        index,
+      }
+    )
+  }
+
+  const handleDetailedBarClick = (_data: unknown, index: number) => {
+    const row = netWorthDetailedData[index]
+    if (!row) return
+    setSelectedNWBar((prev: NWBarState) => {
+      if (prev?.index === index) return null
+      const accounts = nwDetailAccounts.reduce((s: number, it: ReportCompositionItem) => s + ((row[`acct_${it.key}`] as number) ?? 0), 0)
+      const assets = nwDetailAssets.reduce((s: number, it: ReportCompositionItem) => s + ((row[`asset_${it.key}`] as number) ?? 0), 0)
+      const liabilities = Math.abs(nwDetailLiabs.reduce((s: number, it: ReportCompositionItem) => s + ((row[`liab_${it.key}`] as number) ?? 0), 0))
+      return { accounts, assets, liabilities, value: (row.value as number) ?? 0, date: row.date as string, index }
+    })
+  }
 
   const netWorthDetailedData: Record<string, string | number>[] = meta?.type !== 'net_worth' ? [] : chartData.map((d: Record<string, string | number>) => {
     const aTotal = (d.accounts as number) ?? 0
@@ -588,235 +629,348 @@ export default function ReportsPage() {
       </div>
 
       {meta?.type === 'net_worth' && (
-        <div className="bg-card rounded-xl border border-border shadow-sm">
-          <div className="px-5 pt-4 pb-2 flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <p className="text-sm font-semibold text-foreground">{t('reports.evolution')}</p>
-              {compositionView === 'summary' && (
-                <div className="hidden sm:flex items-center gap-3">
-                  {[
-                    { key: 'accounts', color: colorMap['accounts'] || '#6366F1' },
-                    { key: 'assets', color: colorMap['assets'] || '#F59E0B' },
-                    { key: 'liabilities', color: colorMap['liabilities'] || '#F43F5E' },
-                  ].map(({ key, color }) => (
-                    <div key={key} className="flex items-center gap-1.5">
-                      <div className="w-2 h-2 rounded-full" style={{ backgroundColor: color }} />
-                      <span className="text-[11px] text-muted-foreground">{t(`reports.${key}`)}</span>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+          {/* Composition donut — mirrors selected bar or falls back to current snapshot */}
+          <div className="bg-card rounded-xl border border-border shadow-sm">
+            <div className="px-5 pt-4 pb-2 flex items-baseline gap-2">
+              <p className="text-sm font-semibold text-foreground">{t('reports.composition')}</p>
+              <span className="text-xs text-muted-foreground">{nwPeriodLabel}</span>
+            </div>
+            <div className="px-1 pb-4">
+              {isLoading ? (
+                <div className="px-4" style={{ height: 200 }}>
+                  <Skeleton className="h-full w-full" />
+                </div>
+              ) : nwDonutData.length > 0 ? (
+                <div className="flex flex-col items-center">
+                  <div className="relative" style={{ width: 200, height: 200 }}>
+                    <ResponsiveContainer width="100%" height="100%">
+                      <PieChart>
+                        <Pie
+                          data={nwDonutData}
+                          cx="50%"
+                          cy="50%"
+                          innerRadius={55}
+                          outerRadius={85}
+                          paddingAngle={3}
+                          dataKey="value"
+                          strokeWidth={0}
+                          animationBegin={50}
+                          animationDuration={500}
+                        >
+                          {nwDonutData.map((entry, idx) => (
+                            <Cell key={idx} fill={entry.color} />
+                          ))}
+                        </Pie>
+                        <Tooltip
+                          formatter={(value?: number, name?: string) => {
+                            const v = value ?? 0
+                            const total = nwDonutData.reduce((s, d) => s + d.value, 0)
+                            const pct = total > 0 ? ((v / total) * 100).toFixed(1) : '0'
+                            return [
+                              privacyMode ? MASK : `${formatCurrency(v, userCurrency, locale)} (${pct}%)`,
+                              name,
+                            ]
+                          }}
+                          contentStyle={{ ...tooltipStyle, zIndex: 10 }}
+                          itemStyle={tooltipItemStyle}
+                          wrapperStyle={{ zIndex: 10 }}
+                          offset={20}
+                        />
+                      </PieChart>
+                    </ResponsiveContainer>
+                    <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none" style={{ zIndex: 0 }}>
+                      <span className="text-[10px] text-muted-foreground">
+                        {selectedNWBar ? selectedNWBar.date : t('reports.netWorth')}
+                      </span>
+                      <span className="text-base font-bold text-foreground tabular-nums">
+                        {mask(formatCompact(selectedNWBar ? selectedNWBar.value : (summary?.primary_value ?? 0), userCurrency, locale))}
+                      </span>
                     </div>
-                  ))}
-                  <div className="flex items-center gap-1.5">
-                    <div className="w-3 h-0 border-t-2 border-dashed" style={{ borderColor: '#10B981' }} />
-                    <span className="text-[11px] text-muted-foreground">{t('reports.netWorth')}</span>
+                  </div>
+                  <div className="flex flex-wrap justify-center gap-x-3 gap-y-1 px-3 mt-1">
+                    {nwDonutData.map((d) => (
+                      <div key={d.name} className="flex items-center gap-1.5">
+                        <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: d.color }} />
+                        <span className="text-[11px] text-muted-foreground whitespace-nowrap">{d.name}</span>
+                      </div>
+                    ))}
                   </div>
                 </div>
+              ) : (
+                <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
               )}
-            </div>
-            <div className="flex items-center rounded-lg border border-border bg-muted/30 overflow-hidden">
-              {(['summary', 'detailed'] as const).map((opt) => (
-                <button
-                  key={opt}
-                  onClick={() => setCompositionView(opt)}
-                  className={`px-2.5 py-1 text-[11px] font-semibold transition-colors ${
-                    compositionView === opt
-                      ? 'bg-primary text-primary-foreground'
-                      : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
-                  }`}
-                >
-                  {t(`reports.${opt}`)}
-                </button>
-              ))}
             </div>
           </div>
-          {compositionView === 'summary' ? (
-            <div className="px-1 pb-4" style={{ height: 320 }}>
-              {isLoading ? (
-                <div className="px-4"><Skeleton className="h-full w-full" /></div>
-              ) : netWorthSummaryData.length > 0 ? (
-                <ResponsiveContainer width="100%" height="100%">
-                  <ComposedChart data={netWorthSummaryData} stackOffset="sign" margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
-                    <XAxis
-                      dataKey="date"
-                      tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
-                      axisLine={false}
-                      tickLine={false}
-                      interval="preserveStartEnd"
-                    />
-                    <YAxis
-                      tickFormatter={(v) => {
-                        if (privacyMode) return ''
-                        if (v === 0) return '0'
-                        return formatCompact(v, userCurrency, locale)
-                      }}
-                      tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
-                      axisLine={false}
-                      tickLine={false}
-                      width={64}
-                      tickCount={5}
-                    />
-                    <Tooltip
-                      content={({ active, payload, label }) => {
-                        if (!active || !payload) return null
-                        const liabEntry = payload.find((p) => p.dataKey === 'liabilitiesNeg')
-                        const netEntry = payload.find((p) => p.dataKey === 'value')
-                        return (
-                          <div style={tooltipStyle} className="px-3 py-2">
-                            <p className="text-xs font-medium mb-1">{label}</p>
-                            {payload
-                              .filter((p) => p.dataKey !== 'liabilitiesNeg' && p.dataKey !== 'value' && (p.value as number) !== 0)
-                              .map((p) => (
-                                <p key={p.dataKey as string} className="text-xs" style={{ color: p.color }}>
-                                  {t(`reports.${p.dataKey}`, { defaultValue: String(p.name) })}:{' '}
-                                  {privacyMode ? MASK : formatCurrency(p.value as number, userCurrency, locale)}
+
+          {/* Evolution chart */}
+          <div className="lg:col-span-2 bg-card rounded-xl border border-border shadow-sm">
+            <div className="px-5 pt-4 pb-2 flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <p className="text-sm font-semibold text-foreground">{t('reports.evolution')}</p>
+                {compositionView === 'summary' && (
+                  <div className="hidden sm:flex items-center gap-3">
+                    {[
+                      { key: 'accounts', color: colorMap['accounts'] || '#6366F1' },
+                      { key: 'assets', color: colorMap['assets'] || '#F59E0B' },
+                      { key: 'liabilities', color: colorMap['liabilities'] || '#F43F5E' },
+                    ].map(({ key, color }) => (
+                      <div key={key} className="flex items-center gap-1.5">
+                        <div className="w-2 h-2 rounded-full" style={{ backgroundColor: color }} />
+                        <span className="text-[11px] text-muted-foreground">{t(`reports.${key}`)}</span>
+                      </div>
+                    ))}
+                    <div className="flex items-center gap-1.5">
+                      <div className="w-3 h-0 border-t-2 border-dashed" style={{ borderColor: '#10B981' }} />
+                      <span className="text-[11px] text-muted-foreground">{t('reports.netWorth')}</span>
+                    </div>
+                  </div>
+                )}
+              </div>
+              <div className="flex items-center rounded-lg border border-border bg-muted/30 overflow-hidden">
+                {(['summary', 'detailed'] as const).map((opt) => (
+                  <button
+                    key={opt}
+                    onClick={() => setCompositionView(opt)}
+                    className={`px-2.5 py-1 text-[11px] font-semibold transition-colors ${
+                      compositionView === opt
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                    }`}
+                  >
+                    {t(`reports.${opt}`)}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {compositionView === 'summary' ? (
+              <div className="px-1 pb-4" style={{ height: 320 }}>
+                {isLoading ? (
+                  <div className="px-4"><Skeleton className="h-full w-full" /></div>
+                ) : netWorthSummaryData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <ComposedChart
+                      data={netWorthSummaryData}
+                      stackOffset="sign"
+                      margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+                      style={{ cursor: 'pointer' }}
+                    >
+                      <XAxis
+                        dataKey="date"
+                        tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
+                        axisLine={false}
+                        tickLine={false}
+                        interval="preserveStartEnd"
+                      />
+                      <YAxis
+                        tickFormatter={(v) => {
+                          if (privacyMode) return ''
+                          if (v === 0) return '0'
+                          return formatCompact(v, userCurrency, locale)
+                        }}
+                        tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
+                        axisLine={false}
+                        tickLine={false}
+                        width={64}
+                        tickCount={5}
+                      />
+                      <Tooltip
+                        content={({ active, payload, label }) => {
+                          if (!active || !payload) return null
+                          const liabEntry = payload.find((p) => p.dataKey === 'liabilitiesNeg')
+                          const netEntry = payload.find((p) => p.dataKey === 'value')
+                          return (
+                            <div style={tooltipStyle} className="px-3 py-2">
+                              <p className="text-xs font-medium mb-1">{label}</p>
+                              {payload
+                                .filter((p) => p.dataKey !== 'liabilitiesNeg' && p.dataKey !== 'value' && (p.value as number) !== 0)
+                                .map((p) => (
+                                  <p key={p.dataKey as string} className="text-xs" style={{ color: p.color }}>
+                                    {t(`reports.${p.dataKey}`, { defaultValue: String(p.name) })}:{' '}
+                                    {privacyMode ? MASK : formatCurrency(p.value as number, userCurrency, locale)}
+                                  </p>
+                                ))
+                              }
+                              {liabEntry && (liabEntry.value as number) !== 0 && (
+                                <p className="text-xs" style={{ color: '#F43F5E' }}>
+                                  {t('reports.liabilities')}:{' '}
+                                  {privacyMode ? MASK : formatCurrency(-(liabEntry.value as number), userCurrency, locale)}
                                 </p>
-                              ))
-                            }
-                            {liabEntry && (liabEntry.value as number) !== 0 && (
-                              <p className="text-xs" style={{ color: '#F43F5E' }}>
-                                {t('reports.liabilities')}:{' '}
-                                {privacyMode ? MASK : formatCurrency(-(liabEntry.value as number), userCurrency, locale)}
-                              </p>
-                            )}
-                            {netEntry && (
-                              <p className="text-xs font-semibold mt-1" style={{ color: '#10B981' }}>
-                                {t('reports.netWorth')}:{' '}
-                                {privacyMode ? MASK : formatCurrency(netEntry.value as number, userCurrency, locale)}
-                              </p>
-                            )}
-                          </div>
-                        )
-                      }}
-                    />
-                    <ReferenceLine y={0} stroke="var(--border)" strokeDasharray="3 3" />
-                    <Bar dataKey="accounts" stackId="stack" fill={colorMap['accounts'] || '#6366F1'} maxBarSize={32} radius={[0, 0, 0, 0]} />
-                    <Bar dataKey="assets" stackId="stack" fill={colorMap['assets'] || '#F59E0B'} maxBarSize={32} radius={[4, 4, 0, 0]} />
-                    <Bar dataKey="liabilitiesNeg" stackId="stack" fill={colorMap['liabilities'] || '#F43F5E'} maxBarSize={32} radius={[4, 4, 0, 0]} />
-                    <Line
-                      type="monotone"
-                      dataKey="value"
-                      stroke="#10B981"
-                      strokeWidth={2}
-                      strokeDasharray="6 3"
-                      dot={false}
-                      activeDot={{ r: 4, fill: '#10B981' }}
-                    />
-                  </ComposedChart>
-                </ResponsiveContainer>
-              ) : (
-                <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
-              )}
-            </div>
-          ) : (
-            <div className="px-1 pb-4" style={{ height: 320 }}>
-              {isLoading ? (
-                <div className="px-4"><Skeleton className="h-full w-full" /></div>
-              ) : netWorthDetailedData.length > 0 ? (
-                <ResponsiveContainer width="100%" height="100%">
-                  <ComposedChart data={netWorthDetailedData} stackOffset="sign" margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
-                    <XAxis
-                      dataKey="date"
-                      tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
-                      axisLine={false}
-                      tickLine={false}
-                      interval="preserveStartEnd"
-                    />
-                    <YAxis
-                      tickFormatter={(v) => {
-                        if (privacyMode) return ''
-                        if (v === 0) return '0'
-                        return formatCompact(v, userCurrency, locale)
-                      }}
-                      tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
-                      axisLine={false}
-                      tickLine={false}
-                      width={64}
-                      tickCount={5}
-                    />
-                    <Tooltip
-                      content={({ active, payload, label }: { active?: boolean; payload?: { dataKey?: string | number; value?: number; color?: string }[]; label?: string }) => {
-                        if (!active || !payload) return null
-                        const findLabel = (dk: string) =>
-                          composition.find((c: ReportCompositionItem) => c.key === dk.replace(/^(acct_|asset_|liab_)/, ''))?.label ?? dk
-                        const acctEntries = payload.filter((p) => String(p.dataKey).startsWith('acct_') && (p.value ?? 0) !== 0)
-                        const assetEntries = payload.filter((p) => String(p.dataKey).startsWith('asset_') && (p.value ?? 0) !== 0)
-                        const liabEntries = payload.filter((p) => String(p.dataKey).startsWith('liab_') && (p.value ?? 0) !== 0)
-                        const netEntry = payload.find((p) => p.dataKey === 'value')
-                        return (
-                          <div style={tooltipStyle} className="px-3 py-2 max-w-[220px]">
-                            <p className="text-xs font-medium mb-1">{label}</p>
-                            {acctEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.accounts')}</p>}
-                            {acctEntries.map((p) => (
-                              <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
-                                {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(p.value ?? 0, userCurrency, locale)}
-                              </p>
-                            ))}
-                            {assetEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.assets')}</p>}
-                            {assetEntries.map((p) => (
-                              <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
-                                {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(p.value ?? 0, userCurrency, locale)}
-                              </p>
-                            ))}
-                            {liabEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.liabilities')}</p>}
-                            {liabEntries.map((p) => (
-                              <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
-                                {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(-(p.value ?? 0), userCurrency, locale)}
-                              </p>
-                            ))}
-                            {netEntry && (
-                              <p className="text-xs font-semibold mt-1 pt-1 border-t border-border" style={{ color: '#10B981' }}>
-                                {t('reports.netWorth')}: {privacyMode ? MASK : formatCurrency(netEntry.value ?? 0, userCurrency, locale)}
-                              </p>
-                            )}
-                          </div>
-                        )
-                      }}
-                    />
-                    <ReferenceLine y={0} stroke="var(--border)" strokeDasharray="3 3" />
-                    {nwDetailAccounts.map((item: ReportCompositionItem, idx: number) => (
-                      <Bar
-                        key={`acct_${item.key}`}
-                        dataKey={`acct_${item.key}`}
-                        stackId="stack"
-                        fill={item.color}
-                        maxBarSize={32}
-                        radius={idx === nwDetailAccounts.length - 1 && nwDetailAssets.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+                              )}
+                              {netEntry && (
+                                <p className="text-xs font-semibold mt-1" style={{ color: '#10B981' }}>
+                                  {t('reports.netWorth')}:{' '}
+                                  {privacyMode ? MASK : formatCurrency(netEntry.value as number, userCurrency, locale)}
+                                </p>
+                              )}
+                            </div>
+                          )
+                        }}
                       />
-                    ))}
-                    {nwDetailAssets.map((item: ReportCompositionItem, idx: number) => (
-                      <Bar
-                        key={`asset_${item.key}`}
-                        dataKey={`asset_${item.key}`}
-                        stackId="stack"
-                        fill={item.color}
-                        maxBarSize={32}
-                        radius={idx === nwDetailAssets.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+                      <ReferenceLine y={0} stroke="var(--border)" strokeDasharray="3 3" />
+                      <Bar dataKey="accounts" stackId="stack" fill={colorMap['accounts'] || '#6366F1'} maxBarSize={32} radius={[0, 0, 0, 0]} onClick={handleSummaryBarClick}>
+                        {netWorthSummaryData.map((_: unknown, i: number) => (
+                          <Cell key={i} fill={colorMap['accounts'] || '#6366F1'} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                        ))}
+                      </Bar>
+                      <Bar dataKey="assets" stackId="stack" fill={colorMap['assets'] || '#F59E0B'} maxBarSize={32} radius={[4, 4, 0, 0]} onClick={handleSummaryBarClick}>
+                        {netWorthSummaryData.map((_: unknown, i: number) => (
+                          <Cell key={i} fill={colorMap['assets'] || '#F59E0B'} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                        ))}
+                      </Bar>
+                      <Bar dataKey="liabilitiesNeg" stackId="stack" fill={colorMap['liabilities'] || '#F43F5E'} maxBarSize={32} radius={[4, 4, 0, 0]} onClick={handleSummaryBarClick}>
+                        {netWorthSummaryData.map((_: unknown, i: number) => (
+                          <Cell key={i} fill={colorMap['liabilities'] || '#F43F5E'} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                        ))}
+                      </Bar>
+                      <Line
+                        type="monotone"
+                        dataKey="value"
+                        stroke="#10B981"
+                        strokeWidth={2}
+                        strokeDasharray="6 3"
+                        dot={false}
+                        activeDot={{ r: 4, fill: '#10B981' }}
                       />
-                    ))}
-                    {nwDetailLiabs.map((item: ReportCompositionItem, idx: number) => (
-                      <Bar
-                        key={`liab_${item.key}`}
-                        dataKey={`liab_${item.key}`}
-                        stackId="stack"
-                        fill={item.color}
-                        maxBarSize={32}
-                        radius={idx === nwDetailLiabs.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+                    </ComposedChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
+                )}
+              </div>
+            ) : (
+              <div className="px-1 pb-4" style={{ height: 320 }}>
+                {isLoading ? (
+                  <div className="px-4"><Skeleton className="h-full w-full" /></div>
+                ) : netWorthDetailedData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <ComposedChart
+                      data={netWorthDetailedData}
+                      stackOffset="sign"
+                      margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+                      style={{ cursor: 'pointer' }}
+                    >
+                      <XAxis
+                        dataKey="date"
+                        tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
+                        axisLine={false}
+                        tickLine={false}
+                        interval="preserveStartEnd"
                       />
-                    ))}
-                    <Line
-                      type="monotone"
-                      dataKey="value"
-                      stroke="#10B981"
-                      strokeWidth={2}
-                      strokeDasharray="6 3"
-                      dot={false}
-                      activeDot={{ r: 4, fill: '#10B981' }}
-                    />
-                  </ComposedChart>
-                </ResponsiveContainer>
-              ) : (
-                <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
-              )}
-            </div>
-          )}
+                      <YAxis
+                        tickFormatter={(v) => {
+                          if (privacyMode) return ''
+                          if (v === 0) return '0'
+                          return formatCompact(v, userCurrency, locale)
+                        }}
+                        tick={{ fontSize: 10, fill: 'var(--muted-foreground)' }}
+                        axisLine={false}
+                        tickLine={false}
+                        width={64}
+                        tickCount={5}
+                      />
+                      <Tooltip
+                        content={({ active, payload, label }: { active?: boolean; payload?: { dataKey?: string | number; value?: number; color?: string }[]; label?: string }) => {
+                          if (!active || !payload) return null
+                          const findLabel = (dk: string) =>
+                            composition.find((c: ReportCompositionItem) => c.key === dk.replace(/^(acct_|asset_|liab_)/, ''))?.label ?? dk
+                          const acctEntries = payload.filter((p) => String(p.dataKey).startsWith('acct_') && (p.value ?? 0) !== 0)
+                          const assetEntries = payload.filter((p) => String(p.dataKey).startsWith('asset_') && (p.value ?? 0) !== 0)
+                          const liabEntries = payload.filter((p) => String(p.dataKey).startsWith('liab_') && (p.value ?? 0) !== 0)
+                          const netEntry = payload.find((p) => p.dataKey === 'value')
+                          return (
+                            <div style={tooltipStyle} className="px-3 py-2 max-w-[220px]">
+                              <p className="text-xs font-medium mb-1">{label}</p>
+                              {acctEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.accounts')}</p>}
+                              {acctEntries.map((p) => (
+                                <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
+                                  {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(p.value ?? 0, userCurrency, locale)}
+                                </p>
+                              ))}
+                              {assetEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.assets')}</p>}
+                              {assetEntries.map((p) => (
+                                <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
+                                  {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(p.value ?? 0, userCurrency, locale)}
+                                </p>
+                              ))}
+                              {liabEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.liabilities')}</p>}
+                              {liabEntries.map((p) => (
+                                <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
+                                  {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(-(p.value ?? 0), userCurrency, locale)}
+                                </p>
+                              ))}
+                              {netEntry && (
+                                <p className="text-xs font-semibold mt-1 pt-1 border-t border-border" style={{ color: '#10B981' }}>
+                                  {t('reports.netWorth')}: {privacyMode ? MASK : formatCurrency(netEntry.value ?? 0, userCurrency, locale)}
+                                </p>
+                              )}
+                            </div>
+                          )
+                        }}
+                      />
+                      <ReferenceLine y={0} stroke="var(--border)" strokeDasharray="3 3" />
+                      {nwDetailAccounts.map((item: ReportCompositionItem, idx: number) => (
+                        <Bar
+                          key={`acct_${item.key}`}
+                          dataKey={`acct_${item.key}`}
+                          stackId="stack"
+                          fill={item.color}
+                          maxBarSize={32}
+                          radius={idx === nwDetailAccounts.length - 1 && nwDetailAssets.length === 0 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+                          onClick={handleDetailedBarClick}
+                        >
+                          {netWorthDetailedData.map((_: unknown, i: number) => (
+                            <Cell key={i} fill={item.color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                          ))}
+                        </Bar>
+                      ))}
+                      {nwDetailAssets.map((item: ReportCompositionItem, idx: number) => (
+                        <Bar
+                          key={`asset_${item.key}`}
+                          dataKey={`asset_${item.key}`}
+                          stackId="stack"
+                          fill={item.color}
+                          maxBarSize={32}
+                          radius={idx === nwDetailAssets.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+                          onClick={handleDetailedBarClick}
+                        >
+                          {netWorthDetailedData.map((_: unknown, i: number) => (
+                            <Cell key={i} fill={item.color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                          ))}
+                        </Bar>
+                      ))}
+                      {nwDetailLiabs.map((item: ReportCompositionItem, idx: number) => (
+                        <Bar
+                          key={`liab_${item.key}`}
+                          dataKey={`liab_${item.key}`}
+                          stackId="stack"
+                          fill={item.color}
+                          maxBarSize={32}
+                          radius={idx === nwDetailLiabs.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+                          onClick={handleDetailedBarClick}
+                        >
+                          {netWorthDetailedData.map((_: unknown, i: number) => (
+                            <Cell key={i} fill={item.color} opacity={selectedNWBar == null || selectedNWBar.index === i ? 1 : 0.35} />
+                          ))}
+                        </Bar>
+                      ))}
+                      <Line
+                        type="monotone"
+                        dataKey="value"
+                        stroke="#10B981"
+                        strokeWidth={2}
+                        strokeDasharray="6 3"
+                        dot={false}
+                        activeDot={{ r: 4, fill: '#10B981' }}
+                      />
+                    </ComposedChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <p className="text-muted-foreground text-sm text-center py-16">{t('reports.noData')}</p>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       )}
       {!isLoading && meta?.type !== 'net_worth' && (

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -821,17 +821,17 @@ export default function ReportsPage() {
           {/* Inner grid: pies right (col-start-3), evolution left (col-span-2 col-start-1) */}
           <div className="grid grid-cols-1 lg:grid-cols-3">
             {/* Pies — right 1 col */}
-            <div className="lg:col-start-3 lg:row-start-1 lg:border-l lg:border-border">
-              <div className="pb-4">
+            <div className="lg:col-start-3 lg:row-start-1 lg:border-l lg:border-border flex flex-col">
+              <div className="flex flex-col flex-1 pb-4">
                 {isLoading ? (
                   <div className="px-4" style={{ height: 180 }}>
                     <Skeleton className="h-full w-full" />
                   </div>
                 ) : (
-                  <div className="flex flex-col items-center gap-2 pt-3 px-4">
-                    <div className="relative z-10 inline-flex flex-col gap-2 self-end">
-                      {/* Summary / Detailed toggle */}
-                      <div className="flex rounded-lg border border-border bg-muted/30 overflow-hidden">
+                  <div className="flex flex-col flex-1 items-center gap-2 pt-3 px-4">
+                    <div className="relative z-10 self-end inline-flex flex-row rounded-lg border border-border bg-muted/30 overflow-hidden">
+                      {/* Summary / Detailed group */}
+                      <div className="flex">
                         {(['summary', 'detailed'] as const).map((opt) => (
                           <button
                             key={opt}
@@ -846,8 +846,10 @@ export default function ReportsPage() {
                           </button>
                         ))}
                       </div>
-                      {/* What you have / What you owe toggle */}
-                      <div className="flex rounded-lg border border-border bg-muted/30 overflow-hidden">
+                      {/* Divider */}
+                      <div className="w-px bg-border" />
+                      {/* You own / You owe group */}
+                      <div className="flex">
                         <button
                           onClick={() => setNwPieView('accountsAssets')}
                           className={`flex-1 px-2.5 py-1 text-[11px] font-semibold transition-colors ${
@@ -880,7 +882,7 @@ export default function ReportsPage() {
                         <p className="text-muted-foreground text-xs text-center py-10">{t('reports.noData')}</p>
                       )
                       return (
-                        <div className="relative" style={{ width: 190, height: 190 }}>
+                        <div className="relative flex-1 w-full min-h-[160px]">
                           <ResponsiveContainer width="100%" height="100%">
                             <PieChart>
                               <Pie

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -204,21 +204,23 @@ export default function ReportsPage() {
   const nwPieAInner: NWPieItem[] = [
     { name: t('reports.accounts'), value: selectedAccounts, color: colorMap['accounts'] || '#6366F1' },
     { name: t('reports.assets'), value: selectedAssets, color: colorMap['assets'] || '#F59E0B' },
-  ].filter((d) => d.value > 0)
+  ].filter((d) => d.value > 0).sort((a, b) => b.value - a.value)
 
-  // Outer ring: individual items, proportionally scaled to the selected period
-  const nwPieAOuter: NWPieItem[] = [
-    ...nwDetailAccounts.map((item: ReportCompositionItem) => ({
-      name: item.label,
-      value: nwDetailTotalAccounts > 0 ? (item.value / nwDetailTotalAccounts) * selectedAccounts : 0,
-      color: item.color,
-    })),
-    ...nwDetailAssets.map((item: ReportCompositionItem) => ({
-      name: item.label,
-      value: nwDetailTotalAssets > 0 ? (item.value / nwDetailTotalAssets) * selectedAssets : 0,
-      color: item.color,
-    })),
-  ].filter((d) => d.value > 0)
+  // Outer ring: items grouped to match inner ring order, sorted by value within each group
+  const nwPieAOuter: NWPieItem[] = nwPieAInner.flatMap((group) => {
+    const isAccounts = group.name === t('reports.accounts')
+    const items = isAccounts ? nwDetailAccounts : nwDetailAssets
+    const total = isAccounts ? nwDetailTotalAccounts : nwDetailTotalAssets
+    const selected = isAccounts ? selectedAccounts : selectedAssets
+    return items
+      .map((item: ReportCompositionItem) => ({
+        name: item.label,
+        value: total > 0 ? (item.value / total) * selected : 0,
+        color: item.color,
+      }))
+      .filter((d) => d.value > 0)
+      .sort((a, b) => b.value - a.value)
+  })
 
   // Inner ring: liabilities group total
   const nwPieBInner: NWPieItem[] = [
@@ -230,7 +232,7 @@ export default function ReportsPage() {
     name: item.label,
     value: nwDetailTotalLiabs > 0 ? (item.value / nwDetailTotalLiabs) * selectedLiabs : 0,
     color: item.color,
-  })).filter((d: NWPieItem) => d.value > 0)
+  })).filter((d: NWPieItem) => d.value > 0).sort((a: NWPieItem, b: NWPieItem) => b.value - a.value)
 
   type NWBarState = { accounts: number; assets: number; liabilities: number; value: number; date: string; index: number } | null
 
@@ -694,9 +696,10 @@ export default function ReportsPage() {
                               data={nwPieAOuter}
                               innerRadius={52}
                               outerRadius={70}
-                              paddingAngle={1}
+                              paddingAngle={0}
                               dataKey="value"
-                              strokeWidth={0}
+                              stroke="var(--card)"
+                              strokeWidth={1}
                               animationBegin={50}
                               animationDuration={500}
                             >
@@ -708,9 +711,10 @@ export default function ReportsPage() {
                               data={nwPieAInner}
                               innerRadius={28}
                               outerRadius={48}
-                              paddingAngle={2}
+                              paddingAngle={0}
                               dataKey="value"
-                              strokeWidth={0}
+                              stroke="var(--card)"
+                              strokeWidth={1}
                               animationBegin={50}
                               animationDuration={500}
                             >
@@ -753,9 +757,10 @@ export default function ReportsPage() {
                               data={nwPieBOuter}
                               innerRadius={52}
                               outerRadius={70}
-                              paddingAngle={1}
+                              paddingAngle={0}
                               dataKey="value"
-                              strokeWidth={0}
+                              stroke="var(--card)"
+                              strokeWidth={1}
                               animationBegin={50}
                               animationDuration={500}
                             >
@@ -769,7 +774,8 @@ export default function ReportsPage() {
                               outerRadius={48}
                               paddingAngle={0}
                               dataKey="value"
-                              strokeWidth={0}
+                              stroke="var(--card)"
+                              strokeWidth={1}
                               animationBegin={50}
                               animationDuration={500}
                             >

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -195,9 +195,9 @@ export default function ReportsPage() {
   // Build donut data based on composition view
   const composition = data?.composition ?? []
 
-  const nwDetailAccounts = composition.filter((c: ReportCompositionItem) => c.group === 'accounts')
-  const nwDetailAssets = composition.filter((c: ReportCompositionItem) => c.group === 'assets')
-  const nwDetailLiabs = composition.filter((c: ReportCompositionItem) => c.group === 'liabilities')
+  const nwDetailAccounts = composition.filter((c: ReportCompositionItem) => c.group === 'accounts').sort((a, b) => b.value - a.value)
+  const nwDetailAssets = composition.filter((c: ReportCompositionItem) => c.group === 'assets').sort((a, b) => b.value - a.value)
+  const nwDetailLiabs = composition.filter((c: ReportCompositionItem) => c.group === 'liabilities').sort((a, b) => b.value - a.value)
   const nwDetailTotalAccounts = nwDetailAccounts.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
   const nwDetailTotalAssets = nwDetailAssets.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
   const nwDetailTotalLiabs = nwDetailLiabs.reduce((s: number, c: ReportCompositionItem) => s + c.value, 0)
@@ -944,6 +944,7 @@ export default function ReportsPage() {
                               <p className="text-xs font-medium mb-1">{label}</p>
                               {payload
                                 .filter((p) => p.dataKey !== 'liabilitiesNeg' && p.dataKey !== 'value' && (p.value as number) !== 0)
+                                .sort((a, b) => (b.value as number) - (a.value as number))
                                 .map((p) => (
                                   <p key={p.dataKey as string} className="text-xs" style={{ color: p.color }}>
                                     {t(`reports.${p.dataKey}`, { defaultValue: String(p.name) })}:{' '}
@@ -1034,35 +1035,48 @@ export default function ReportsPage() {
                           if (!active || !payload) return null
                           const findLabel = (dk: string) =>
                             composition.find((c: ReportCompositionItem) => c.key === dk.replace(/^(acct_|asset_|liab_)/, ''))?.label ?? dk
-                          const acctEntries = payload.filter((p) => String(p.dataKey).startsWith('acct_') && (p.value ?? 0) !== 0)
-                          const assetEntries = payload.filter((p) => String(p.dataKey).startsWith('asset_') && (p.value ?? 0) !== 0)
-                          const liabEntries = payload.filter((p) => String(p.dataKey).startsWith('liab_') && (p.value ?? 0) !== 0)
+                          const acctEntries = payload.filter((p) => String(p.dataKey).startsWith('acct_') && (p.value ?? 0) !== 0).sort((a, b) => Math.abs(b.value ?? 0) - Math.abs(a.value ?? 0))
+                          const assetEntries = payload.filter((p) => String(p.dataKey).startsWith('asset_') && (p.value ?? 0) !== 0).sort((a, b) => Math.abs(b.value ?? 0) - Math.abs(a.value ?? 0))
+                          const liabEntries = payload.filter((p) => String(p.dataKey).startsWith('liab_') && (p.value ?? 0) !== 0).sort((a, b) => Math.abs(b.value ?? 0) - Math.abs(a.value ?? 0))
                           const netEntry = payload.find((p) => p.dataKey === 'value')
                           return (
-                            <div style={tooltipStyle} className="px-3 py-2 max-w-[220px]">
+                            <div style={tooltipStyle} className="px-3 py-2">
                               <p className="text-xs font-medium mb-1">{label}</p>
                               {acctEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.accounts')}</p>}
                               {acctEntries.map((p) => (
-                                <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
-                                  {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(p.value ?? 0, userCurrency, locale)}
-                                </p>
+                                <div key={String(p.dataKey)} style={{ display: 'flex', justifyContent: 'space-between', gap: 16, marginBottom: 2 }}>
+                                  <span className="text-xs flex items-center gap-1.5" style={{ color: p.color }}>
+                                    <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: p.color, flexShrink: 0, display: 'inline-block' }} />
+                                    {findLabel(String(p.dataKey))}
+                                  </span>
+                                  <span className="text-xs" style={{ fontVariantNumeric: 'tabular-nums', color: p.color }}>{privacyMode ? MASK : formatCurrency(p.value ?? 0, userCurrency, locale)}</span>
+                                </div>
                               ))}
                               {assetEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.assets')}</p>}
                               {assetEntries.map((p) => (
-                                <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
-                                  {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(p.value ?? 0, userCurrency, locale)}
-                                </p>
+                                <div key={String(p.dataKey)} style={{ display: 'flex', justifyContent: 'space-between', gap: 16, marginBottom: 2 }}>
+                                  <span className="text-xs flex items-center gap-1.5" style={{ color: p.color }}>
+                                    <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: p.color, flexShrink: 0, display: 'inline-block' }} />
+                                    {findLabel(String(p.dataKey))}
+                                  </span>
+                                  <span className="text-xs" style={{ fontVariantNumeric: 'tabular-nums', color: p.color }}>{privacyMode ? MASK : formatCurrency(p.value ?? 0, userCurrency, locale)}</span>
+                                </div>
                               ))}
                               {liabEntries.length > 0 && <p className="text-[10px] font-semibold text-muted-foreground mt-1 uppercase tracking-wide">{t('reports.liabilities')}</p>}
                               {liabEntries.map((p) => (
-                                <p key={String(p.dataKey)} className="text-xs" style={{ color: p.color }}>
-                                  {findLabel(String(p.dataKey))}: {privacyMode ? MASK : formatCurrency(-(p.value ?? 0), userCurrency, locale)}
-                                </p>
+                                <div key={String(p.dataKey)} style={{ display: 'flex', justifyContent: 'space-between', gap: 16, marginBottom: 2 }}>
+                                  <span className="text-xs flex items-center gap-1.5" style={{ color: p.color }}>
+                                    <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: p.color, flexShrink: 0, display: 'inline-block' }} />
+                                    {findLabel(String(p.dataKey))}
+                                  </span>
+                                  <span className="text-xs" style={{ fontVariantNumeric: 'tabular-nums', color: p.color }}>{privacyMode ? MASK : formatCurrency(-(p.value ?? 0), userCurrency, locale)}</span>
+                                </div>
                               ))}
                               {netEntry && (
-                                <p className="text-xs font-semibold mt-1 pt-1 border-t border-border" style={{ color: '#10B981' }}>
-                                  {t('reports.netWorth')}: {privacyMode ? MASK : formatCurrency(netEntry.value ?? 0, userCurrency, locale)}
-                                </p>
+                                <div style={{ borderTop: '1px solid var(--border)', marginTop: 6, paddingTop: 6, display: 'flex', justifyContent: 'space-between', gap: 16 }}>
+                                  <span className="text-xs font-semibold" style={{ color: '#10B981' }}>{t('reports.netWorth')}</span>
+                                  <span className="text-xs font-semibold" style={{ fontVariantNumeric: 'tabular-nums', color: '#10B981' }}>{privacyMode ? MASK : formatCurrency(netEntry.value ?? 0, userCurrency, locale)}</span>
+                                </div>
                               )}
                             </div>
                           )

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -161,6 +161,18 @@ export default function ReportsPage() {
     liabilitiesNeg: -((d.liabilities as number) ?? 0),
   }))
 
+  const nwTrendData = chartData.map((d, i) => {
+    const current = d.value as number
+    const prev = i > 0 ? (chartData[i - 1].value as number) : current
+    const delta = current - prev
+    return {
+      ...d,
+      _deltaBase: i > 0 ? Math.min(prev, current) : current,
+      _deltaSize: i > 0 ? Math.abs(delta) : 0,
+      _delta: delta,
+    }
+  })
+
   const changePrefix = (summary?.change_amount ?? 0) >= 0 ? '+' : ''
   const changeColor = (summary?.change_amount ?? 0) >= 0 ? 'text-emerald-600' : 'text-rose-500'
 
@@ -452,24 +464,42 @@ export default function ReportsPage() {
           </p>
           {meta && (
             <div className="flex items-center gap-3">
-              {meta.series_keys.map((key) => (
-                <div key={key} className="flex items-center gap-1.5">
-                  <div
-                    className="w-2 h-2 rounded-full"
-                    style={{ backgroundColor: colorMap[key] || '#6366F1' }}
-                  />
-                  <span className="text-[11px] text-muted-foreground">
-                    {t(`reports.${key}`, { defaultValue: key })}
-                  </span>
-                </div>
-              ))}
-              {meta.type === 'income_expenses' && (
-                <div className="flex items-center gap-1.5">
-                  <div className="w-3 h-0 border-t-2 border-dashed" style={{ borderColor: '#6366F1' }} />
-                  <span className="text-[11px] text-muted-foreground">
-                    {t('reports.netIncome')}
-                  </span>
-                </div>
+              {meta.type === 'net_worth' ? (
+                <>
+                  <div className="flex items-center gap-1.5">
+                    <div className="w-3 h-0 border-t-2" style={{ borderColor: '#6366F1' }} />
+                    <span className="text-[11px] text-muted-foreground">{t('reports.netWorth')}</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <div className="w-2.5 h-2.5 rounded-sm overflow-hidden flex">
+                      <div className="flex-1" style={{ backgroundColor: '#10B981', opacity: 0.8 }} />
+                      <div className="flex-1" style={{ backgroundColor: '#F43F5E', opacity: 0.8 }} />
+                    </div>
+                    <span className="text-[11px] text-muted-foreground">{t('reports.change')}</span>
+                  </div>
+                </>
+              ) : (
+                <>
+                  {meta.series_keys.map((key) => (
+                    <div key={key} className="flex items-center gap-1.5">
+                      <div
+                        className="w-2 h-2 rounded-full"
+                        style={{ backgroundColor: colorMap[key] || '#6366F1' }}
+                      />
+                      <span className="text-[11px] text-muted-foreground">
+                        {t(`reports.${key}`, { defaultValue: key })}
+                      </span>
+                    </div>
+                  ))}
+                  {meta.type === 'income_expenses' && (
+                    <div className="flex items-center gap-1.5">
+                      <div className="w-3 h-0 border-t-2 border-dashed" style={{ borderColor: '#6366F1' }} />
+                      <span className="text-[11px] text-muted-foreground">
+                        {t('reports.netIncome')}
+                      </span>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           )}
@@ -606,11 +636,11 @@ export default function ReportsPage() {
             </ResponsiveContainer>
             ) : (
             <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+              <ComposedChart data={nwTrendData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
                 <defs>
                   <linearGradient id="netWorthGrad" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#6366F1" stopOpacity={0.2} />
-                    <stop offset="95%" stopColor="#6366F1" stopOpacity={0.02} />
+                    <stop offset="5%" stopColor="#6366F1" stopOpacity={0.15} />
+                    <stop offset="95%" stopColor="#6366F1" stopOpacity={0.01} />
                   </linearGradient>
                 </defs>
                 <XAxis
@@ -633,15 +663,38 @@ export default function ReportsPage() {
                   tickCount={5}
                 />
                 <Tooltip
-                  formatter={(value?: number, name?: string) => [
-                    privacyMode ? MASK : formatCurrency(value ?? 0, userCurrency, locale),
-                    name === 'value'
-                      ? t(currentTab.labelKey)
-                      : t(`reports.${name ?? ''}`, { defaultValue: name ?? '' }),
-                  ]}
-                  labelFormatter={(label) => label}
-                  contentStyle={tooltipStyle}
+                  content={({ active, payload, label }) => {
+                    if (!active || !payload || payload.length === 0) return null
+                    const point = payload[0]?.payload as (typeof nwTrendData)[0] | undefined
+                    if (!point) return null
+                    const nw = point.value as number
+                    const delta = point._delta as number
+                    return (
+                      <div style={tooltipStyle} className="px-3 py-2">
+                        <p className="text-xs font-medium mb-1">{label}</p>
+                        <p className="text-xs" style={{ color: '#6366F1' }}>
+                          {t('reports.netWorth')}: {privacyMode ? MASK : formatCurrency(nw, userCurrency, locale)}
+                        </p>
+                        {delta !== 0 && (
+                          <p className="text-xs" style={{ color: delta >= 0 ? '#10B981' : '#F43F5E' }}>
+                            {t('reports.change')}: {privacyMode ? MASK : `${delta >= 0 ? '+' : ''}${formatCurrency(delta, userCurrency, locale)}`}
+                          </p>
+                        )}
+                      </div>
+                    )
+                  }}
                 />
+                {/* Invisible base lifts delta bars to float from prev → current value */}
+                <Bar dataKey="_deltaBase" stackId="nwdelta" fillOpacity={0} stroke="none" maxBarSize={14} isAnimationActive={false} legendType="none" />
+                <Bar dataKey="_deltaSize" stackId="nwdelta" maxBarSize={14} radius={[2, 2, 2, 2]} isAnimationActive={false} legendType="none">
+                  {nwTrendData.map((entry, i) => (
+                    <Cell
+                      key={i}
+                      fill={(entry._delta as number) >= 0 ? '#10B981' : '#F43F5E'}
+                      fillOpacity={(entry._delta as number) === 0 ? 0 : 0.75}
+                    />
+                  ))}
+                </Bar>
                 <Area
                   type="monotone"
                   dataKey="value"
@@ -651,7 +704,7 @@ export default function ReportsPage() {
                   dot={false}
                   activeDot={{ r: 4, fill: '#6366F1' }}
                 />
-              </AreaChart>
+              </ComposedChart>
             </ResponsiveContainer>
             )
           ) : (


### PR DESCRIPTION
Hi everyone, here is a group of suggestions on how to tackle  #219 , I would love to hear what you think


1. Networth - Over time graph:
	Add a waterfall chart overlay to the Networth over time that clearly states your net worth against the last period date. Want to know how much your net worth increased or decresed? Just mouse hover the bar.

<img width="1070" height="405" alt="image" src="https://github.com/user-attachments/assets/ae4d87f5-3622-4db0-b8f0-8ff6a1a5b3c4" />


2. Composition pie charts:
	I Separated the Liabilities from the same pie chart from Accounts and Assets, creating a second one. One represent values that add up to the net worth, other represent the ones that subtracts from it. 

<img width="372" height="395" alt="image" src="https://github.com/user-attachments/assets/f8355708-79d6-4d9b-890f-19d17c5198a4" />

3. Evolution  bar charts:
	Updated  bars to grow to the negative values to the negative  vertical axis of chart. This way it is clear that they contributes by subtracting from the total ammount. 
	Then add the Networth graph overlay to reinforce the idea.

<img width="721" height="397" alt="image" src="https://github.com/user-attachments/assets/92f1f41b-d5ce-456c-b29d-a907fdb91426" />


4. The Composition + pie charts.
	The composition + the pie chart were looking like they were  related, but interacting with one did not affected the other. The "detailed / summary" toggle just affect one of them, while one showed the current composition, while the other showed the history.
		So I made the toggle to affect both of them.
		In detail mode, every asset/account/liability is now sorted by value inside its respective group, so its easy to understand which asset/account contributes the most for the final result.
		I updated the colors so its easy to identify what asset/account/liability belong in which group.

<img width="1068" height="501" alt="image" src="https://github.com/user-attachments/assets/157ab482-f8f7-4c21-9c39-bb2251f80de1" />


	Also,  added a new interaction, by clicking in a bar on the evolution graph, the composition bar update to show info about the current bar selected. By clicking again, it deselect the bar and fallback for the default state, which is to show the composition of the today's net worth. By not interacting with the graph, it haves the same behavior as before. 

https://github.com/user-attachments/assets/c30af55f-9073-49a5-bbe8-398fc144e4ea





- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
