### PR TITLE
fix: Pluggy category mapping by workspace

### DIFF
--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -316,6 +316,7 @@ async def _match_pluggy_category(
     session: AsyncSession,
     user_id: uuid.UUID,
     pluggy_category: Optional[str],
+    workspace_id: Optional[uuid.UUID] = None,
     enabled: bool = True,
 ) -> Optional[uuid.UUID]:
     # `enabled` is the resolved value of the global `use_provider_categories`
@@ -330,8 +331,14 @@ async def _match_pluggy_category(
         app_name = PLUGGY_CATEGORY_MAP.get(pluggy_category.split(" - ")[0])
     if not app_name:
         return None
+    query = select(Category.id).where(Category.name == app_name)
+    if workspace_id is not None:
+        query = query.where(Category.workspace_id == workspace_id)
+    else:
+        query = query.where(Category.user_id == user_id)
+
     result = await session.execute(
-        select(Category.id).where(Category.user_id == user_id, Category.name == app_name)
+        query.order_by(Category.is_system.desc(), Category.name, Category.id).limit(1)
     )
     return result.scalar_one_or_none()
 
@@ -578,7 +585,11 @@ async def handle_oauth_callback(
                 continue
 
             category_id = await _match_pluggy_category(
-                session, user_id, txn_data.pluggy_category, enabled=use_provider_cats
+                session,
+                user_id,
+                txn_data.pluggy_category,
+                workspace_id=workspace_id,
+                enabled=use_provider_cats,
             )
             # Resolve payee entity from raw payee text
             payee_id = None
@@ -1278,7 +1289,11 @@ async def sync_connection(
                     continue
 
                 category_id = await _match_pluggy_category(
-                    session, user_id, txn_data.pluggy_category, enabled=use_provider_cats
+                    session,
+                    user_id,
+                    txn_data.pluggy_category,
+                    workspace_id=workspace_id,
+                    enabled=use_provider_cats,
                 )
 
                 # Resolve payee entity from raw payee text

--- a/backend/tests/test_connection_service.py
+++ b/backend/tests/test_connection_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.bank_connection import BankConnection
 from app.models.category import Category
 from app.models.transaction import Transaction
+from app.models.workspace import Workspace, WorkspaceMember
 from app.providers.base import AccountData, BillData, ConnectionData, ConnectTokenData, TransactionData
 from app.services.connection_service import (
     _description_similarity,
@@ -48,16 +49,46 @@ async def _make_connection(
 
 
 async def _make_category(
-    session: AsyncSession, user_id: uuid.UUID, name: str,
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    name: str,
+    workspace_id: uuid.UUID | None = None,
 ) -> Category:
     cat = Category(
         id=uuid.uuid4(), user_id=user_id, name=name,
+        workspace_id=workspace_id,
         icon="tag", color="#000", is_system=False,
     )
     session.add(cat)
     await session.commit()
     await session.refresh(cat)
     return cat
+
+
+async def _make_workspace(
+    session: AsyncSession, user_id: uuid.UUID, name: str = "Extra",
+) -> Workspace:
+    workspace = Workspace(
+        id=uuid.uuid4(),
+        name=name,
+        kind="personal",
+        created_by_user_id=user_id,
+        default_currency="BRL",
+        locale="pt-BR",
+    )
+    session.add(workspace)
+    await session.flush()
+    session.add(
+        WorkspaceMember(
+            id=uuid.uuid4(),
+            workspace_id=workspace.id,
+            user_id=user_id,
+            role="owner",
+        )
+    )
+    await session.commit()
+    await session.refresh(workspace)
+    return workspace
 
 
 # ---------------------------------------------------------------------------
@@ -155,6 +186,29 @@ async def test_match_pluggy_user_has_no_category(session: AsyncSession, test_use
     # "Eating out" maps to "Alimentação" but we don't create it
     cat_id = await _match_pluggy_category(session, test_user.id, "Eating out")
     assert cat_id is None
+
+
+@pytest.mark.asyncio
+async def test_match_pluggy_scopes_duplicate_names_to_workspace(
+    session: AsyncSession, test_user, test_workspace
+):
+    """Provider category mapping must not mix equal names across workspaces."""
+    other_workspace = await _make_workspace(session, test_user.id)
+    primary = await _make_category(
+        session, test_user.id, "Alimentação", workspace_id=test_workspace.id
+    )
+    await _make_category(
+        session, test_user.id, "Alimentação", workspace_id=other_workspace.id
+    )
+
+    cat_id = await _match_pluggy_category(
+        session,
+        test_user.id,
+        "Eating out",
+        workspace_id=test_workspace.id,
+    )
+
+    assert cat_id == primary.id
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Scope Pluggy category mapping to the bank connection workspace and add regression coverage for duplicate category names across workspaces.

## Why

Pluggy synchronization queried categories globally by user and name. Users with multiple workspaces could have valid duplicate category names, causing `MultipleResultsFound` and HTTP 500 errors during bank synchronization.

## How to Test

1. Run `pytest tests/test_connection_service.py -q`.
2. Create equal category names in two workspaces.
3. Synchronize a Pluggy connection.
4. Confirm the category from the connection’s workspace is selected.
5. Confirm the connection returns to `active`.

## Checklist

- [x] Backend tests pass (`pytest`)