### PR TITLE
feat(accounts): show bank institution logos for connected accounts

### DIFF
--- a/backend/alembic/versions/055_bank_connection_logo_url.py
+++ b/backend/alembic/versions/055_bank_connection_logo_url.py
@@ -1,0 +1,22 @@
+"""add logo_url to bank_connections
+
+Revision ID: 055
+Revises: 054
+Create Date: 2026-06-08
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "055"
+down_revision = "054"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("bank_connections", sa.Column("logo_url", sa.String(500), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("bank_connections", "logo_url")

--- a/backend/app/api/accounts.py
+++ b/backend/app/api/accounts.py
@@ -133,7 +133,7 @@ async def get_account(
     account = await account_service.get_account(session, account_id, ctx.workspace.id)
     if not account:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
-    return account_service.serialize_account(account, None, None)
+    return account_service.serialize_account(account, None, None, account.connection)
 
 
 @router.post("", response_model=AccountRead, status_code=status.HTTP_201_CREATED)

--- a/backend/app/models/bank_connection.py
+++ b/backend/app/models/bank_connection.py
@@ -25,6 +25,10 @@ class BankConnection(Base):
     external_id: Mapped[str] = mapped_column(String(255))  # Provider's item ID
     institution_name: Mapped[str] = mapped_column(String(255))
     display_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    # Fully-formed institution logo URL captured from the provider (Pluggy
+    # connector.imageUrl, Enable Banking ASPSP logo). Null = no logo; the
+    # frontend falls back to the account-type icon. Mirrors assets.logo_url.
+    logo_url: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
     credentials: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)  # Encrypted tokens
     settings: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True, default=dict)
     status: Mapped[str] = mapped_column(String(50), default="active")  # active, error, expired

--- a/backend/app/providers/base.py
+++ b/backend/app/providers/base.py
@@ -62,6 +62,10 @@ class ConnectionData:
     institution_name: str
     credentials: dict
     accounts: list[AccountData]
+    # Fully-formed institution logo URL when the provider exposes one
+    # (Pluggy connector.imageUrl, Enable Banking ASPSP logo). None for
+    # providers/institutions without a logo (e.g. SimpleFin).
+    logo_url: Optional[str] = None
 
 
 @dataclass
@@ -289,6 +293,16 @@ class BankProvider(ABC):
         already serve live data on every read don't need to override.
         """
         return "skipped"
