### PR TITLE
add: costa rican colon currency

### DIFF
--- a/backend/app/api/currencies.py
+++ b/backend/app/api/currencies.py
@@ -22,6 +22,12 @@ CURRENCY_META = {
     "UYU": {"symbol": "$U", "name": "Peso Uruguayo", "flag": "\U0001F1FA\U0001F1FE"},
     "INR": {"symbol": "\u20B9", "name": "Indian Rupee", "flag": "\U0001F1EE\U0001F1F3"},
     "SEK": {"symbol": "kr", "name": "Swedish Krona", "flag": "\U0001F1F8\U0001F1EA"},
+    "DKK": {"symbol": "kr", "name": "Danish Krone", "flag": "\U0001F1E9\U0001F1F0"},
+    "NOK": {"symbol": "kr", "name": "Norwegian Krone", "flag": "\U0001F1F3\U0001F1F4"},
+    "PLN": {"symbol": "zł", "name": "Polish Złoty", "flag": "\U0001F1F5\U0001F1F1"},
+    "CZK": {"symbol": "Kč", "name": "Czech Koruna", "flag": "\U0001F1E8\U0001F1FF"},
+    "HUF": {"symbol": "Ft", "name": "Hungarian Forint", "flag": "\U0001F1ED\U0001F1FA"},
+    "RON": {"symbol": "lei", "name": "Romanian Leu", "flag": "\U0001F1F7\U0001F1F4"},
     "CRC": {"symbol": "₡", "name": "Costa Rican Colón", "flag": "\U0001F1E8\U0001F1F7"},
 }
 

--- a/backend/app/api/currencies.py
+++ b/backend/app/api/currencies.py
@@ -22,6 +22,7 @@ CURRENCY_META = {
     "UYU": {"symbol": "$U", "name": "Peso Uruguayo", "flag": "\U0001F1FA\U0001F1FE"},
     "INR": {"symbol": "\u20B9", "name": "Indian Rupee", "flag": "\U0001F1EE\U0001F1F3"},
     "SEK": {"symbol": "kr", "name": "Swedish Krona", "flag": "\U0001F1F8\U0001F1EA"},
+    "CRC": {"symbol": "₡", "name": "Costa Rican Colón", "flag": "\U0001F1E8\U0001F1F7"},
 }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,CRC"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,CRC"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -20,6 +20,12 @@ const currencies = [
   { code: 'AUD', flag: '\u{1F1E6}\u{1F1FA}', symbol: 'A$' },
   { code: 'CHF', flag: '\u{1F1E8}\u{1F1ED}', symbol: 'Fr' },
   { code: 'ARS', flag: '\u{1F1E6}\u{1F1F7}', symbol: '$' },
+  { code: 'DKK', flag: '\u{1F1E9}\u{1F1F0}', symbol: 'kr' },
+  { code: 'NOK', flag: '\u{1F1F3}\u{1F1F4}', symbol: 'kr' },
+  { code: 'PLN', flag: '\u{1F1F5}\u{1F1F1}', symbol: 'zł' },
+  { code: 'CZK', flag: '\u{1F1E8}\u{1F1FF}', symbol: 'Kč' },
+  { code: 'HUF', flag: '\u{1F1ED}\u{1F1FA}', symbol: 'Ft' },
+  { code: 'RON', flag: '\u{1F1F7}\u{1F1F4}', symbol: 'lei' },
   { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
 ] as const
 

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -20,6 +20,7 @@ const currencies = [
   { code: 'AUD', flag: '\u{1F1E6}\u{1F1FA}', symbol: 'A$' },
   { code: 'CHF', flag: '\u{1F1E8}\u{1F1ED}', symbol: 'Fr' },
   { code: 'ARS', flag: '\u{1F1E6}\u{1F1F7}', symbol: '$' },
+  { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
 ] as const
 
 export default function RegisterPage() {

--- a/frontend/src/pages/setup.tsx
+++ b/frontend/src/pages/setup.tsx
@@ -149,6 +149,7 @@ export default function SetupPage() {
                   { code: 'AUD', flag: '\u{1F1E6}\u{1F1FA}', symbol: 'A$' },
                   { code: 'CHF', flag: '\u{1F1E8}\u{1F1ED}', symbol: 'Fr' },
                   { code: 'ARS', flag: '\u{1F1E6}\u{1F1F7}', symbol: '$' },
+                  { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
                 ] as const).map(({ code, flag, symbol }) => (
                   <button
                     key={code}

--- a/frontend/src/pages/setup.tsx
+++ b/frontend/src/pages/setup.tsx
@@ -149,6 +149,12 @@ export default function SetupPage() {
                   { code: 'AUD', flag: '\u{1F1E6}\u{1F1FA}', symbol: 'A$' },
                   { code: 'CHF', flag: '\u{1F1E8}\u{1F1ED}', symbol: 'Fr' },
                   { code: 'ARS', flag: '\u{1F1E6}\u{1F1F7}', symbol: '$' },
+                  { code: 'DKK', flag: '\u{1F1E9}\u{1F1F0}', symbol: 'kr' },
+                  { code: 'NOK', flag: '\u{1F1F3}\u{1F1F4}', symbol: 'kr' },
+                  { code: 'PLN', flag: '\u{1F1F5}\u{1F1F1}', symbol: 'zł' },
+                  { code: 'CZK', flag: '\u{1F1E8}\u{1F1FF}', symbol: 'Kč' },
+                  { code: 'HUF', flag: '\u{1F1ED}\u{1F1FA}', symbol: 'Ft' },
+                  { code: 'RON', flag: '\u{1F1F7}\u{1F1F4}', symbol: 'lei' },
                   { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
                 ] as const).map(({ code, flag, symbol }) => (
                   <button


### PR DESCRIPTION
## What

Costa Rican colón currency has been added.

## Why

Adding support for this currency.

## How to Test

Steps to verify the changes work:

1. Create a new account to see the Costa Rican colón as a currency option.
2. Register a new account to see the same.
3. Go to the workspace settings and change the default currency to Costa Rican Colón.
4. Add new transactions with this currency.

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
