### PR TITLE
feat(setup): redesign onboarding setup page

### DIFF
--- a/frontend/src/components/auth-brand-panel.tsx
+++ b/frontend/src/components/auth-brand-panel.tsx
@@ -1,0 +1,71 @@
+import { useTranslation } from 'react-i18next'
+import { ShellLogo } from '@/components/shell-logo'
+
+// Left-hand brand panel for the auth/onboarding screens. A deep indigo→violet
+// field with a slow purple aurora drifting behind an oversized, translucent
+// shell watermark. Decorative only — hidden below `lg`, where the form takes
+// the full width and carries its own compact header.
+export function AuthBrandPanel() {
+  const { t } = useTranslation()
+
+  return (
+    <div
+      className="relative hidden overflow-hidden p-12 text-white lg:flex lg:flex-col lg:justify-between"
+      style={{
+        background:
+          'linear-gradient(150deg, #3F37C9 0%, #5B30C9 48%, #6D28D9 100%)',
+      }}
+    >
+      {/* Soft animated aurora */}
+      <div aria-hidden className="pointer-events-none absolute inset-0">
+        <div className="securo-aurora securo-aurora-1" />
+        <div className="securo-aurora securo-aurora-2" />
+        <div className="securo-aurora securo-aurora-3" />
+      </div>
+
+      {/* Oversized translucent shell, bleeding off the lower-right edge */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-28 -bottom-24 text-white/[0.06]"
+        style={{ transform: 'rotate(-8deg)' }}
+      >
+        <ShellLogo size={640} />
+      </div>
+
+      {/* Depth: gentle vignette toward the edges */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(115% 90% at 78% 8%, transparent 42%, rgba(20, 12, 60, 0.38) 100%)',
+        }}
+      />
+
+      {/* Wordmark */}
+      <div className="relative flex items-center gap-2.5">
+        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/15">
+          <ShellLogo size={20} className="text-white" />
+        </div>
+        <span className="text-lg font-semibold tracking-tight">Securo</span>
+      </div>
+
+      {/* Tagline */}
+      <div className="relative max-w-md space-y-5">
+        <h2 className="text-[2.6rem] font-semibold leading-[1.08] tracking-tight">
+          {t('setup.brandTagline')}
+        </h2>
+        <p className="max-w-sm text-base leading-relaxed text-white/70">
+          {t('setup.brandSubtitle')}
+        </p>
+        <div className="flex items-center gap-2.5 pt-1 text-xs font-medium text-white/55">
+          <span>{t('setup.brandOpen')}</span>
+          <span className="h-1 w-1 rounded-full bg-white/35" />
+          <span>{t('setup.brandSelfHosted')}</span>
+          <span className="h-1 w-1 rounded-full bg-white/35" />
+          <span>{t('setup.brandPrivate')}</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/currency-select.tsx
+++ b/frontend/src/components/currency-select.tsx
@@ -1,0 +1,58 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+
+// Shared across the setup and register flows. A compact dropdown keeps these
+// forms short instead of rendering one button per currency in a tall grid.
+export const CURRENCIES = [
+  { code: 'USD', flag: '\u{1F1FA}\u{1F1F8}', symbol: '$' },
+  { code: 'EUR', flag: '\u{1F1EA}\u{1F1FA}', symbol: '€' },
+  { code: 'GBP', flag: '\u{1F1EC}\u{1F1E7}', symbol: '£' },
+  { code: 'BRL', flag: '\u{1F1E7}\u{1F1F7}', symbol: 'R$' },
+  { code: 'CAD', flag: '\u{1F1E8}\u{1F1E6}', symbol: 'C$' },
+  { code: 'AUD', flag: '\u{1F1E6}\u{1F1FA}', symbol: 'A$' },
+  { code: 'CHF', flag: '\u{1F1E8}\u{1F1ED}', symbol: 'Fr' },
+  { code: 'ARS', flag: '\u{1F1E6}\u{1F1F7}', symbol: '$' },
+  { code: 'DKK', flag: '\u{1F1E9}\u{1F1F0}', symbol: 'kr' },
+  { code: 'NOK', flag: '\u{1F1F3}\u{1F1F4}', symbol: 'kr' },
+  { code: 'PLN', flag: '\u{1F1F5}\u{1F1F1}', symbol: 'zł' },
+  { code: 'CZK', flag: '\u{1F1E8}\u{1F1FF}', symbol: 'Kč' },
+  { code: 'HUF', flag: '\u{1F1ED}\u{1F1FA}', symbol: 'Ft' },
+  { code: 'RON', flag: '\u{1F1F7}\u{1F1F4}', symbol: 'lei' },
+  { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
+  { code: 'IDR', flag: '\u{1F1EE}\u{1F1E9}', symbol: 'Rp' },
+  { code: 'COP', flag: '\u{1F1E8}\u{1F1F4}', symbol: '$' },
+  { code: 'CLP', flag: '\u{1F1E8}\u{1F1F1}', symbol: '$' },
+  { code: 'DOP', flag: '\u{1F1E9}\u{1F1F4}', symbol: 'RD$' },
+] as const
+
+interface CurrencySelectProps {
+  value: string
+  onChange: (code: string) => void
+  id?: string
+  className?: string
+}
+
+export function CurrencySelect({ value, onChange, id, className }: CurrencySelectProps) {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger id={id} className={cn('w-full', className)}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {CURRENCIES.map(({ code, flag, symbol }) => (
+          <SelectItem key={code} value={code}>
+            <span className="text-base leading-none">{flag}</span>
+            <span className="font-medium">{code}</span>
+            <span className="text-muted-foreground text-xs">{symbol}</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,3 +149,59 @@
 .securo-highlight-flash {
   animation: securo-highlight-flash 2.4s ease-out;
 }
+
+/* Soft ambient aurora for the auth brand panel. Drifting, blurred purple
+   blobs over a deep indigo base — slow enough to feel alive, not busy.
+   Only transform/opacity animate, never layout. */
+@keyframes securo-aurora-1 {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(1); }
+  50% { transform: translate3d(7%, 10%, 0) scale(1.18); }
+}
+@keyframes securo-aurora-2 {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(1.12); }
+  50% { transform: translate3d(-9%, -7%, 0) scale(1); }
+}
+@keyframes securo-aurora-3 {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(1); }
+  50% { transform: translate3d(6%, -11%, 0) scale(1.22); }
+}
+
+.securo-aurora {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(72px);
+  will-change: transform;
+}
+.securo-aurora-1 {
+  top: -12%;
+  left: -8%;
+  width: 62%;
+  height: 62%;
+  opacity: 0.55;
+  background: radial-gradient(circle at center, #818cf8 0%, transparent 70%);
+  animation: securo-aurora-1 24s ease-in-out infinite;
+}
+.securo-aurora-2 {
+  right: -12%;
+  bottom: -18%;
+  width: 68%;
+  height: 68%;
+  opacity: 0.5;
+  background: radial-gradient(circle at center, #a78bfa 0%, transparent 70%);
+  animation: securo-aurora-2 29s ease-in-out infinite;
+}
+.securo-aurora-3 {
+  top: 28%;
+  left: 22%;
+  width: 46%;
+  height: 46%;
+  opacity: 0.4;
+  background: radial-gradient(circle at center, #c4b5fd 0%, transparent 70%);
+  animation: securo-aurora-3 33s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .securo-aurora {
+    animation: none;
+  }
+}

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -19,7 +19,15 @@ i18n
       en: { translation: en },
       es: { translation: es },
     },
-    fallbackLng: 'pt-BR',
+    fallbackLng: 'en',
+    // English is the default. Honour an explicit, persisted choice
+    // (querystring/localStorage/cookie) but do NOT auto-pick the browser
+    // language — otherwise a pt-BR/es-* browser would override the English
+    // default before the user ever chooses.
+    detection: {
+      order: ['querystring', 'localStorage', 'cookie'],
+      caches: ['localStorage'],
+    },
     interpolation: {
       escapeValue: false,
     },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1086,7 +1086,7 @@
     "recentTransactions": "Recent transactions",
     "recentTransactionsHint": "Transactions split through this group",
     "viewAllTransactions": "View all",
-    "noTransactions": "No transactions split through this group yet",
+    "noTransactions": "No transactions found.",
     "splitWays": "split {{count}} ways",
     "isSelf": "This is me",
     "balances": "Balances",
@@ -1108,7 +1108,6 @@
     "txActionCreate": "Create a new transaction",
     "txActionExisting": "Link an existing transaction",
     "searchTransaction": "Search transactions by description...",
-    "noTransactions": "No transactions found.",
     "selectedTransaction": "Selected",
     "settled": "Settlement recorded",
     "settlements": "Settlements",
@@ -1155,7 +1154,12 @@
     "theme": "Theme",
     "currency": "Currency",
     "name": "Your name",
-    "namePlaceholder": "How should we call you?"
+    "namePlaceholder": "How should we call you?",
+    "brandTagline": "Own your finances.",
+    "brandSubtitle": "Self-hosted personal finance that keeps you in control. Your money, your data, your rules.",
+    "brandOpen": "Open source",
+    "brandSelfHosted": "Self-hosted",
+    "brandPrivate": "Private by design"
   },
   "backup": {
     "button": "Backup",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1084,7 +1084,7 @@
     "recentTransactions": "Transacciones recientes",
     "recentTransactionsHint": "Transacciones divididas a través de este grupo",
     "viewAllTransactions": "Ver todo",
-    "noTransactions": "Aún no hay transacciones divididas en este grupo",
+    "noTransactions": "No se encontraron transacciones.",
     "splitWays": "dividir en {{count}} partes",
     "isSelf": "Soy yo",
     "balances": "Saldos",
@@ -1106,7 +1106,6 @@
     "txActionCreate": "Crear una nueva transacción",
     "txActionExisting": "Vincular una transacción existente",
     "searchTransaction": "Buscar transacciones por descripción...",
-    "noTransactions": "No se encontraron transacciones.",
     "selectedTransaction": "Seleccionada",
     "settled": "Liquidación registrada",
     "settlements": "Liquidaciones",
@@ -1153,7 +1152,12 @@
     "theme": "Tema",
     "currency": "Moneda",
     "name": "Tu nombre",
-    "namePlaceholder": "¿Cómo deberíamos llamarte?"
+    "namePlaceholder": "¿Cómo deberíamos llamarte?",
+    "brandTagline": "Sé dueño de tus finanzas.",
+    "brandSubtitle": "Finanzas personales self-hosted, con el control en tus manos. Tu dinero, tus datos, tus reglas.",
+    "brandOpen": "Código abierto",
+    "brandSelfHosted": "Self-hosted",
+    "brandPrivate": "Privado por diseño"
   },
   "backup": {
     "button": "Copia de seguridad",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1086,7 +1086,7 @@
     "recentTransactions": "Transações recentes",
     "recentTransactionsHint": "Transações divididas neste grupo",
     "viewAllTransactions": "Ver todas",
-    "noTransactions": "Ainda não há transações divididas neste grupo",
+    "noTransactions": "Nenhuma transação encontrada.",
     "splitWays": "dividida entre {{count}}",
     "isSelf": "Sou eu",
     "balances": "Saldos",
@@ -1108,7 +1108,6 @@
     "txActionCreate": "Criar uma nova transação",
     "txActionExisting": "Vincular uma transação existente",
     "searchTransaction": "Buscar transações pela descrição...",
-    "noTransactions": "Nenhuma transação encontrada.",
     "selectedTransaction": "Selecionada",
     "settled": "Acerto registrado",
     "settlements": "Acertos",
@@ -1155,7 +1154,12 @@
     "theme": "Tema",
     "currency": "Moeda",
     "name": "Seu nome",
-    "namePlaceholder": "Como devemos te chamar?"
+    "namePlaceholder": "Como devemos te chamar?",
+    "brandTagline": "Seja dono das suas finanças.",
+    "brandSubtitle": "Finanças pessoais self-hosted, com você no controle. Seu dinheiro, seus dados, suas regras.",
+    "brandOpen": "Código aberto",
+    "brandSelfHosted": "Self-hosted",
+    "brandPrivate": "Privado por padrão"
   },
   "backup": {
     "button": "Backup",

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -8,31 +8,9 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardFooter } from '@/components/ui/card'
+import { CurrencySelect } from '@/components/currency-select'
 import { ShellLogo } from '@/components/shell-logo'
-import { cn } from '@/lib/utils'
 import type { AxiosError } from 'axios'
-
-const currencies = [
-  { code: 'USD', flag: '\u{1F1FA}\u{1F1F8}', symbol: '$' },
-  { code: 'EUR', flag: '\u{1F1EA}\u{1F1FA}', symbol: '\u20AC' },
-  { code: 'GBP', flag: '\u{1F1EC}\u{1F1E7}', symbol: '\u00A3' },
-  { code: 'BRL', flag: '\u{1F1E7}\u{1F1F7}', symbol: 'R$' },
-  { code: 'CAD', flag: '\u{1F1E8}\u{1F1E6}', symbol: 'C$' },
-  { code: 'AUD', flag: '\u{1F1E6}\u{1F1FA}', symbol: 'A$' },
-  { code: 'CHF', flag: '\u{1F1E8}\u{1F1ED}', symbol: 'Fr' },
-  { code: 'ARS', flag: '\u{1F1E6}\u{1F1F7}', symbol: '$' },
-  { code: 'DKK', flag: '\u{1F1E9}\u{1F1F0}', symbol: 'kr' },
-  { code: 'NOK', flag: '\u{1F1F3}\u{1F1F4}', symbol: 'kr' },
-  { code: 'PLN', flag: '\u{1F1F5}\u{1F1F1}', symbol: 'zł' },
-  { code: 'CZK', flag: '\u{1F1E8}\u{1F1FF}', symbol: 'Kč' },
-  { code: 'HUF', flag: '\u{1F1ED}\u{1F1FA}', symbol: 'Ft' },
-  { code: 'RON', flag: '\u{1F1F7}\u{1F1F4}', symbol: 'lei' },
-  { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
-  { code: 'IDR', flag: '\u{1F1EE}\u{1F1E9}', symbol: 'Rp' },
-  { code: 'COP', flag: '\u{1F1E8}\u{1F1F4}', symbol: '$' },
-  { code: 'CLP', flag: '\u{1F1E8}\u{1F1F1}', symbol: '$' },
-  { code: 'DOP', flag: '\u{1F1E9}\u{1F1F4}', symbol: 'RD$' },
-] as const
 
 export default function RegisterPage() {
   const { t, i18n } = useTranslation()
@@ -134,27 +112,9 @@ export default function RegisterPage() {
                 required
               />
             </div>
-            <div className="space-y-2 pt-1">
-              <Label className="text-sm">{t('auth.currency')}</Label>
-              <div className="grid grid-cols-4 gap-2">
-                {currencies.map(({ code, flag, symbol }) => (
-                  <button
-                    key={code}
-                    type="button"
-                    onClick={() => setCurrency(code)}
-                    className={cn(
-                      'flex flex-col items-center gap-1 py-2.5 rounded-lg border transition-all',
-                      currency === code
-                        ? 'border-primary bg-primary/10 text-primary ring-1 ring-primary/30'
-                        : 'border-border text-muted-foreground hover:border-foreground/20 hover:text-foreground'
-                    )}
-                  >
-                    <span className="text-lg leading-none">{flag}</span>
-                    <span className="text-[11px] font-bold">{code}</span>
-                    <span className="text-[10px] opacity-60">{symbol}</span>
-                  </button>
-                ))}
-              </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="currency" className="text-sm">{t('auth.currency')}</Label>
+              <CurrencySelect id="currency" value={currency} onChange={setCurrency} />
             </div>
           </CardContent>
           <CardFooter className="flex flex-col gap-4 px-8 pb-8 pt-2">

--- a/frontend/src/pages/setup.tsx
+++ b/frontend/src/pages/setup.tsx
@@ -9,6 +9,8 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardFooter } from '@/components/ui/card'
+import { CurrencySelect } from '@/components/currency-select'
+import { AuthBrandPanel } from '@/components/auth-brand-panel'
 import { cn } from '@/lib/utils'
 import { Sun, Moon, Globe } from 'lucide-react'
 import { ShellLogo } from '@/components/shell-logo'
@@ -75,11 +77,13 @@ export default function SetupPage() {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-background px-4">
-      <Card className="w-full max-w-[400px] shadow-sm">
+    <div className="min-h-screen lg:grid lg:grid-cols-2">
+      <AuthBrandPanel />
+      <div className="flex min-h-screen items-center justify-center bg-background px-4 py-10">
+      <Card className="w-full max-w-[400px] border-border/60 shadow-sm">
         <form onSubmit={handleSubmit}>
           <div className="flex flex-col items-center pt-8 pb-2 px-8">
-            <div className="w-11 h-11 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
+            <div className="w-11 h-11 rounded-xl bg-primary/10 flex items-center justify-center mb-4 lg:hidden">
               <ShellLogo size={22} className="text-primary" />
             </div>
             <h1 className="text-xl font-semibold tracking-tight">{t('setup.title')}</h1>
@@ -91,6 +95,81 @@ export default function SetupPage() {
                 {error}
               </div>
             )}
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-1.5">
+                <Label className="text-sm flex items-center gap-1.5">
+                  <Globe size={14} />
+                  {t('setup.language')}
+                </Label>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => i18n.changeLanguage('en')}
+                    className={cn(
+                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
+                      currentLang === 'en'
+                        ? 'bg-primary/15 text-primary'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    EN
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => i18n.changeLanguage('es')}
+                    className={cn(
+                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
+                      currentLang === 'es'
+                        ? 'bg-primary/15 text-primary'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    ES
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => i18n.changeLanguage('pt-BR')}
+                    className={cn(
+                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
+                      currentLang === 'pt-BR'
+                        ? 'bg-primary/15 text-primary'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    PT
+                  </button>
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-sm">{t('setup.theme')}</Label>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => setTheme('light')}
+                    className={cn(
+                      'p-1.5 rounded transition-colors',
+                      theme === 'light'
+                        ? 'bg-primary/15 text-primary'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    <Sun size={14} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setTheme('dark')}
+                    className={cn(
+                      'p-1.5 rounded transition-colors',
+                      theme === 'dark'
+                        ? 'bg-primary/15 text-primary'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    <Moon size={14} />
+                  </button>
+                </div>
+              </div>
+            </div>
             <div className="space-y-1.5">
               <Label htmlFor="name" className="text-sm">{t('setup.name')}</Label>
               <Input
@@ -138,122 +217,9 @@ export default function SetupPage() {
                 minLength={8}
               />
             </div>
-            <div className="space-y-2 pt-1">
-              <Label className="text-sm">{t('setup.currency')}</Label>
-              <div className="grid grid-cols-4 gap-2">
-                {([
-                  { code: 'USD', flag: '\u{1F1FA}\u{1F1F8}', symbol: '$' },
-                  { code: 'EUR', flag: '\u{1F1EA}\u{1F1FA}', symbol: '\u20AC' },
-                  { code: 'GBP', flag: '\u{1F1EC}\u{1F1E7}', symbol: '\u00A3' },
-                  { code: 'BRL', flag: '\u{1F1E7}\u{1F1F7}', symbol: 'R$' },
-                  { code: 'CAD', flag: '\u{1F1E8}\u{1F1E6}', symbol: 'C$' },
-                  { code: 'AUD', flag: '\u{1F1E6}\u{1F1FA}', symbol: 'A$' },
-                  { code: 'CHF', flag: '\u{1F1E8}\u{1F1ED}', symbol: 'Fr' },
-                  { code: 'ARS', flag: '\u{1F1E6}\u{1F1F7}', symbol: '$' },
-                  { code: 'DKK', flag: '\u{1F1E9}\u{1F1F0}', symbol: 'kr' },
-                  { code: 'NOK', flag: '\u{1F1F3}\u{1F1F4}', symbol: 'kr' },
-                  { code: 'PLN', flag: '\u{1F1F5}\u{1F1F1}', symbol: 'zł' },
-                  { code: 'CZK', flag: '\u{1F1E8}\u{1F1FF}', symbol: 'Kč' },
-                  { code: 'HUF', flag: '\u{1F1ED}\u{1F1FA}', symbol: 'Ft' },
-                  { code: 'RON', flag: '\u{1F1F7}\u{1F1F4}', symbol: 'lei' },
-                  { code: 'CRC', flag: '\u{1F1E8}\u{1F1F7}', symbol: '₡' },
-                  { code: 'IDR', flag: '\u{1F1EE}\u{1F1E9}', symbol: 'Rp' },
-                  { code: 'COP', flag: '\u{1F1E8}\u{1F1F4}', symbol: '$' },
-                  { code: 'CLP', flag: '\u{1F1E8}\u{1F1F1}', symbol: '$' },
-                  { code: 'DOP', flag: '\u{1F1E9}\u{1F1F4}', symbol: 'RD$' },
-                ] as const).map(({ code, flag, symbol }) => (
-                  <button
-                    key={code}
-                    type="button"
-                    onClick={() => setCurrency(code)}
-                    className={cn(
-                      'flex flex-col items-center gap-1 py-2.5 rounded-lg border transition-all',
-                      currency === code
-                        ? 'border-primary bg-primary/10 text-primary ring-1 ring-primary/30'
-                        : 'border-border text-muted-foreground hover:border-foreground/20 hover:text-foreground'
-                    )}
-                  >
-                    <span className="text-lg leading-none">{flag}</span>
-                    <span className="text-[11px] font-bold">{code}</span>
-                    <span className="text-[10px] opacity-60">{symbol}</span>
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div className="flex items-center justify-between gap-4 pt-1">
-              <div className="space-y-1.5">
-                <Label className="text-sm flex items-center gap-1.5">
-                  <Globe size={14} />
-                  {t('setup.language')}
-                </Label>
-                <div className="flex items-center gap-1">
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('pt-BR')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'pt-BR'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    PT
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('en')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'en'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    EN
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('es')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'es'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    ES
-                  </button>
-                </div>
-              </div>
-              <div className="space-y-1.5">
-                <Label className="text-sm">{t('setup.theme')}</Label>
-                <div className="flex items-center gap-1">
-                  <button
-                    type="button"
-                    onClick={() => setTheme('light')}
-                    className={cn(
-                      'p-1.5 rounded transition-colors',
-                      theme === 'light'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    <Sun size={14} />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setTheme('dark')}
-                    className={cn(
-                      'p-1.5 rounded transition-colors',
-                      theme === 'dark'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    <Moon size={14} />
-                  </button>
-                </div>
-              </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="currency" className="text-sm">{t('setup.currency')}</Label>
+              <CurrencySelect id="currency" value={currency} onChange={setCurrency} />
             </div>
           </CardContent>
           <CardFooter className="px-8 pb-8 pt-2">
@@ -263,6 +229,7 @@ export default function SetupPage() {
           </CardFooter>
         </form>
       </Card>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What
- Split-screen setup page: branded panel (soft animated aurora, translucent shell watermark, localized tagline) + form.
- Default language English; removed browser auto-detect override.
- Language selector moved above name, alphabetized (EN/ES/PT), theme toggle alongside.
- Replaced the 19-button currency grid with a shared compact `CurrencySelect` dropdown, reused in register to drop duplication.
- Brand copy added for en / pt-BR / es.

## Verification
- `npm run lint` — 0 errors.
- `npm run build` — typecheck + vite build pass.
- Checked desktop and mobile (430px); PT/ES/EN taglines verified in browser.