+
+    async def get_institution_logo(self, credentials: dict) -> Optional[str]:
+        """Return the institution logo URL for an existing connection, or None.
+
+        Used to backfill connections that were linked before logo capture
+        existed (the sync layer calls this only when a connection has no
+        stored logo). Default is no-op so providers without institution
+        logos (e.g. SimpleFin) don't need to implement it.
+        """
+        return None
 
     async def get_holdings(self, credentials: dict) -> list[HoldingData]:
         """Fetch investment holdings for a connection.

--- a/backend/app/providers/enable_banking.py
+++ b/backend/app/providers/enable_banking.py
@@ -405,7 +405,22 @@ class EnableBankingProvider(BankProvider):
             institution_name=institution_name,
             credentials=credentials,
             accounts=accounts,
+            # The session payload sometimes carries the ASPSP logo; when it
+            # doesn't, the sync layer backfills it via get_institution_logo.
+            logo_url=aspsp.get("logo"),
         )
+
+    async def get_institution_logo(self, credentials: dict) -> Optional[str]:
+        aspsp = credentials.get("aspsp") or {}
+        name = aspsp.get("name")
+        country = aspsp.get("country")
+        if not name:
+            return None
+        institutions = await self.list_institutions(country)
+        for inst in institutions.institutions:
+            if inst.name == name:
+                return inst.logo
+        return None
 
     async def _build_account(self, raw: dict) -> AccountData:
         uid = raw.get("uid") or raw.get("account_uid") or ""

--- a/backend/app/providers/favicon.py
+++ b/backend/app/providers/favicon.py
@@ -1,0 +1,37 @@
+"""Derive a logo URL from a website/domain via Google's favicon service.
+
+Shared by the market-price provider (asset logos from a company website) and
+the bank providers (institution logos when an integration exposes the bank's
+URL but no logo image — e.g. SimpleFIN). No API key, works for any public
+domain; the frontend falls back to a type icon on image-load failure.
+"""
+from typing import Optional
+from urllib.parse import urlparse
+
+from app.core.config import get_settings
+
+
+def extract_domain(url: Optional[str]) -> Optional[str]:
+    """Extract the bare domain from a URL, stripping ``www.`` and scheme.
+
+    Returns None for blanks / unparseable inputs.
+    """
+    if not url:
+        return None
+    try:
+        parsed = urlparse(url if "://" in url else f"https://{url}")
+    except ValueError:
+        return None
+    host = (parsed.hostname or "").strip().lower()
+    if not host:
+        return None
+    return host[4:] if host.startswith("www.") else host
+
+
+def favicon_url_for(website: Optional[str]) -> Optional[str]:
+    """Build a favicon-based logo URL for a website, or None if unavailable."""
+    domain = extract_domain(website)
+    if not domain:
+        return None
+    size = get_settings().logo_size
+    return f"https://www.google.com/s2/favicons?domain={domain}&sz={size}"

--- a/backend/app/providers/market_price.py
+++ b/backend/app/providers/market_price.py
@@ -30,9 +30,8 @@ import logging
 from abc import ABC, abstractmethod
 from decimal import Decimal
 from typing import Optional
-from urllib.parse import urlparse
 
-from app.core.config import get_settings
+from app.providers.favicon import favicon_url_for
 from app.schemas.asset import MarketSymbolMatch, MarketSymbolQuote
 
 logger = logging.getLogger(__name__)
@@ -363,42 +362,9 @@ class YFinanceProvider(MarketPriceProvider):
             return None
 
 
-def _extract_domain(url: Optional[str]) -> Optional[str]:
-    """Extract the bare domain from a URL, stripping ``www.`` and scheme.
-
-    Returns None for blanks / unparseable inputs. Used as the identifier
-    Brandfetch (or any logo-by-domain service) expects.
-    """
-    if not url:
-        return None
-    try:
-        parsed = urlparse(url if "://" in url else f"https://{url}")
-    except ValueError:
-        return None
-    host = (parsed.hostname or "").strip().lower()
-    if not host:
-        return None
-    return host[4:] if host.startswith("www.") else host
-
-
-def _logo_url_for(website: Optional[str]) -> Optional[str]:
-    """Build a logo URL for a company website, or None if unavailable.
-
-    Uses Google's free favicon service — no API key, no third-party sign-up,
-    works for any public domain. Quality caps at 128×128 and can be lower
-    for older sites; when Google doesn't have a favicon it returns a
-    generic globe, which the frontend treats as "good enough" (falling
-    back to the type icon is reserved for image-load failures).
-
-    Returns None when the upstream quote didn't include a website (most
-    crypto tickers), which is the signal for the frontend to show the
-    type icon instead.
-    """
-    domain = _extract_domain(website)
-    if not domain:
-        return None
-    size = get_settings().logo_size
-    return f"https://www.google.com/s2/favicons?domain={domain}&sz={size}"
+# Asset logos reuse the shared favicon helper. Kept as a module-local alias so
+# existing call sites stay untouched.
+_logo_url_for = favicon_url_for
 
 
 def _last_decimal_close(series) -> Optional[Decimal]:

--- a/backend/app/providers/pluggy.py
+++ b/backend/app/providers/pluggy.py
@@ -299,7 +299,8 @@ class PluggyProvider(BankProvider):
             accounts_resp.raise_for_status()
             accounts_data = accounts_resp.json()
 
-        institution_name = item_data.get("connector", {}).get("name", "Unknown Bank")
+        connector = item_data.get("connector", {})
+        institution_name = connector.get("name", "Unknown Bank")
 
         account_list = []
         for acc in accounts_data.get("results", []):
@@ -310,7 +311,18 @@ class PluggyProvider(BankProvider):
             institution_name=institution_name,
             credentials={"item_id": item_id},
             accounts=account_list,
+            logo_url=connector.get("imageUrl"),
         )
+
+    async def get_institution_logo(self, credentials: dict) -> Optional[str]:
+        item_id = credentials["item_id"]
+        headers = await self._headers()
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(
+                f"{PLUGGY_API_BASE}/items/{item_id}", headers=headers
+            )
+            resp.raise_for_status()
+            return resp.json().get("connector", {}).get("imageUrl")
 
     async def get_accounts(self, credentials: dict) -> list[AccountData]:
         item_id = credentials["item_id"]

--- a/backend/app/providers/simplefin.py
+++ b/backend/app/providers/simplefin.py
@@ -29,6 +29,7 @@ from typing import Any, Optional
 import httpx
 
 from app.agents.services.crypto import decrypt, encrypt
+from app.providers.favicon import favicon_url_for
 from app.providers.base import (
     AccountData,
     BankProvider,
@@ -247,7 +248,34 @@ class SimpleFinProvider(BankProvider):
             institution_name=institution_name,
             credentials=credentials,
             accounts=accounts,
+            # SimpleFIN has no logo image, but its org metadata carries the
+            # bank's website — derive a favicon from it (same approach as
+            # asset logos).
+            logo_url=favicon_url_for(self._org_website(payload)),
         )
+
+    @staticmethod
+    def _org_website(payload: dict) -> Optional[str]:
+        """Best-effort bank website from a SimpleFIN /accounts payload.
+
+        Checks the connection metadata first, then each account's ``org``
+        (the SimpleFIN spec attaches ``url``/``domain`` to the institution
+        org). Returns None when nothing usable is present.
+        """
+        for src in (payload.get("connections") or []):
+            url = src.get("url") or src.get("domain")
+            if url:
+                return url
+        for acc in (payload.get("accounts") or []):
+            org = acc.get("org") or {}
+            url = org.get("url") or org.get("domain")
+            if url:
+                return url
+        return None
+
+    async def get_institution_logo(self, credentials: dict) -> Optional[str]:
+        payload = await self._fetch_accounts(credentials, pending=False)
+        return favicon_url_for(self._org_website(payload))
 
     @staticmethod
     def _stable_external_id(payload: dict, fallback: str) -> str:

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -47,6 +47,11 @@ class AccountRead(AccountBase):
     connection_id: Optional[uuid.UUID] = None
     external_id: Optional[str] = None
     display_name: Optional[str] = None
+    # Denormalized from the linked BankConnection so every surface that shows
+    # an account (transactions list, accounts page, dashboard) can render the
+    # bank identity without a separate join. Null for manual accounts.
+    institution_name: Optional[str] = None
+    institution_logo_url: Optional[str] = None
     current_balance: float = 0.0
     previous_balance: Optional[float] = None
     balance_primary: Optional[float] = None

--- a/backend/app/schemas/bank_connection.py
+++ b/backend/app/schemas/bank_connection.py
@@ -15,6 +15,7 @@ class BankConnectionRead(BankConnectionBase):
     user_id: uuid.UUID
     external_id: str
     display_name: Optional[str] = None
+    logo_url: Optional[str] = None
     settings: Optional[dict] = None
     status: str
     last_sync_at: Optional[datetime] = None

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from sqlalchemy import case, func, select, or_
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import contains_eager
 
 from app.models.account import Account
 from app.models.bank_connection import BankConnection
@@ -78,6 +79,7 @@ async def get_accounts(session: AsyncSession, workspace_id: uuid.UUID, include_c
     query = (
         select(
             Account,
+            BankConnection,
             func.coalesce(balance_sq.c.current_balance, 0).label("current_balance"),
             func.coalesce(prev_balance_sq.c.previous_balance, 0).label("previous_balance"),
         )
@@ -96,15 +98,22 @@ async def get_accounts(session: AsyncSession, workspace_id: uuid.UUID, include_c
     query = query.order_by(Account.name)
     result = await session.execute(query)
     return [
-            serialize_account(acc, current_balance, previous_balance)
-            for acc, current_balance, previous_balance in result.all()
+            serialize_account(acc, current_balance, previous_balance, connection)
+            for acc, connection, current_balance, previous_balance in result.all()
         ]
+
+
+def _institution_name(connection: Optional[BankConnection]) -> Optional[str]:
+    if not connection:
+        return None
+    return connection.display_name or connection.institution_name
 
 
 def serialize_account(
     acc: Account,
     current_balance: Optional[Decimal],
     previous_balance: Optional[Decimal],
+    connection: Optional[BankConnection] = None,
 ) -> dict:
     # Connected CC: provider stores positive for debt → negate.
     # Manual accounts: transaction math already gives correct sign.
@@ -133,6 +142,8 @@ def serialize_account(
         "minimum_payment": float(acc.minimum_payment) if acc.minimum_payment is not None else None,
         "card_brand": acc.card_brand,
         "card_level": acc.card_level,
+        "institution_name": _institution_name(connection),
+        "institution_logo_url": connection.logo_url if connection else None,
         "available_credit": None,
         "next_close_date": None,
         "next_due_date": None,
@@ -180,6 +191,7 @@ async def get_account(session: AsyncSession, account_id: uuid.UUID, workspace_id
     result = await session.execute(
         select(Account)
         .outerjoin(BankConnection)
+        .options(contains_eager(Account.connection))
         .where(
             Account.id == account_id,
             or_(

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -40,6 +40,16 @@ logger = logging.getLogger(__name__)
 
 settings = get_settings()
 
+
+def _clean_logo_url(value: object) -> Optional[str]:
+    """Normalize a provider-supplied logo to a non-empty string or None.
+
+    Guards the DB column against anything a provider hands back that isn't a
+    usable URL (None, empty string, or a non-string), so a misbehaving
+    integration can never write junk into ``bank_connections.logo_url``.
+    """
+    return value if isinstance(value, str) and value.strip() else None
+
 PLUGGY_CATEGORY_MAP = {
     "Eating out": "Alimentação",
     "Restaurants": "Alimentação",
@@ -505,6 +515,7 @@ async def handle_oauth_callback(
         existing.institution_name = (
             connection_data.institution_name or existing.institution_name
         )
+        existing.logo_url = _clean_logo_url(connection_data.logo_url) or existing.logo_url
         existing.credentials = connection_data.credentials
         existing.status = "active"
         # Re-sync from current data on next sync cycle.
@@ -519,6 +530,7 @@ async def handle_oauth_callback(
         provider=provider_name,
         external_id=connection_data.external_id,
         institution_name=connection_data.institution_name,
+        logo_url=_clean_logo_url(connection_data.logo_url),
         credentials=connection_data.credentials,
         settings={"flow_params": state_payload.get("flow_params") or {}},
         status="active",
@@ -1098,6 +1110,19 @@ async def sync_connection(
         # Refresh credentials if needed
         credentials = await provider.refresh_credentials(connection.credentials)
         connection.credentials = credentials
+
+        # Backfill the institution logo for connections linked before logo
+        # capture existed. Best-effort: a failure here must never break sync.
+        if not connection.logo_url:
+            try:
+                logo = _clean_logo_url(await provider.get_institution_logo(credentials))
+                if logo:
+                    connection.logo_url = logo
+            except Exception:
+                logger.warning(
+                    "Failed to backfill logo for connection %s", connection.id,
+                    exc_info=True,
+                )
 
         # When the caller asks for fresh data (typically a user-initiated
         # manual sync), ask the provider to pull from the bank before we

--- a/frontend/src/components/account-icon.tsx
+++ b/frontend/src/components/account-icon.tsx
@@ -1,0 +1,107 @@
+import { useState, type ElementType } from 'react'
+import { Building2, PiggyBank, CreditCard, TrendingUp, Wallet } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+// Account-type → icon/color, the fallback shown when an account has no bank
+// logo (manual accounts, and connected accounts whose provider exposes none).
+export const ACCOUNT_TYPE_CONFIG: Record<
+  string,
+  { icon: ElementType; color: string; bg: string; label: string }
+> = {
+  checking:    { icon: Building2,   color: 'text-indigo-600',  bg: 'bg-indigo-100',  label: 'accounts.typeChecking' },
+  savings:     { icon: PiggyBank,   color: 'text-emerald-600', bg: 'bg-emerald-100', label: 'accounts.typeSavings' },
+  credit_card: { icon: CreditCard,  color: 'text-violet-600',  bg: 'bg-violet-100',  label: 'accounts.typeCreditCard' },
+  investment:  { icon: TrendingUp,  color: 'text-amber-600',   bg: 'bg-amber-100',   label: 'accounts.typeInvestment' },
+  wallet:      { icon: Wallet,      color: 'text-rose-600',    bg: 'bg-rose-100',    label: 'accounts.typeWallet' },
+}
+
+export function getAccountTypeConfig(type: string) {
+  return ACCOUNT_TYPE_CONFIG[type] ?? ACCOUNT_TYPE_CONFIG['checking']
+}
+
+const SIZES = {
+  xs: { tile: 'w-5 h-5', icon: 11 },
+  sm: { tile: 'w-6 h-6', icon: 12 },
+  md: { tile: 'w-8 h-8', icon: 14 },
+  lg: { tile: 'w-10 h-10', icon: 18 },
+} as const
+
+/**
+ * Renders the institution logo for an account when one is available, falling
+ * back to the colored account-type icon. The image's `onError` swaps to the
+ * type icon so a broken/blocked logo URL never leaves an empty tile.
+ */
+export function AccountIcon({
+  account,
+  size = 'md',
+  className,
+}: {
+  account: { type: string; institution_logo_url?: string | null }
+  size?: keyof typeof SIZES
+  className?: string
+}) {
+  const [errored, setErrored] = useState(false)
+  const cfg = getAccountTypeConfig(account.type)
+  const Icon = cfg.icon
+  const logo = account.institution_logo_url
+  const showImage = !!logo && !errored
+  const { tile, icon } = SIZES[size]
+
+  return (
+    <div
+      className={cn(
+        tile,
+        'rounded-lg flex items-center justify-center overflow-hidden shrink-0',
+        showImage ? 'bg-white border border-border' : cfg.bg,
+        className,
+      )}
+    >
+      {showImage ? (
+        <img
+          src={logo!}
+          alt=""
+          className="w-full h-full object-contain"
+          onError={() => setErrored(true)}
+        />
+      ) : (
+        <Icon size={icon} className={cfg.color} />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Institution logo for a bank connection header. Falls back to a generic
+ * bank icon when no logo is stored or the image fails to load.
+ */
+export function ConnectionLogo({
+  logoUrl,
+  className,
+}: {
+  logoUrl?: string | null
+  className?: string
+}) {
+  const [errored, setErrored] = useState(false)
+  const showImage = !!logoUrl && !errored
+
+  return (
+    <div
+      className={cn(
+        'w-8 h-8 rounded-lg flex items-center justify-center overflow-hidden shrink-0',
+        showImage ? 'bg-white border border-border' : 'bg-muted',
+        className,
+      )}
+    >
+      {showImage ? (
+        <img
+          src={logoUrl!}
+          alt=""
+          className="w-full h-full object-contain"
+          onError={() => setErrored(true)}
+        />
+      ) : (
+        <Building2 size={14} className="text-muted-foreground" />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/accounts.tsx
+++ b/frontend/src/pages/accounts.tsx
@@ -23,11 +23,6 @@ import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { Account, BankConnection } from '@/types'
 import {
-  Building2,
-  PiggyBank,
-  CreditCard,
-  TrendingUp,
-  Wallet,
   Pencil,
   Trash2,
   RefreshCw,
@@ -36,6 +31,7 @@ import {
   Settings,
   Archive,
 } from 'lucide-react'
+import { AccountIcon, ConnectionLogo, getAccountTypeConfig } from '@/components/account-icon'
 import { PageHeader } from '@/components/page-header'
 import { BankConnectDialog } from '@/components/bank-connect-dialog'
 import { ConnectorSelectDialog, type Provider } from '@/components/connector-select-dialog'
@@ -56,18 +52,6 @@ function daysUntil(dateStr: string | null): number | null {
   const today = new Date()
   today.setHours(0, 0, 0, 0)
   return Math.round((due.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
-}
-
-const ACCOUNT_TYPE_CONFIG: Record<string, { icon: React.ElementType; color: string; bg: string; label: string }> = {
-  checking:    { icon: Building2,   color: 'text-indigo-600',    bg: 'bg-indigo-100',    label: 'accounts.typeChecking' },
-  savings:     { icon: PiggyBank,   color: 'text-emerald-600', bg: 'bg-emerald-100', label: 'accounts.typeSavings' },
-  credit_card: { icon: CreditCard,  color: 'text-violet-600', bg: 'bg-violet-100', label: 'accounts.typeCreditCard' },
-  investment:  { icon: TrendingUp,  color: 'text-amber-600',  bg: 'bg-amber-100',  label: 'accounts.typeInvestment' },
-  wallet:      { icon: Wallet,      color: 'text-rose-600',   bg: 'bg-rose-100',   label: 'accounts.typeWallet' },
-}
-
-function getTypeConfig(type: string) {
-  return ACCOUNT_TYPE_CONFIG[type] ?? ACCOUNT_TYPE_CONFIG['checking']
 }
 
 export default function AccountsPage() {
@@ -254,8 +238,7 @@ export default function AccountsPage() {
             {manualAccounts.length > 0 ? (
               <div className="divide-y divide-muted">
                 {manualAccounts.map((acc) => {
-                  const cfg = getTypeConfig(acc.type)
-                  const Icon = cfg.icon
+                  const cfg = getAccountTypeConfig(acc.type)
                   const bal = Number(acc.current_balance)
                   const isCC = acc.type === 'credit_card'
                   const dueIn = isCC ? daysUntil(acc.next_due_date) : null
@@ -268,9 +251,7 @@ export default function AccountsPage() {
                   return (
                     <div key={acc.id} className="group flex items-center px-5 py-3 hover:bg-muted/50 transition-colors">
                       <Link to={`/accounts/${acc.id}`} className="flex items-center gap-3 flex-1 min-w-0">
-                        <div className={`w-8 h-8 rounded-lg ${cfg.bg} flex items-center justify-center shrink-0`}>
-                          <Icon size={14} className={cfg.color} />
-                        </div>
+                        <AccountIcon account={acc} />
                         <div className="min-w-0 flex-1">
                           <p className="text-sm font-medium text-foreground truncate">{getAccountName(acc)}</p>
                           <p className="text-xs text-muted-foreground">
@@ -340,9 +321,7 @@ export default function AccountsPage() {
                     {/* Connection header */}
                     <div className="flex items-center justify-between px-5 py-3.5 border-b border-border">
                       <div className="flex items-center gap-3">
-                        <div className="w-8 h-8 rounded-lg bg-muted flex items-center justify-center">
-                          <Building2 size={14} className="text-muted-foreground" />
-                        </div>
+                        <ConnectionLogo logoUrl={conn.logo_url} />
                         <div>
                           <div className="flex items-center gap-2">
                             <p className="text-sm font-semibold text-foreground">{getConnectionName(conn)}</p>
@@ -416,8 +395,7 @@ export default function AccountsPage() {
                     {connAccounts.length > 0 ? (
                       <div className="divide-y divide-muted">
                         {connAccounts.map((acc) => {
-                          const cfg = getTypeConfig(acc.type)
-                          const Icon = cfg.icon
+                          const cfg = getAccountTypeConfig(acc.type)
                           const bal = Number(acc.current_balance)
                           const isCC = acc.type === 'credit_card'
                           const dueIn = isCC ? daysUntil(acc.next_due_date) : null
@@ -430,9 +408,7 @@ export default function AccountsPage() {
                           return (
                             <div key={acc.id} className="group flex items-center px-5 py-3 hover:bg-muted/50 transition-colors">
                               <Link to={`/accounts/${acc.id}`} className="flex items-center gap-3 flex-1 min-w-0">
-                                <div className={`w-8 h-8 rounded-lg ${cfg.bg} flex items-center justify-center shrink-0`}>
-                                  <Icon size={14} className={cfg.color} />
-                                </div>
+                                <AccountIcon account={acc} />
                                 <div className="min-w-0 flex-1">
                                   <p className="text-sm font-medium text-foreground truncate">{getAccountName(acc)}</p>
                                   <p className="text-xs text-muted-foreground">
@@ -500,14 +476,10 @@ export default function AccountsPage() {
               </div>
               <div className="divide-y divide-muted">
                 {closedAccounts.map((acc) => {
-                  const cfg = getTypeConfig(acc.type)
-                  const Icon = cfg.icon
                   return (
                     <div key={acc.id} className="flex items-center px-5 py-3">
                       <div className="flex items-center gap-3 flex-1 min-w-0">
-                        <div className={`w-8 h-8 rounded-lg ${cfg.bg} flex items-center justify-center shrink-0`}>
-                          <Icon size={14} className={cfg.color} />
-                        </div>
+                        <AccountIcon account={acc} />
                         <p className="text-sm font-medium text-muted-foreground truncate">{getAccountName(acc)}</p>
                       </div>
                       {canWrite && (

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -34,6 +34,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { ICON_MAP } from '@/lib/category-icons'
 import { PageHeader } from '@/components/page-header'
 import { CategoryIcon } from '@/components/category-icon'
+import { AccountIcon } from '@/components/account-icon'
 import { TransactionDrillDown, type DrillDownFilter } from '@/components/transaction-drill-down'
 import { TransactionDialog, extractApiError } from '@/components/transaction-dialog'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
@@ -277,6 +278,7 @@ export default function DashboardPage() {
     categoryIcon: string | null
     categoryName: string | null
     categoryColor: string | null
+    accountId: string | null
     isProjected: boolean
     attachmentCount: number
     isShared: boolean
@@ -319,6 +321,7 @@ export default function DashboardPage() {
         categoryIcon: tx.category?.icon ?? null,
         categoryName: tx.category?.name ?? null,
         categoryColor: tx.category?.color ?? null,
+        accountId: tx.account_id ?? null,
         isProjected: false,
         attachmentCount: tx.attachment_count ?? 0,
         isShared,
@@ -342,6 +345,7 @@ export default function DashboardPage() {
         categoryIcon: pt.category_icon,
         categoryName: pt.category_name,
         categoryColor: pt.category_color ?? null,
+        accountId: null,
         isProjected: true,
         attachmentCount: 0,
         isShared: false,
@@ -912,7 +916,9 @@ export default function DashboardPage() {
               <Table>
                 <TableHeader>
                   <TableRow className="border-b border-border hover:bg-transparent">
-                    <TableHead className="pl-5 text-xs font-medium text-muted-foreground">{t('transactions.description')}</TableHead>
+                    <TableHead className="pl-5 text-xs font-medium text-muted-foreground hidden sm:table-cell">{t('transactions.date')}</TableHead>
+                    <TableHead className="text-xs font-medium text-muted-foreground">{t('transactions.description')}</TableHead>
+                    <TableHead className="text-xs font-medium text-muted-foreground hidden sm:table-cell">{t('transactions.account')}</TableHead>
                     <TableHead className="pr-5 text-right text-xs font-medium text-muted-foreground">{t('transactions.amount')}</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -939,7 +945,10 @@ export default function DashboardPage() {
                         if (tx) { setEditingTx(tx); setDialogOpen(true) }
                       }}
                     >
-                      <TableCell className="py-2.5 pl-5">
+                      <TableCell className="py-2.5 pl-5 text-sm text-muted-foreground tabular-nums whitespace-nowrap hidden sm:table-cell">
+                        {formatDate(row.date, dateLocale)}
+                      </TableCell>
+                      <TableCell className="py-2.5 pl-5 sm:pl-0">
                         <div className="flex items-center gap-3">
                           <CategoryIcon icon={row.categoryIcon} color={row.categoryColor} size="lg" />
                           <div className="min-w-0">
@@ -968,9 +977,23 @@ export default function DashboardPage() {
                                 <Paperclip size={12} className="text-muted-foreground shrink-0" />
                               )}
                             </div>
-                            <p className="text-xs text-muted-foreground">{formatDate(row.date, dateLocale)}</p>
+                            <p className="text-xs text-muted-foreground sm:hidden">{formatDate(row.date, dateLocale)}</p>
                           </div>
                         </div>
+                      </TableCell>
+                      <TableCell className="py-2.5 text-sm text-muted-foreground hidden sm:table-cell">
+                        {(() => {
+                          const acc = row.accountId
+                            ? accountsList?.find((a) => a.id === row.accountId)
+                            : undefined
+                          if (!acc) return <span className="text-muted-foreground">—</span>
+                          return (
+                            <span className="flex items-center gap-2 min-w-0">
+                              <AccountIcon account={acc} size="sm" />
+                              <span className="truncate">{getAccountName(acc)}</span>
+                            </span>
+                          )
+                        })()}
                       </TableCell>
                       <TableCell className="py-2.5 pr-5 text-right">
                         <span className={`text-sm font-semibold tabular-nums ${row.isIgnored ? 'text-gray-500' : row.type === 'credit' ? 'text-emerald-600' : 'text-rose-500'}`}>

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { useRegisterPageChatContext } from '@/lib/page-chat-context'
 import { getAccountName } from '@/lib/account-utils'
+import { AccountIcon } from '@/components/account-icon'
 import { currentMonth, monthRange, monthFromRange } from '@/lib/month-utils'
 import { MonthStepper } from '@/components/month-stepper'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -984,14 +985,21 @@ export default function TransactionsPage() {
             )}
           </TableCell>
         )
-      case 'account':
+      case 'account': {
+        const acc = accountsList?.find((a) => a.id === tx.account_id)
         return (
           <TableCell key={col.id} style={widthStyle} className={`${baseClass} text-sm text-muted-foreground`}>
-            {getAccountName(accountsList?.find((a) => a.id === tx.account_id) ?? { name: '', display_name: null }) || (
+            {acc ? (
+              <span className="flex items-center gap-2 min-w-0">
+                <AccountIcon account={acc} size="sm" />
+                <span className="truncate">{getAccountName(acc)}</span>
+              </span>
+            ) : (
               <span className="text-muted-foreground">—</span>
             )}
           </TableCell>
         )
+      }
       case 'amount':
         return (
           <TableCell key={col.id} style={widthStyle} className={`${baseClass} pr-5`}>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -91,6 +91,7 @@ export interface BankConnection {
   provider: string
   institution_name: string
   display_name: string | null
+  logo_url: string | null
   external_id: string
   status: string
   settings: ConnectionSettings | null
@@ -110,6 +111,10 @@ export interface Account {
   external_id: string | null
   name: string
   display_name: string | null
+  // Denormalized bank identity from the linked connection (null for manual
+  // accounts). Used to render the institution logo next to the account.
+  institution_name: string | null
+  institution_logo_url: string | null
   type: string
   balance: number
   current_balance: number


### PR DESCRIPTION
## What

<img width="654" height="687" alt="Screenshot 2026-06-08 at 12 33 18" src="https://github.com/user-attachments/assets/5c7833e2-b6f5-48ef-bc90-c27f3902bd54" />


Show the bank's institution logo next to the account name on the **accounts page**, the **transactions list**, and the **dashboard** (which also gets a dedicated Conta/Account column). Manual accounts and accounts without a logo fall back to the existing account-type icon.

## Why

Accounts were identified by name alone, making it hard to tell at a glance where a transaction came from. A recognizable bank logo makes scanning the transaction and account lists much faster.

## How

Each provider already receives the institution logo and threw it away; we now capture and persist it:
- **Pluggy** → `connector.imageUrl`
- **Enable Banking** → ASPSP `logo` (matched by institution name)
- **SimpleFIN** → no logo image, so we derive a favicon from the bank's `org` URL (reusing the same favicon helper as asset logos)

The logo is stored on `bank_connections.logo_url` (new nullable column, migration `055`) and denormalized onto `AccountRead` so every surface can render it without an extra join. Existing connections backfill automatically on their next sync (best-effort, never breaks a sync). A shared `AccountIcon` component renders the logo with an `onError` fallback to the type icon.

## How to Test
1. Connect a bank (or use an existing connection) and run a sync.
2. Open the **Accounts** page — connection headers and account rows show the bank logo; manual accounts keep the type icon.
3. Open **Transactions** — the Account column shows the logo next to the account name.
4. Open the **Dashboard** — the period transactions table has a new Account column with the logo.
5. A SimpleFIN connection shows a favicon derived from the bank URL; a connection with no logo and no URL falls back to the type icon.

## Changes

| File | What changed |
|---|---|
| `backend/alembic/versions/055_bank_connection_logo_url.py` | New nullable `logo_url` column on `bank_connections`. |
| `backend/app/models/bank_connection.py`, `schemas/bank_connection.py` | Store/expose `logo_url`. |
| `backend/app/providers/base.py` | `ConnectionData.logo_url` field + `get_institution_logo()` hook (default no-op). |
| `backend/app/providers/pluggy.py` / `enable_banking.py` / `simplefin.py` | Capture the logo at connect + implement `get_institution_logo` for sync backfill. |
| `backend/app/providers/favicon.py` | Shared favicon helper extracted from `market_price.py` (used by assets and banks). |
| `backend/app/services/connection_service.py` | Persist logo on connect/reconnect, backfill on sync, `_clean_logo_url` guard. |
| `backend/app/services/account_service.py`, `schemas/account.py`, `api/accounts.py` | Denormalize `institution_name` / `institution_logo_url` onto `AccountRead`. |
| `frontend/src/components/account-icon.tsx` | New `AccountIcon` / `ConnectionLogo` (logo with type-icon fallback). |
| `frontend/src/pages/accounts.tsx`, `transactions.tsx`, `dashboard.tsx`, `types/index.ts` | Render logos across the three surfaces; dashboard gets Date/Account columns. |

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Backend lints clean (`ruff`)
- [x] Frontend builds (`npm run build`)
- [x] Migration is additive and nullable (safe for existing installs)