### PR TITLE
fix(sync): import transactions for Enable Banking and repair background sync

### DIFF
--- a/backend/app/providers/enable_banking.py
+++ b/backend/app/providers/enable_banking.py
@@ -438,17 +438,45 @@ class EnableBankingProvider(BankProvider):
         # Backward compat: plaintext during dev.
         return credentials.get("session_id") or ""
 
+    @staticmethod
+    def _account_uids(session_data: dict) -> list[str]:
+        """Extract account uids from a GET /sessions payload.
+
+        EB exposes the uids in two shapes and neither carries the account
+        name/type: `accounts` is a list of uid *strings*, while
+        `accounts_data` is a list of objects keyed by `uid` (plus identity
+        hashes only). The human-readable name/type/currency live behind
+        /accounts/{uid}/details, fetched per account below.
+        """
+        uids: list[str] = []
+        for entry in session_data.get("accounts_data") or []:
+            if isinstance(entry, dict):
+                uid = entry.get("uid") or entry.get("account_uid")
+                if uid:
+                    uids.append(uid)
+        if uids:
+            return uids
+        # Fallback: `accounts` is a plain list of uid strings.
+        return [a for a in (session_data.get("accounts") or []) if isinstance(a, str)]
+
     async def get_accounts(self, credentials: dict) -> list[AccountData]:
         session_id = self._session_id(credentials)
         if not session_id:
             raise SessionExpiredError("Enable Banking session_id missing")
         data = await self._request("GET", f"/sessions/{session_id}")
-        accounts_raw = data.get("accounts") or []
         result: list[AccountData] = []
-        for raw_acc in accounts_raw:
-            if isinstance(raw_acc, str):
+        for uid in self._account_uids(data):
+            try:
+                details = await self._request("GET", f"/accounts/{uid}/details")
+            except (httpx.HTTPError, SessionExpiredError) as exc:
+                # Without details we can't safely name/type the account, and a
+                # bare-uid AccountData would overwrite the stored name with a
+                # placeholder. Skip this account for this run (non-destructive:
+                # the existing row and its transactions are left intact and the
+                # next sync retries) rather than corrupt it.
+                logger.warning("Failed to fetch details for account %s: %s", uid, exc)
                 continue
-            result.append(await self._build_account(raw_acc))
+            result.append(await self._build_account(details))
         return result
 
     async def get_transactions(

--- a/backend/app/tasks/sync_tasks.py
+++ b/backend/app/tasks/sync_tasks.py
@@ -63,7 +63,15 @@ async def _sync_all() -> int:
 async def _sync_one(session_maker, connection_id: uuid.UUID, user_id: uuid.UUID) -> None:
     """Sync a single connection. Error status is set by sync_connection itself."""
     async with session_maker() as session:
-        await connection_service.sync_connection(session, connection_id, user_id)
+        workspace_id = await session.scalar(
+            select(BankConnection.workspace_id).where(BankConnection.id == connection_id)
+        )
+        if workspace_id is None:
+            logger.warning("Connection %s has no workspace; skipping sync", connection_id)
+            return
+        await connection_service.sync_connection(
+            session, connection_id, workspace_id, user_id
+        )
 
 
 @celery_app.task(name="app.tasks.sync_tasks.sync_all_connections")
@@ -89,6 +97,15 @@ async def _sync_one_celery(connection_id: str, user_id: str) -> None:
     engine, session_maker = _make_session_maker()
     try:
         async with session_maker() as session:
-            await connection_service.sync_connection(session, uuid.UUID(connection_id), uuid.UUID(user_id))
+            conn_uuid = uuid.UUID(connection_id)
+            workspace_id = await session.scalar(
+                select(BankConnection.workspace_id).where(BankConnection.id == conn_uuid)
+            )
+            if workspace_id is None:
+                logger.warning("Connection %s has no workspace; skipping sync", connection_id)
+                return
+            await connection_service.sync_connection(
+                session, conn_uuid, workspace_id, uuid.UUID(user_id)
+            )
     finally:
         await engine.dispose()


### PR DESCRIPTION
## Problem
Enable Banking connections imported transactions on connect, then every later sync imported nothing while still reporting success and advancing the "last synced" time.

Two bugs:
1. `get_accounts()` returned `[]`. EB's `GET /sessions/{id}` lists account UIDs in `accounts` as **strings**; the loop skipped every string. With no accounts, the sync fetched no transactions but still advanced `last_sync_at`.
2. Celery background sync threw `TypeError: sync_connection() missing 1 required positional argument` every run — `workspace_id` was never passed.

## Fix
- `get_accounts()` extracts UIDs and fetches name/type/currency from `/accounts/{uid}/details`.
- Background sync passes `workspace_id`.

Verified live: Revolut 186→197, Caisse 116→118, fresh inserts confirmed. `ruff check` passes.

Fixes #255