### PR TITLE
fix: switch app display currency when workspace currency changes

### DIFF
--- a/backend/app/api/workspaces.py
+++ b/backend/app/api/workspaces.py
@@ -136,8 +136,19 @@ async def update_workspace(
     workspace = await session.get(Workspace, workspace_id)
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    for key, value in body.model_dump(exclude_unset=True).items():
+    updates = body.model_dump(exclude_unset=True)
+    for key, value in updates.items():
         setattr(workspace, key, value)
+    # Changing the workspace currency follows through to the acting
+    # owner's display currency, so the whole app re-renders in the new
+    # currency (display is driven by user.currency_display, not the
+    # workspace). Other members keep their own currency_display override.
+    new_currency = updates.get("default_currency")
+    if new_currency and (user.preferences or {}).get("currency_display") != new_currency:
+        prefs = dict(user.preferences or {})
+        prefs["currency_display"] = new_currency
+        user.preferences = prefs
+        session.add(user)
     await session.commit()
     await session.refresh(workspace)
     item = WorkspaceRead.model_validate(workspace)
@@ -203,6 +214,19 @@ async def invite_member(
                 password=body.password,
             )
             target = await user_manager.create(create_payload)
+            # A user created to join this workspace inherits its currency
+            # as their display currency, so the app comes up in the
+            # workspace's currency rather than the USD default. Set this
+            # before bootstrapping their Personal workspace below, which
+            # reads currency_display for its own default_currency.
+            ws = await session.get(Workspace, workspace_id)
+            if ws is not None:
+                target.preferences = {
+                    **(target.preferences or {}),
+                    "currency_display": ws.default_currency,
+                }
+                session.add(target)
+                await session.flush()
             # The fresh user gets their own Personal workspace by virtue
             # of the registration hook (called below via on_after_register
             # when request is non-None; programmatic call leaves it empty,

--- a/frontend/src/pages/admin/settings.tsx
+++ b/frontend/src/pages/admin/settings.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { admin as adminApi } from '@/lib/api'
+import { admin as adminApi, currencies as currenciesApi } from '@/lib/api'
 import { useAuth } from '@/contexts/auth-context'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -18,6 +18,13 @@ import {
   DialogFooter,
   DialogDescription,
 } from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { PageHeader } from '@/components/page-header'
 import { Search, Plus, Trash2, Shield, ShieldOff, UserCog, Users, Scale, Tag } from 'lucide-react'
 import type { AdminUser } from '@/types'
@@ -132,6 +139,12 @@ export default function AdminSettingsPage() {
     retry: false,
   })
 
+  const { data: supportedCurrencies } = useQuery({
+    queryKey: ['currencies'],
+    queryFn: currenciesApi.list,
+    staleTime: Infinity,
+  })
+
   const updateProviderCatsMutation = useMutation({
     mutationFn: (value: string) => adminApi.updateSetting('use_provider_categories', value),
     onSuccess: () => {
@@ -150,7 +163,9 @@ export default function AdminSettingsPage() {
     setFormPassword('')
     setFormIsAdmin(false)
     setFormLanguage('en')
-    setFormCurrency('USD')
+    // New users default to the admin's current display currency so they
+    // follow the currency the workspace is running in.
+    setFormCurrency(currentUser?.preferences?.currency_display ?? 'USD')
   }
 
   function openEdit(u: AdminUser) {
@@ -393,7 +408,18 @@ export default function AdminSettingsPage() {
                 </div>
                 <div className="space-y-1.5">
                   <Label className="text-[13px]">{t('setup.currency')}</Label>
-                  <Input value={formCurrency} onChange={(e) => setFormCurrency(e.target.value)} className="h-10 rounded-lg" />
+                  <Select value={formCurrency} onValueChange={setFormCurrency}>
+                    <SelectTrigger className="h-10 rounded-lg w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(supportedCurrencies ?? []).map((c) => (
+                        <SelectItem key={c.code} value={c.code}>
+                          {c.flag} {c.code} — {c.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
               <button

--- a/frontend/src/pages/workspace-settings.tsx
+++ b/frontend/src/pages/workspace-settings.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { currencies as currenciesApi, workspaces as workspacesApi } from '@/lib/api'
+import { auth as authApi, currencies as currenciesApi, workspaces as workspacesApi } from '@/lib/api'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
 import { Button } from '@/components/ui/button'
@@ -74,7 +74,7 @@ export default function WorkspaceSettingsPage() {
   const { t, i18n } = useTranslation()
   const navigate = useNavigate()
   const { current, canManage, workspaces: allWorkspaces, refresh, switchWorkspace } = useWorkspace()
-  const { user: currentUser } = useAuth()
+  const { user: currentUser, updateUser } = useAuth()
   const queryClient = useQueryClient()
 
   const [editName, setEditName] = useState('')
@@ -130,6 +130,12 @@ export default function WorkspaceSettingsPage() {
     onSuccess: () => {
       toast.success(t('workspace.saveSuccess'))
       void refresh()
+      // Changing the workspace currency also updates the acting user's
+      // display currency server-side; refresh the cached user so the
+      // whole app re-renders in the new currency, then drop currency-
+      // dependent queries.
+      void authApi.me().then(updateUser).catch(() => {})
+      void queryClient.invalidateQueries()
     },
     onError: (e: unknown) => {
       const detail =


### PR DESCRIPTION
## What

Changing a workspace's default currency now updates the owner's display currency, so the entire app re-renders in the new currency. Previously the display currency was set once at setup with no way to change it — the workspace currency setting existed but did nothing.

Also: new users created to join a workspace inherit its currency, and the admin "create user" currency field is now a dropdown defaulting to the current currency.

Existing accounts keep their own currency (an account holds a real currency); only the display/consolidation currency follows the change.

## How to test

1. Set up a fresh instance with a currency (e.g. DKK).
2. Workspace Settings → change currency to PLN → app re-renders in PLN.
3. Add a member → they come up in PLN too.