### PR TITLE
fix(compose): add mcp-server and agents/EnableBanking wiring to prod

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,10 +14,41 @@ x-backend-env: &backend-env
   FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
   PLUGGY_CLIENT_ID: ${PLUGGY_CLIENT_ID:-}
   PLUGGY_CLIENT_SECRET: ${PLUGGY_CLIENT_SECRET:-}
-  OPENEXCHANGERATES_APP_ID: ${OPENEXCHANGERATES_APP_ID:-}
   PLUGGY_OAUTH_REDIRECT_URI: ${PLUGGY_OAUTH_REDIRECT_URI:-http://localhost:3000/oauth/callback}
+  ENABLE_BANKING_APP_ID: ${ENABLE_BANKING_APP_ID:-}
+  ENABLE_BANKING_PRIVATE_KEY_FILE: ${ENABLE_BANKING_PRIVATE_KEY_FILE:-/app/secrets/enable_banking_private.pem}
+  ENABLE_BANKING_API_URL: ${ENABLE_BANKING_API_URL:-https://api.enablebanking.com}
+  ENABLE_BANKING_OAUTH_REDIRECT_URI: ${ENABLE_BANKING_OAUTH_REDIRECT_URI:-http://localhost:3000/oauth/callback}
+  SIMPLEFIN_ENABLED: ${SIMPLEFIN_ENABLED:-false}
+  SIMPLEFIN_API_URL: ${SIMPLEFIN_API_URL:-https://beta-bridge.simplefin.org}
+  OPENEXCHANGERATES_APP_ID: ${OPENEXCHANGERATES_APP_ID:-}
+  FX_SYNC_MODE: ${FX_SYNC_MODE:-on_demand}
   REDIS_URL: redis://redis:6379/0
   STORAGE_LOCAL_PATH: /app/data/attachments
+  AGENTS_KNOWLEDGE_STORAGE_PATH: /app/data/agent_knowledge
+  # Agents/LLM feature — opt-in. Off by default so existing users pay
+  # zero cost. Run `docker compose -f docker-compose.prod.yml --profile
+  # agents up` after enabling.
+  AGENTS_ENABLED: ${AGENTS_ENABLED:-false}
+  AGENTS_BUILTIN_MCP_URL: ${AGENTS_BUILTIN_MCP_URL:-http://mcp-server:8765/mcp}
+  AGENTS_EXTRA_MCP_SERVERS: ${AGENTS_EXTRA_MCP_SERVERS:-}
+  AGENTS_MCP_JWT_SECRET: ${AGENTS_MCP_JWT_SECRET:-dev-mcp-secret-change-in-production}
+  # TTL for tokens minted from /agents/connections → "External MCP access".
+  # Used by Claude Desktop, n8n, custom clients plugging into Securo.
+  AGENTS_MCP_EXTERNAL_TTL_DAYS: ${AGENTS_MCP_EXTERNAL_TTL_DAYS:-90}
+  # LLM provider config — only the provider you actually use needs setting.
+  AGENTS_DEFAULT_PROVIDER: ${AGENTS_DEFAULT_PROVIDER:-ollama}
+  AGENTS_DEFAULT_MODEL: ${AGENTS_DEFAULT_MODEL:-}
+  AGENTS_OLLAMA_BASE_URL: ${AGENTS_OLLAMA_BASE_URL:-http://ollama:11434}
+  AGENTS_OPENAI_API_KEY: ${AGENTS_OPENAI_API_KEY:-}
+  AGENTS_ANTHROPIC_API_KEY: ${AGENTS_ANTHROPIC_API_KEY:-}
+  AGENTS_OPENAI_COMPAT_BASE_URL: ${AGENTS_OPENAI_COMPAT_BASE_URL:-}
+  AGENTS_OPENAI_COMPAT_API_KEY: ${AGENTS_OPENAI_COMPAT_API_KEY:-}
+  # Knowledge-base embeddings. `native` (default) uses fastembed with a
+  # bundled multilingual model — zero external setup. Override with
+  # ollama/openai/openai_compatible for better quality.
+  AGENTS_EMBEDDING_PROVIDER: ${AGENTS_EMBEDDING_PROVIDER:-native}
+  AGENTS_EMBEDDING_MODEL: ${AGENTS_EMBEDDING_MODEL:-sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2}
 
 x-backend-base: &backend-base
   image: ghcr.io/securo-finance/securo-backend:latest
@@ -26,7 +57,10 @@ x-backend-base: &backend-base
     db: { condition: service_healthy }
     redis: { condition: service_healthy }
   volumes:
+    - ./secrets:/app/secrets:ro
     - attachments:/app/data/attachments
+    - agent_knowledge:/app/data/agent_knowledge
+    - agent_embedding_models:/app/data/embedding_models
   restart: unless-stopped
 
 services:
@@ -81,6 +115,24 @@ services:
     <<: *backend-base
     command: celery -A app.worker beat --loglevel=info
 
+  # Optional: Securo built-in MCP server. Only starts under the `agents`
+  # profile (`docker compose -f docker-compose.prod.yml --profile agents up`).
+  # Reuses the backend image, just runs a different uvicorn entry point.
+  # Modular by design — users not using the agents feature pay zero cost.
+  #
+  # The port is published on the host (127.0.0.1 by default) so external
+  # agents — Claude Desktop, n8n, custom clients — can reach it after
+  # minting a token from the UI. JWT auth is always required. Override
+  # AGENTS_MCP_EXTERNAL_HOST_PORT to e.g. "0.0.0.0:8765" to expose to LAN.
+  mcp-server:
+    <<: *backend-base
+    profiles: [agents]
+    command: uvicorn mcp_server.main:app --host 0.0.0.0 --port 8765
+    ports:
+      - "${AGENTS_MCP_EXTERNAL_HOST_PORT:-127.0.0.1:8765}:8765"
+
 volumes:
   pgdata:
   attachments:
+  agent_knowledge:
+  agent_embedding_models:


### PR DESCRIPTION
Closes #244.

`docker-compose.prod.yml` had drifted from `docker-compose.yml`, so `docker compose -f docker-compose.prod.yml --profile agents up` started nothing — the `mcp-server` service was absent.

Ports the missing wiring from dev to prod:

- **`mcp-server` service** under the `agents` profile (reuses the backend image, JWT-auth'd, `127.0.0.1:8765` by default)
- **`AGENTS_*` env vars** + `agent_knowledge` / `agent_embedding_models` volumes
- **EnableBanking + SimpleFIN + FX_SYNC_MODE** env vars and the `./secrets` mount (also-drifted config)

Everything defaults to off / zero-cost, so existing prod deployments are unaffected until opted in.

Verified by running an isolated `--profile agents` stack against the published backend image: `mcp-server` starts cleanly and serves (`POST /mcp` → `401`, JWT required).