### PR TITLE
feat: show investments total in transactions summary (closes #242)

### DIFF
--- a/backend/app/api/transactions.py
+++ b/backend/app/api/transactions.py
@@ -37,6 +37,7 @@ class TransactionsSummary(BaseModel):
     income: float
     expense: float
     net: float
+    investments: float
     currency: str
 
 

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -386,10 +386,33 @@ async def get_transactions(
                 income = Decimal(str(row_total or 0))
             elif row_type == "debit":
                 expense = Decimal(str(row_total or 0))
+        # Investments contributed in the period: debits in the seeded
+        # "Investments" category. Only contributions (debits) count — redemptions
+        # (credits) and ignored transactions are left out — so users can see
+        # "how much did I invest" at a glance. Matched against the seeded category
+        # (treat_as_transfer + localized name); a renamed category won't match.
+        investment_category_ids = select(Category.id).where(
+            Category.workspace_id == workspace_id,
+            Category.treat_as_transfer == True,
+            Category.is_ignored == False,
+            Category.name.in_(["Investments", "Investimentos"]),
+        )
+        inv_subq = base_query.where(
+            Transaction.is_ignored == False,
+            Transaction.type == "debit",
+            Transaction.transfer_pair_id.is_(None),
+            Transaction.category_id.in_(investment_category_ids),
+        ).subquery()
+        inv_amount_norm = func.coalesce(inv_subq.c.amount_primary, inv_subq.c.amount)
+        investments_total = await session.scalar(
+            select(func.coalesce(func.sum(func.abs(inv_amount_norm)), 0))
+        )
+        investments = Decimal(str(investments_total or 0))
         summary = {
             "income": income,
             "expense": expense,
             "net": income - expense,
+            "investments": investments,
         }
 
     # Apply ordering (and pagination unless skipped). Bill-view callers

--- a/backend/tests/test_transaction_service_coverage.py
+++ b/backend/tests/test_transaction_service_coverage.py
@@ -18,6 +18,7 @@ from app.models.account import Account
 from app.models.credit_card_bill import CreditCardBill
 from app.models.group import Group, GroupMember
 from app.models.transaction import Transaction
+from app.models.category import Category
 from app.schemas.transaction import (
     TransactionCreate,
     TransactionUpdate,
@@ -246,6 +247,93 @@ async def test_get_transactions_summary_excludes_ignored(session, test_user, tes
         session, test_workspace.id, test_user.id, include_summary=True
     )
     assert summary["expense"] == Decimal("100")
+
+
+async def _mk_investments_category(session, test_user, test_workspace, name="Investimentos"):
+    cat = Category(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        workspace_id=test_workspace.id,
+        name=name,
+        treat_as_transfer=True,
+    )
+    session.add(cat)
+    await session.flush()
+    return cat
+
+
+async def test_get_transactions_summary_investments_counts_only_contributions(
+    session, test_user, test_workspace, acct
+):
+    """Investments aggregate sums only contributions (debits) in the period,
+    excluding redemptions (credits) and ignored transactions."""
+    inv = await _mk_investments_category(session, test_user, test_workspace)
+    # Contribution (money going into investments) — counts.
+    await _mk_txn(session, test_user, acct, description="Aplicacao CDB",
+                  amount=Decimal("500"), type="debit", category_id=inv.id)
+    await _mk_txn(session, test_user, acct, description="Tesouro Direto",
+                  amount=Decimal("250"), type="debit", category_id=inv.id)
+    # Redemption (money coming back) — must NOT count.
+    await _mk_txn(session, test_user, acct, description="Resgate",
+                  amount=Decimal("999"), type="credit", category_id=inv.id)
+    # Ignored contribution — must NOT count.
+    await _mk_txn(session, test_user, acct, description="Aplicacao ignorada",
+                  amount=Decimal("777"), type="debit", category_id=inv.id, is_ignored=True)
+    # A normal expense in another (non-investment) category — must NOT leak in.
+    await _mk_txn(session, test_user, acct, description="Mercado",
+                  amount=Decimal("80"), type="debit")
+
+    _, _, summary = await get_transactions(
+        session, test_workspace.id, test_user.id, include_summary=True
+    )
+    assert summary["investments"] == Decimal("750")  # 500 + 250 only
+
+
+async def test_get_transactions_summary_investments_zero_when_none(
+    session, test_user, test_workspace, acct
+):
+    """Investments aggregate is 0 when there are no investment transactions."""
+    await _mk_txn(session, test_user, acct, description="Exp", amount=Decimal("10"), type="debit")
+    _, _, summary = await get_transactions(
+        session, test_workspace.id, test_user.id, include_summary=True
+    )
+    assert summary["investments"] == Decimal("0")
+
+
+async def test_get_transactions_summary_investments_excludes_transfer_pairs(
+    session, test_user, test_workspace, acct
+):
+    """A debit in the Investments category that is part of a transfer pair is
+    not counted as a contribution (transfers are flows, not new investment)."""
+    inv = await _mk_investments_category(session, test_user, test_workspace)
+    await _mk_txn(session, test_user, acct, description="Aplicacao",
+                  amount=Decimal("300"), type="debit", category_id=inv.id)
+    await _mk_txn(session, test_user, acct, description="Transfer leg",
+                  amount=Decimal("900"), type="debit", category_id=inv.id,
+                  transfer_pair_id=uuid.uuid4())
+    _, _, summary = await get_transactions(
+        session, test_workspace.id, test_user.id, include_summary=True
+    )
+    assert summary["investments"] == Decimal("300")
+
+
+async def test_get_transactions_summary_investments_uses_primary_amount(
+    session, test_user, test_workspace, acct
+):
+    """Cross-currency contributions are summed using amount_primary when set,
+    falling back to amount otherwise (consistent with income/expense)."""
+    inv = await _mk_investments_category(session, test_user, test_workspace)
+    # Native amount 100 (USD) but stamped primary 520 (BRL) — primary wins.
+    await _mk_txn(session, test_user, acct, description="USD aporte",
+                  amount=Decimal("100"), amount_primary=Decimal("520"),
+                  type="debit", category_id=inv.id)
+    # No primary stamped — falls back to amount.
+    await _mk_txn(session, test_user, acct, description="BRL aporte",
+                  amount=Decimal("80"), type="debit", category_id=inv.id)
+    _, _, summary = await get_transactions(
+        session, test_workspace.id, test_user.id, include_summary=True
+    )
+    assert summary["investments"] == Decimal("600")  # 520 + 80
 
 
 async def test_get_transactions_sorting(session, test_user, test_workspace, acct):

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -283,6 +283,7 @@
     "summaryIncome": "Income",
     "summaryExpenses": "Expenses",
     "summaryNet": "Net",
+    "summaryInvestments": "Investments",
     "bulkCategorize": "Apply",
     "bulkSuccess": "{{count}} transactions categorized",
     "selectCategory": "Select category...",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -283,6 +283,7 @@
     "summaryIncome": "Receitas",
     "summaryExpenses": "Despesas",
     "summaryNet": "Saldo",
+    "summaryInvestments": "Investimentos",
     "bulkCategorize": "Aplicar",
     "bulkSuccess": "{{count}} transações categorizadas",
     "selectCategory": "Selecionar categoria...",

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -1276,6 +1276,12 @@ export default function TransactionsPage() {
                 {mask(formatCurrency(data.summary.net, data.summary.currency, locale))}
               </span>
             </span>
+            <span className="flex items-baseline gap-1.5 text-xs">
+              <span className="text-muted-foreground">{t('transactions.summaryInvestments')}</span>
+              <span className="text-sm font-semibold tabular-nums text-blue-600">
+                {mask(formatCurrency(data.summary.investments, data.summary.currency, locale))}
+              </span>
+            </span>
           </div>
         )}
       </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -589,6 +589,7 @@ export interface TransactionsSummary {
   income: number
   expense: number
   net: number
+  investments: number
   currency: string
 }
 


### PR DESCRIPTION
## What

Adds an **Investments** figure to the per-period summary footer of the transactions page, next to Income / Expenses / Net. It shows how much was *contributed* to investments in the active period.

It reuses the existing summary computation in `transaction_service.py`: a small additional aggregate over the seeded **Investments** category, scoped to the same filters/date range. The aggregate sums **only contributions** — `debit` transactions in the Investments category — excluding redemptions (credits), ignored transactions, transfer-pair legs, and ignored categories. Amounts are normalized to the primary currency (`coalesce(amount_primary, amount)`), consistent with the other figures.

Adds the `investments` field to `TransactionsSummary` (backend schema + frontend type), a footer line (localized EN/PT-BR), and backend tests.

## Why

The Investments category is `treat_as_transfer`, so its transactions are flows rather than P/L. "How much did I invest this period" is a common question that isn't answerable from the current summary. Surfacing it as a separate figure makes it visible without changing the existing Income/Expense/Net values.

## How to Test

1. Open `/transactions` and filter to a period that has investment contributions (e.g. a month with `APLICACAO`/`CDB`/`TESOURO DIRETO` debits categorized as Investments).
2. The footer shows **Investments** = the sum of those contributions for the period.
3. A period with no investment debits shows `0`.
4. Redemptions (credit transactions in the Investments category) and ignored transactions are not counted.

## Checklist

- [x] Backend tests pass (`pytest`) — added 4 tests (contributions only, zero when none, excludes transfer pairs, respects `amount_primary`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (EN + PT-BR)

Closes #242.


