### PR TITLE
fix(migrations): resolve duplicate 055 revision from #276/#294 merge

### DIFF
--- a/backend/alembic/versions/056_collections.py
+++ b/backend/alembic/versions/056_collections.py
@@ -1,7 +1,7 @@
 """add collections (account groups for reporting/filtering)
 
-Revision ID: 055
-Revises: 054
+Revision ID: 056
+Revises: 055
 Create Date: 2026-06-05
 """
 
@@ -9,8 +9,8 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID
 
-revision = "055"
-down_revision = "054"
+revision = "056"
+down_revision = "055"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/057_collection_wallets.py
+++ b/backend/alembic/versions/057_collection_wallets.py
@@ -1,7 +1,7 @@
 """add collection <-> wallet (asset_group) membership
 
-Revision ID: 056
-Revises: 055
+Revision ID: 057
+Revises: 056
 Create Date: 2026-06-05
 """
 
@@ -9,8 +9,8 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID
 
-revision = "056"
-down_revision = "055"
+revision = "057"
+down_revision = "056"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## What

#276 (collections) and #294 (bank logos) each shipped a migration with `revision="055"` / `down_revision="054"`. Merged together on `main`, this leaves a duplicate revision id and two alembic heads, so **`alembic upgrade head` fails on a fresh database** and a clean deploy can't start.

Re-chains collections after the logo migration so the graph is linear and unique:

`054 → 055 (logo) → 056 (collections) → 057 (wallets)`

No schema changes; only revision ids / file names.

## How to Test

1. `alembic heads` shows a single head (`057`).
2. On a fresh DB, `alembic upgrade head` runs clean through all four.
3. `pytest tests/test_collections_api.py tests/test_collection_filtering.py` passes (test DB migrates from scratch).

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Migrations apply cleanly from scratch (`alembic upgrade head`)
- [x] ruff clean
