### PR TITLE
Feat/networth change tooltip

### DIFF
--- a/backend/app/schemas/report.py
+++ b/backend/app/schemas/report.py
@@ -19,6 +19,7 @@ class ReportDataPoint(BaseModel):
     date: str
     value: float
     breakdowns: dict[str, float]
+    change: float | None = None
 
 
 class ReportMeta(BaseModel):

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -179,6 +179,7 @@ async def get_net_worth_report(
     for point in points:
         dp = await _net_worth_at(session, workspace_id, point, primary_currency)
         dp.date = _format_date_label(point, interval)
+        dp.change = round(dp.value - trend[-1].value, 2) if trend else None
         trend.append(dp)
 
     # Current snapshot (last point) for summary; baseline at period start for delta

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -927,6 +927,64 @@ async def test_net_worth_change_percent_zero_previous(session: AsyncSession, tes
 
 
 # ---------------------------------------------------------------------------
+# Trend data point change field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trend_change_calculation(session: AsyncSession, test_user, test_workspace: User):
+    """change is None on the first point and equals round(value - prev.value, 2) on all others.
+    Uses activity spread over time so the trend contains positive, negative, and flat changes."""
+    acct = await _make_manual_account(session, test_user.id, "Change Calc")
+    today = date.today()
+    await _add_txn(session, test_user.id, acct.id, 5000, "credit", today - timedelta(days=150))  # opening
+    await _add_txn(session, test_user.id, acct.id, 1200, "credit", today - timedelta(days=90))   # income
+    await _add_txn(session, test_user.id, acct.id, 300,  "debit",  today - timedelta(days=60))   # expense
+    await _add_txn(session, test_user.id, acct.id, 800,  "credit", today - timedelta(days=30))   # income
+    await _add_txn(session, test_user.id, acct.id, 450,  "debit",  today)                        # recent expense
+
+    report = await get_net_worth_report(session, test_workspace.id, test_user.id, months=6, interval="monthly")
+
+    assert len(report.trend) > 1
+    assert report.trend[0].change is None
+    for prev, curr in zip(report.trend, report.trend[1:]):
+        assert curr.change == round(curr.value - prev.value, 2)
+
+
+@pytest.mark.asyncio
+async def test_trend_change_zero_when_net_worth_unchanged(
+    session: AsyncSession, test_user, test_workspace: User
+):
+    """When no activity occurs inside the report window, every non-first point has change == 0."""
+    acct = await _make_manual_account(session, test_user.id, "Change Zero")
+    two_years_ago = date.today() - timedelta(days=730)
+    await _add_txn(session, test_user.id, acct.id, 4000, "credit", two_years_ago)
+
+    report = await get_net_worth_report(session, test_workspace.id, test_user.id, months=3, interval="monthly")
+
+    for dp in report.trend[1:]:
+        assert dp.change == 0.0
+
+
+@pytest.mark.asyncio
+async def test_net_worth_api_trend_points_include_change(client, auth_headers, test_transactions):
+    """GET /reports/net-worth: change is None on the first point and present on all others."""
+    response = await client.get(
+        "/api/reports/net-worth",
+        params={"months": 6, "interval": "monthly"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    trend = data["trend"]
+    assert len(trend) > 1
+    assert trend[0]["change"] is None
+    for point in trend[1:]:
+        assert point["change"] is not None
+
+
+# ---------------------------------------------------------------------------
 # Pure-function tests: _add_months
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -958,6 +958,7 @@
     "balance": "Balance",
     "inflow": "Inflow",
     "outflow": "Outflow",
+    "change": "Change",
     "inflowOutflow": "Inflow vs Outflow",
     "startingBalance": "Starting Balance",
     "endingBalance": "Projected Balance",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -956,6 +956,7 @@
     "balance": "Saldo",
     "inflow": "Entrada",
     "outflow": "Salida",
+    "change": "Variación",
     "inflowOutflow": "Entrada vs. salida",
     "startingBalance": "Saldo inicial",
     "endingBalance": "Saldo proyectado",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -1024,6 +1024,7 @@
     "balance": "Saldo",
     "inflow": "Wpływy",
     "outflow": "Wypływy",
+    "change": "Zmiana",
     "inflowOutflow": "Wpływy a wypływy",
     "startingBalance": "Saldo początkowe",
     "endingBalance": "Saldo prognozowane",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -958,6 +958,7 @@
     "balance": "Saldo",
     "inflow": "Entrada",
     "outflow": "Saída",
+    "change": "Variação",
     "inflowOutflow": "Entradas vs Saídas",
     "startingBalance": "Saldo Atual",
     "endingBalance": "Saldo Projetado",

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -637,7 +637,7 @@ export default function ReportsPage() {
                         </p>
                         {change !== null && (
                           <p className="text-xs" style={{ color: changeColor }}>
-                            {t('reports.change', { defaultValue: 'Change' })}:{' '}
+                            {t('reports.change')}:{' '}
                             {privacyMode ? MASK : `${changeSign}${formatCurrency(change, userCurrency, locale)}`}
                           </p>
                         )}

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -162,6 +162,7 @@ export default function ReportsPage() {
     return {
       date: dp.date,
       value: dp.value,
+      change: dp.change ?? null,
       valuePast: isPast || isBoundary ? dp.value : null,
       valueForecast: !isPast ? dp.value : null,
       ...dp.breakdowns,
@@ -620,14 +621,29 @@ export default function ReportsPage() {
                   tickCount={5}
                 />
                 <Tooltip
-                  formatter={(value?: number, name?: string) => [
-                    privacyMode ? MASK : formatCurrency(value ?? 0, userCurrency, locale),
-                    name === 'value'
-                      ? t(currentTab.labelKey)
-                      : t(`reports.${name ?? ''}`, { defaultValue: name ?? '' }),
-                  ]}
-                  labelFormatter={(label) => label}
-                  contentStyle={tooltipStyle}
+                  content={({ active, payload, label }) => {
+                    if (!active || !payload || payload.length === 0) return null
+                    const point = payload[0]?.payload as Record<string, number | null>
+                    const value = (payload[0]?.value as number) ?? 0
+                    const change = point.change ?? null
+                    const changeSign = change !== null && change >= 0 ? '+' : ''
+                    const changeColor = change !== null ? (change >= 0 ? '#10B981' : '#F43F5E') : ''
+                    return (
+                      <div style={tooltipStyle} className="px-3 py-2">
+                        <p className="text-xs font-medium mb-1">{label}</p>
+                        <p className="text-xs" style={{ color: '#6366F1' }}>
+                          {t(currentTab.labelKey)}:{' '}
+                          {privacyMode ? MASK : formatCurrency(value, userCurrency, locale)}
+                        </p>
+                        {change !== null && (
+                          <p className="text-xs" style={{ color: changeColor }}>
+                            {t('reports.change', { defaultValue: 'Change' })}:{' '}
+                            {privacyMode ? MASK : `${changeSign}${formatCurrency(change, userCurrency, locale)}`}
+                          </p>
+                        )}
+                      </div>
+                    )
+                  }}
                 />
                 <Area
                   type="monotone"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -615,6 +615,7 @@ export interface ReportDataPoint {
   date: string
   value: number
   breakdowns: Record<string, number>
+  change: number | null
 }
 
 export interface ReportMeta {


### PR DESCRIPTION
## What

Add the ammount of change in networth between date points in the Reports / Networth page

## Why

This is a way to easily show the user exactly how much its Networth has changed between date points. I find it specially useful to compare month to month. The graph already showed the trend over time, but  only the snapshot of the Networth values were presented. Knowing the exactly the amount its valuated required the user to do some math. Now, it is easily shown in the UI.
This solution is based on the discussion running on issue #219 



### Before 
<img width="1276" height="664" alt="Gravando 2026-06-06 120341" src="https://github.com/user-attachments/assets/a852609e-908e-4707-8fdf-a822461a0375" />

### After
<img width="1340" height="656" alt="Gravando 2026-06-06 120212" src="https://github.com/user-attachments/assets/930c934a-645a-4308-849a-8dd9385a157c" />


## How to Test

Steps to verify the changes work:

1. Go to Networth page In the Reports Page
2. Mouse over the graph of  `Networth Over Time`
3. Notice that the comparison between the previous date point is shown in the tooltip

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
