### PR TITLE
fix(frontend): stop Vite build dir from shadowing the /assets route (#295)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,6 +24,15 @@ export default defineConfig(async ({ mode }) => {
     define: {
       __APP_VERSION__: JSON.stringify(appVersion),
     },
+    build: {
+      // Emit hashed JS/CSS into `static/` instead of Vite's default `assets/`.
+      // The default collides with our `/assets` SPA route: nginx's
+      // `try_files $uri $uri/ /index.html` matches the real `dist/assets/`
+      // directory before falling back to index.html, so a direct load or
+      // refresh of `/assets` 301s into the build dir and renders a blank
+      // page instead of booting the app (issue #295).
+      assetsDir: 'static',
+    },
     plugins: [react(), tailwindcss()],
     resolve: {
       alias: {


### PR DESCRIPTION
Fixes #295

## What

The **Assets** page can't be opened by direct URL or reloaded — both render a blank page. It only loads when reached through the sidebar.

This PR points Vite's `build.assetsDir` at `static/` (instead of the default `assets/`) so the build output no longer shadows the `/assets` SPA route.

## Why

Vite emits hashed JS/CSS into `dist/assets/`, which collides with the app's `/assets` route. The production nginx SPA fallback is `try_files $uri $uri/ /index.html`, so a direct load or refresh of `/assets` matches the real `dist/assets/` **directory** via `$uri/` and 301s into it instead of falling back to `index.html`. The bundle never loads, so the page renders blank.

Sidebar navigation works because it's client-side routing that never hits nginx. The bug only reproduces on the production (nginx) build — the dev server has its own SPA fallback and no `dist/assets/` directory.

Emitting build assets to `static/` removes the collision entirely: no directory shadows a route, so nginx falls back to `index.html` and the SPA boots normally on direct load and refresh.

## How to Test

1. On `main`, build the frontend and serve `dist/` with the production nginx config: `GET /assets` → **301** into the build dir → blank page.
2. On this branch: rebuild (`npm run build`) — assets land in `dist/static/`, no `dist/assets/` dir.
3. Serve `dist/` with the same nginx config and open `/assets` directly (or refresh): the Assets page renders, and real build chunks are still served from `/static/`.

Verified against the production nginx build in Chrome: cold load **and** refresh of `/assets` now render the full page (chart, wallets, asset cards) with no console errors; `/transactions`, `/reports`, etc. continue to work.

## Checklist

- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Verified in the browser against the production nginx build (direct load + refresh)
- [x] No user-facing strings changed