### PR TITLE
feat: add Indonesian Rupiah (IDR)

### DIFF
--- a/backend/app/api/currencies.py
+++ b/backend/app/api/currencies.py
@@ -29,6 +29,7 @@ CURRENCY_META = {
     "HUF": {"symbol": "Ft", "name": "Hungarian Forint", "flag": "\U0001F1ED\U0001F1FA"},
     "RON": {"symbol": "lei", "name": "Romanian Leu", "flag": "\U0001F1F7\U0001F1F4"},
     "CRC": {"symbol": "₡", "name": "Costa Rican Colón", "flag": "\U0001F1E8\U0001F1F7"},
+    "IDR": {"symbol": "Rp", "name": "Indonesian Rupiah", "flag": "\U0001F1EE\U0001F1E9"},
 }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -27,6 +27,7 @@ const currencies = [
   { code: 'HUF', flag: '\u{1F1ED}\u{1F1FA}', symbol: 'Ft' },
   { code: 'RON', flag: '\u{1F1F7}\u{1F1F4}', symbol: 'lei' },
   { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
+  { code: 'IDR', flag: '\u{1F1EE}\u{1F1E9}', symbol: 'Rp' },
 ] as const
 
 export default function RegisterPage() {

--- a/frontend/src/pages/setup.tsx
+++ b/frontend/src/pages/setup.tsx
@@ -156,6 +156,7 @@ export default function SetupPage() {
                   { code: 'HUF', flag: '\u{1F1ED}\u{1F1FA}', symbol: 'Ft' },
                   { code: 'RON', flag: '\u{1F1F7}\u{1F1F4}', symbol: 'lei' },
                   { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
+                  { code: 'IDR', flag: '\u{1F1EE}\u{1F1E9}', symbol: 'Rp' },
                 ] as const).map(({ code, flag, symbol }) => (
                   <button
                     key={code}


### PR DESCRIPTION
## What

Adds **Indonesian Rupiah (IDR, Rp)** to the supported currencies — metadata, default supported list, and the signup/setup pickers.

Thanks @adheizal for the request 🙏

Closes #240

## How to test

1. Create a new account / setup — IDR appears in the currency picker.
2. Set the workspace currency to IDR and add a transaction in another currency — converts to IDR via OER.