### PR TITLE
fix(sync): scope Pluggy category match to the connection's workspace

### DIFF
--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -314,7 +314,7 @@ async def _upsert_asset_value_for_today(
 
 async def _match_pluggy_category(
     session: AsyncSession,
-    user_id: uuid.UUID,
+    workspace_id: uuid.UUID,
     pluggy_category: Optional[str],
     enabled: bool = True,
 ) -> Optional[uuid.UUID]:
@@ -330,10 +330,16 @@ async def _match_pluggy_category(
         app_name = PLUGGY_CATEGORY_MAP.get(pluggy_category.split(" - ")[0])
     if not app_name:
         return None
+    # Scope to the connection's workspace: a user in multiple workspaces owns
+    # the same default category names in each, so a user_id-only lookup returns
+    # several rows. `.first()` is belt-and-suspenders — a category match must
+    # never crash the whole sync even if a workspace somehow has name dupes.
     result = await session.execute(
-        select(Category.id).where(Category.user_id == user_id, Category.name == app_name)
+        select(Category.id)
+        .where(Category.workspace_id == workspace_id, Category.name == app_name)
+        .limit(1)
     )
-    return result.scalar_one_or_none()
+    return result.scalars().first()
 
 
 async def get_connections(session: AsyncSession, workspace_id: uuid.UUID) -> list[BankConnection]:
@@ -578,7 +584,7 @@ async def handle_oauth_callback(
                 continue
 
             category_id = await _match_pluggy_category(
-                session, user_id, txn_data.pluggy_category, enabled=use_provider_cats
+                session, workspace_id, txn_data.pluggy_category, enabled=use_provider_cats
             )
             # Resolve payee entity from raw payee text
             payee_id = None
@@ -1278,7 +1284,7 @@ async def sync_connection(
                     continue
 
                 category_id = await _match_pluggy_category(
-                    session, user_id, txn_data.pluggy_category, enabled=use_provider_cats
+                    session, workspace_id, txn_data.pluggy_category, enabled=use_provider_cats
                 )
 
                 # Resolve payee entity from raw payee text

--- a/backend/tests/test_connection_service.py
+++ b/backend/tests/test_connection_service.py
@@ -100,37 +100,41 @@ def test_description_similarity_case_insensitive():
 
 
 @pytest.mark.asyncio
-async def test_match_pluggy_exact(session: AsyncSession, test_user):
-    """Exact Pluggy category match maps to user's category."""
+async def test_match_pluggy_exact(session: AsyncSession, test_user, test_workspace):
+    """Exact Pluggy category match maps to the workspace's category."""
     await _make_category(session, test_user.id, "Alimentação")
-    cat_id = await _match_pluggy_category(session, test_user.id, "Eating out")
+    cat_id = await _match_pluggy_category(session, test_workspace.id, "Eating out")
     assert cat_id is not None
 
 
 @pytest.mark.asyncio
-async def test_match_pluggy_prefix(session: AsyncSession, test_user):
+async def test_match_pluggy_prefix(session: AsyncSession, test_user, test_workspace):
     """Pluggy category with ' - ' prefix matches via split."""
     await _make_category(session, test_user.id, "Transferências")
-    cat_id = await _match_pluggy_category(session, test_user.id, "Transfer - PIX")
+    cat_id = await _match_pluggy_category(session, test_workspace.id, "Transfer - PIX")
     assert cat_id is not None
 
 
 @pytest.mark.asyncio
-async def test_match_pluggy_no_match(session: AsyncSession, test_user):
+async def test_match_pluggy_no_match(session: AsyncSession, test_workspace):
     """Unknown Pluggy category returns None."""
-    cat_id = await _match_pluggy_category(session, test_user.id, "Unknown Category XYZ")
+    cat_id = await _match_pluggy_category(
+        session, test_workspace.id, "Unknown Category XYZ"
+    )
     assert cat_id is None
 
 
 @pytest.mark.asyncio
-async def test_match_pluggy_none(session: AsyncSession, test_user):
+async def test_match_pluggy_none(session: AsyncSession, test_workspace):
     """None category returns None."""
-    cat_id = await _match_pluggy_category(session, test_user.id, None)
+    cat_id = await _match_pluggy_category(session, test_workspace.id, None)
     assert cat_id is None
 
 
 @pytest.mark.asyncio
-async def test_match_pluggy_disabled_short_circuits(session: AsyncSession, test_user):
+async def test_match_pluggy_disabled_short_circuits(
+    session: AsyncSession, test_user, test_workspace
+):
     """When the global use_provider_categories flag is off, the matcher returns
     None even on inputs that would otherwise resolve. This is the contract
     sync_connection / handle_oauth_callback rely on to leave transactions
@@ -138,22 +142,22 @@ async def test_match_pluggy_disabled_short_circuits(session: AsyncSession, test_
     await _make_category(session, test_user.id, "Alimentação")
     # Sanity: enabled=True still matches.
     enabled_match = await _match_pluggy_category(
-        session, test_user.id, "Eating out", enabled=True
+        session, test_workspace.id, "Eating out", enabled=True
     )
     assert enabled_match is not None
 
     # enabled=False short-circuits before any DB lookup.
     disabled_match = await _match_pluggy_category(
-        session, test_user.id, "Eating out", enabled=False
+        session, test_workspace.id, "Eating out", enabled=False
     )
     assert disabled_match is None
 
 
 @pytest.mark.asyncio
-async def test_match_pluggy_user_has_no_category(session: AsyncSession, test_user):
-    """Pluggy category maps but user doesn't have the target category."""
+async def test_match_pluggy_user_has_no_category(session: AsyncSession, test_workspace):
+    """Pluggy category maps but the workspace doesn't have the target category."""
     # "Eating out" maps to "Alimentação" but we don't create it
-    cat_id = await _match_pluggy_category(session, test_user.id, "Eating out")
+    cat_id = await _match_pluggy_category(session, test_workspace.id, "Eating out")
     assert cat_id is None
 
 


### PR DESCRIPTION
`_match_pluggy_category` looked up the category by `user_id` + name only. A user in multiple workspaces owns the same default category names in each, so the lookup returned several rows and `scalar_one_or_none()` raised `MultipleResultsFound` — aborting the whole sync with a 500 and flipping the connection to `error`.

Fix: scope the query to the connection's `workspace_id` and use `.limit(1)` / `.first()` so a category match can never crash a sync. Both callers already have `workspace_id` in scope.