### PR TITLE
feat: add CLP currency for Chile

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/backend/tests/test_currencies_api.py
+++ b/backend/tests/test_currencies_api.py
@@ -22,3 +22,15 @@ async def test_currencies_include_brl_and_usd(client: AsyncClient):
     codes = [c["code"] for c in response.json()]
     assert "BRL" in codes
     assert "USD" in codes
+
+
+@pytest.mark.asyncio
+async def test_currencies_include_clp_with_metadata(client: AsyncClient):
+    response = await client.get("/api/currencies")
+    data = response.json()
+    clp = next((currency for currency in data if currency["code"] == "CLP"), None)
+
+    assert clp is not None
+    assert clp["symbol"] == "$"
+    assert clp["name"] == "Peso Chileno"
+    assert clp["flag"] == "🇨🇱"

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -29,6 +29,7 @@ const currencies = [
   { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
   { code: 'IDR', flag: '\u{1F1EE}\u{1F1E9}', symbol: 'Rp' },
   { code: 'COP', flag: '\u{1F1E8}\u{1F1F4}', symbol: '$' },
+  { code: 'CLP', flag: '\u{1F1E8}\u{1F1F1}', symbol: '$' },
 ] as const
 
 export default function RegisterPage() {

--- a/frontend/src/pages/setup.tsx
+++ b/frontend/src/pages/setup.tsx
@@ -158,6 +158,7 @@ export default function SetupPage() {
                   { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
                   { code: 'IDR', flag: '\u{1F1EE}\u{1F1E9}', symbol: 'Rp' },
                   { code: 'COP', flag: '\u{1F1E8}\u{1F1F4}', symbol: '$' },
+                  { code: 'CLP', flag: '\u{1F1E8}\u{1F1F1}', symbol: '$' },
                 ] as const).map(({ code, flag, symbol }) => (
                   <button
                     key={code}


### PR DESCRIPTION
  ## What

  Inclusion of Chilean Peso (Peso Chileno)

  ## Why

  Support for CLP allows users in Chile to manage their local finances accurately, leveraging the platform's currency conversion and asset tracking capabilities.

  ## How to Test

  1. Go to workspace settings and change default currency to Peso Chileno
  2. Open the registration page and confirm CLP appears as a currency option
  3. Open the setup flow and confirm CLP appears there as well
  4. Call `GET /api/currencies` and verify `CLP` is returned with:
     - symbol: `$`
     - name: `Peso Chileno`
     - flag: 🇨🇱

  ## Checklist

  - [x] Backend tests pass (`pytest`)
  - [x] Frontend lints clean (`npm run lint`)
  - [x] Frontend builds (`npm run build`)
  - [ ] Translations updated (if user-facing strings changed)



The only tests that didn’t pass were the ones related to AI agents.