### PR TITLE
fix(report): show negative-balance non-CC accounts as liabilities in net worth

### DIFF
--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -74,13 +74,10 @@ async def _net_worth_at(
             session, Decimal(str(abs(bal))), account.currency, primary_currency, cutoff
         )
         converted_val = float(converted)
-        if account.type == "credit_card":
+        if account.type == "credit_card" or bal < 0:
             liabilities_total += converted_val
         else:
-            if bal < 0:
-                accounts_total -= converted_val
-            else:
-                accounts_total += converted_val
+            accounts_total += converted_val
 
     assets_total = await _asset_value_at(session, workspace_id, cutoff, primary_currency)
     net_worth = accounts_total + assets_total - liabilities_total
@@ -267,6 +264,14 @@ async def get_net_worth_report(
                     value=round(converted_val, 2),
                     color=account_type_colors.get(account.type, "#6B7280"),
                     group="accounts",
+                ))
+            elif bal < 0:
+                composition.append(ReportCompositionItem(
+                    key=str(account.id),
+                    label=get_account_name(account),
+                    value=round(converted_val, 2),
+                    color="#F43F5E",
+                    group="liabilities",
                 ))
 
     # Assets — scoped to workspace

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -851,7 +851,20 @@ async def test_net_worth_negative_manual_balance(session: AsyncSession, test_use
     await _add_txn(session, test_user.id, acct.id, 1000, "debit", date.today())
 
     dp = await _net_worth_at(session, test_workspace.id, date.today(), "BRL")
-    assert dp.breakdowns["accounts"] == -1000.0
+    assert dp.breakdowns["accounts"] == 0.0
+    assert dp.breakdowns["liabilities"] == 1000.0
+    assert dp.value == -1000.0
+
+
+@pytest.mark.asyncio
+async def test_net_worth_negative_account_in_composition(session: AsyncSession, test_user, test_workspace: User):
+    acct = await _make_manual_account(session, test_user.id, "Overdrawn Acct")
+    await _add_txn(session, test_user.id, acct.id, 500, "debit", date.today())
+
+    report = await get_net_worth_report(session, test_workspace.id, test_user.id, months=1, interval="monthly")
+    liability_items = [c for c in report.composition if c.group == "liabilities"]
+    labels = [c.label for c in liability_items]
+    assert "Overdrawn Acct" in labels
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## What

Stop ignoring negative balance accounts in net worth report graphs in the Reports/NetWorth page

## Why

Non-credit-card accounts with negative balances were correctly reducing net worth but were invisible in the breakdown cards and composition donut — users had no way to see what was dragging the total down.

They now contribute to the liabilities breakdown and appear as a red slice in the composition chart, similar  with credit cards.

## How to Test
1. Create a manual (non-credit-card) account and record a debit that exceeds any credits so the balance goes negative.
2. Open the Net Worth report.
3. Breakdown cards — the liabilities card should now include this account's absolute balance; the accounts card should no longer subtract it.
4. Composition donut — a red (#F43F5E) slice labelled with the account name should appear in the liabilities group.
5. The overall net worth value must be unchanged — moving the account from assets to liabilities is a purely cosmetic reclassification.

## Changes

| File | What changed |
|---|---|
| `backend/app/services/report_service.py` | `_net_worth_at`: negative-balance non-CC accounts are bucketed into `liabilities_total` (absolute value) instead of being subtracted from `accounts_total`. `get_net_worth_report`: adds a composition entry (group `liabilities`, colour `#F43F5E`) for any non-CC account with `bal < 0`. |
| `backend/tests/test_report_service.py` | Updates existing `test_net_worth_negative_manual_balance` assertions to match the new bucketing; adds `test_net_worth_negative_account_in_composition` to verify the account appears in the composition liabilities group. |

## Checklist

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
