### PR TITLE
fix(sync): handle bank rate limits (HTTP 429) gracefully

### DIFF
--- a/backend/app/providers/base.py
+++ b/backend/app/providers/base.py
@@ -151,6 +151,16 @@ class ProviderUserActionRequired(Exception):
         self.help_url = help_url
 
 
+class ProviderRateLimited(Exception):
+    """Raised when the upstream bank/aggregator is throttling data requests.
+
+    Transient and outside the user's control — PSD2 caps unattended account
+    access (commonly ~4/day per resource), so a burst of syncs returns HTTP
+    429. The connection is healthy; callers should skip this run and retry
+    later rather than flag it as errored.
+    """
+
+
 class FxRateProvider(ABC):
     """Abstract interface for FX rate providers."""
 

--- a/backend/app/providers/enable_banking.py
+++ b/backend/app/providers/enable_banking.py
@@ -30,6 +30,7 @@ from app.providers.base import (
     ConnectionData,
     InstitutionData,
     InstitutionListData,
+    ProviderRateLimited,
     ProviderUserActionRequired,
     SessionExpiredError,
     TransactionData,
@@ -243,6 +244,13 @@ class EnableBankingProvider(BankProvider):
         if resp.status_code in (401, 410):
             raise SessionExpiredError(
                 f"Enable Banking returned {resp.status_code} for {path}"
+            )
+        if resp.status_code == 429:
+            # The bank (ASPSP) is throttling us — transient, not a broken
+            # connection. Surface a distinct type so sync can skip-and-retry
+            # instead of erroring the connection.
+            raise ProviderRateLimited(
+                f"Enable Banking {method} {path} → 429: {resp.text[:200]}"
             )
         if resp.status_code >= 400:
             raise httpx.HTTPStatusError(

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -22,6 +22,7 @@ from app.models.user import User
 from app.providers import get_provider
 from app.providers.base import (
     HoldingData,
+    ProviderRateLimited,
     ProviderUserActionRequired,
     SessionExpiredError,
 )
@@ -1375,6 +1376,18 @@ async def sync_connection(
         # so the API layer can surface the specific code to the UI.
         await session.rollback()
         raise
+    except ProviderRateLimited:
+        # The bank/aggregator is throttling data requests (PSD2 caps unattended
+        # access, commonly ~4/day). The connection is healthy, so don't error
+        # it or 500 the request — skip this run, keep it active, and leave
+        # last_sync_at untouched so the next sync retries the same window.
+        await session.rollback()
+        async with session.begin():
+            conn = await session.get(BankConnection, connection_id)
+            if conn and conn.status != "expired":
+                conn.status = "active"
+        refreshed = await session.get(BankConnection, connection_id)
+        return refreshed, 0
     except Exception:
         # Mark connection as errored so UI shows reconnect banner
         await session.rollback()


### PR DESCRIPTION
When a bank/ASPSP throttles data requests, Enable Banking returns `429 ASPSP_RATE_LIMIT_EXCEEDED`. It propagated uncaught out of `get_transactions`, **500'd the sync** and flipped the connection to `error` — misleading, since a rate limit is transient and the connection is healthy (PSD2 caps unattended access to ~4/day per resource).

Fix: add a `ProviderRateLimited` exception raised by the Enable Banking client on `429`, and handle it in `sync_connection` as a soft outcome — keep the connection `active`, don't 500, and leave `last_sync_at` untouched so the next run retries the same window.

Verified live against a currently rate-limited connection: previously 500 + `status=error`; now returns gracefully with `status=active`, no raise.