### PR TITLE
feat: add COP currency for Colombia

### DIFF
--- a/backend/app/api/currencies.py
+++ b/backend/app/api/currencies.py
@@ -29,6 +29,7 @@ CURRENCY_META = {
     "HUF": {"symbol": "Ft", "name": "Hungarian Forint", "flag": "\U0001F1ED\U0001F1FA"},
     "RON": {"symbol": "lei", "name": "Romanian Leu", "flag": "\U0001F1F7\U0001F1F4"},
     "CRC": {"symbol": "₡", "name": "Costa Rican Colón", "flag": "\U0001F1E8\U0001F1F7"},
+    "COP": {"symbol": "$", "name": "Peso Colombiano", "flag": "\U0001F1E8\U0001F1F4"},
 }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,COP"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -27,6 +27,7 @@ const currencies = [
   { code: 'HUF', flag: '\u{1F1ED}\u{1F1FA}', symbol: 'Ft' },
   { code: 'RON', flag: '\u{1F1F7}\u{1F1F4}', symbol: 'lei' },
   { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
+  { code: 'COP', flag: '\u{1F1E8}\u{1F1F4}', symbol: '$' },
 ] as const
 
 export default function RegisterPage() {

--- a/frontend/src/pages/setup.tsx
+++ b/frontend/src/pages/setup.tsx
@@ -156,6 +156,7 @@ export default function SetupPage() {
                   { code: 'HUF', flag: '\u{1F1ED}\u{1F1FA}', symbol: 'Ft' },
                   { code: 'RON', flag: '\u{1F1F7}\u{1F1F4}', symbol: 'lei' },
                   { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
+                  { code: 'COP', flag: '\u{1F1E8}\u{1F1F4}', symbol: '$' },
                 ] as const).map(({ code, flag, symbol }) => (
                   <button
                     key={code}


### PR DESCRIPTION
## What

Inclusion of Colombian peso (Peso Colombiano)

## Why

Support for COP allows users in Colombia to manage their local finances accurately, leveraging the platform’s currency conversion and asset tracking capabilities.

## How to Test

Steps to verify the changes work:

1. Go to workspace settings
2. Change on default currency to Peso Colombiano
3. Or add new transaction using Peso Colombiano

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)

<img width="757" height="234" alt="imagen" src="https://github.com/user-attachments/assets/74392893-ffdd-4cac-bc2a-ab9ddc384472" />
