### PR TITLE
fix: Decouple nginx.conf in frontend from container names

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,6 +15,6 @@ RUN npm run build
 FROM nginx:alpine
 
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY default.conf.template /etc/nginx/templates/default.conf.template
 
 EXPOSE 80

--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -5,7 +5,7 @@ server {
 
     # API proxy to backend
     location /api/ {
-        proxy_pass http://backend:8000;
+        proxy_pass ${BACKEND_URL};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## What

Currently the container name of the backend server is hardcoded into the nginx.conf file of the frontend container.
This PR fixes the problem by using the default envsubst feature of the nginx container and the already used env variables.

## Why


Renaming the backend container name from the `docker-compose.prod.yml` file breaks the application as the frontend container is trying to resolve DNS for `http://backend:8000`. This creates a tight coupling between the containers which should be avoided.

## How to Test

Steps to verify the changes work:

1. On main branch: try to start up `docker-compose.prod.yml` after renaming the backend container and all its dependencies
2. Try the same on this branch: All containers start well and the application is running correctly.

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
