### PR TITLE
feat(accounts): allow overriding the type of bank-connected accounts (#271)

### DIFF
--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -267,12 +267,17 @@ async def update_account(
         k in update_data for k in ("statement_close_day", "payment_due_day")
     )
 
-    # Bank-connected accounts are managed by the sync pipeline. Only credit card
-    # metadata (limit + cycle days) can be user-edited, since providers often don't
-    # expose those — users fill them in to unlock cycle-aware filtering.
+    # Bank-connected accounts are managed by the sync pipeline. Beyond display
+    # name and credit card metadata (limit + cycle days, which providers often
+    # don't expose), users may also override the account `type` — providers
+    # sometimes misreport it (e.g. Enable Banking labels an mBank savings
+    # account as "checking"; issue #271). Sync only writes `type` on initial
+    # account creation and never overwrites it afterwards, so the override
+    # survives subsequent syncs without a separate field.
     if account.connection_id is not None:
         editable_fields = {
             "display_name",
+            "type",
             "credit_limit",
             "statement_close_day",
             "payment_due_day",
@@ -283,12 +288,22 @@ async def update_account(
         disallowed = set(update_data.keys()) - editable_fields
         if disallowed:
             raise ValueError("Cannot edit bank-connected accounts")
-        cc_fields = editable_fields - {"display_name"}
+        new_type = update_data.get("type", account.type)
+        cc_fields = editable_fields - {"display_name", "type"}
         cc_update = {k: v for k, v in update_data.items() if k in cc_fields}
-        if cc_update and account.type != "credit_card":
+        if cc_update and new_type != "credit_card":
             raise ValueError("Credit card fields can only be set on credit card accounts")
         for key, value in update_data.items():
             setattr(account, key, value)
+        # If the override moves the account away from credit_card, drop any
+        # stale card metadata so it isn't left half credit-card.
+        if new_type != "credit_card":
+            account.credit_limit = None
+            account.statement_close_day = None
+            account.payment_due_day = None
+            account.minimum_payment = None
+            account.card_brand = None
+            account.card_level = None
         if cycle_fields_changed:
             await _recompute_effective_dates(session, account)
         await session.commit()

--- a/backend/tests/test_account_service.py
+++ b/backend/tests/test_account_service.py
@@ -280,6 +280,44 @@ async def test_update_bank_connected_raises(session: AsyncSession, test_user, te
 
 
 @pytest.mark.asyncio
+async def test_update_bank_connected_type_override(
+    session: AsyncSession, test_user, test_workspace, test_connection
+):
+    """The account type can be overridden on a bank-connected account (issue #271)."""
+    account = await _make_account(
+        session, test_user.id, "mBank Savings", acc_type="checking",
+        connection_id=test_connection.id, external_id="ext-type",
+    )
+    updated = await update_account(
+        session, account.id, test_workspace.id, AccountUpdate(type="savings")
+    )
+    assert updated is not None
+    assert updated.type == "savings"
+
+
+@pytest.mark.asyncio
+async def test_update_bank_connected_type_override_clears_card_metadata(
+    session: AsyncSession, test_user, test_workspace, test_connection
+):
+    """Overriding a connected card to a non-card type drops stale card metadata."""
+    account = await _make_account(
+        session, test_user.id, "Was a card", acc_type="credit_card",
+        connection_id=test_connection.id, external_id="ext-card",
+    )
+    account.credit_limit = Decimal("5000.00")
+    account.statement_close_day = 10
+    await session.commit()
+
+    updated = await update_account(
+        session, account.id, test_workspace.id, AccountUpdate(type="checking")
+    )
+    assert updated is not None
+    assert updated.type == "checking"
+    assert updated.credit_limit is None
+    assert updated.statement_close_day is None
+
+
+@pytest.mark.asyncio
 async def test_update_account_not_found(session: AsyncSession, test_user, test_workspace):
     """Updating nonexistent account returns None."""
     data = AccountUpdate(name="Ghost")

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -456,6 +456,7 @@
     "accountName": "Account name",
     "displayName": "Display name",
     "displayNameHint": "Overrides the default provider name everywhere in the app.",
+    "typeOverrideHint": "Overrides the account type reported by your bank. Syncs won't change it back.",
     "accountType": "Type",
     "currency": "Currency",
     "typeChecking": "Checking",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -454,6 +454,7 @@
     "accountName": "Nombre de la cuenta",
     "displayName": "Nombre para mostrar",
     "displayNameHint": "Sobrescribe el nombre del proveedor por defecto en toda la app.",
+    "typeOverrideHint": "Sobrescribe el tipo de cuenta informado por tu banco. La sincronización no lo revierte.",
     "accountType": "Tipo",
     "currency": "Moneda",
     "typeChecking": "Cuenta corriente",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -429,6 +429,7 @@
     "accountName": "Nome del conto",
     "displayName": "Nome visualizzato",
     "displayNameHint": "Sostituisce il nome predefinito del provider ovunque nell'app.",
+    "typeOverrideHint": "Sostituisce il tipo di conto riportato dalla tua banca. La sincronizzazione non lo ripristina.",
     "accountType": "Tipo",
     "currency": "Valuta",
     "typeChecking": "Conto corrente",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -483,6 +483,7 @@
     "accountName": "Nazwa konta",
     "displayName": "Nazwa wyświetlana",
     "displayNameHint": "Zastępuje domyślną nazwę dostawcy wszędzie w aplikacji.",
+    "typeOverrideHint": "Zastępuje typ konta zgłoszony przez bank. Synchronizacja go nie przywróci.",
     "accountType": "Typ",
     "currency": "Waluta",
     "typeChecking": "Bieżące",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -456,6 +456,7 @@
     "accountName": "Nome da conta",
     "displayName": "Nome de exibição",
     "displayNameHint": "Substitui o nome padrão do provedor em todo o sistema.",
+    "typeOverrideHint": "Substitui o tipo de conta informado pelo seu banco. A sincronização não reverte.",
     "accountType": "Tipo",
     "currency": "Moeda",
     "typeChecking": "Conta Corrente",

--- a/frontend/src/pages/accounts.tsx
+++ b/frontend/src/pages/accounts.tsx
@@ -43,6 +43,17 @@ import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
 
+// Account types offered in the create/edit dialog. Shared between the manual
+// type selector and the connected-account override selector so the list stays
+// in one place.
+const ACCOUNT_TYPE_OPTIONS = [
+  { value: 'checking', labelKey: 'accounts.typeChecking' },
+  { value: 'savings', labelKey: 'accounts.typeSavings' },
+  { value: 'credit_card', labelKey: 'accounts.typeCreditCard' },
+  { value: 'investment', labelKey: 'accounts.typeInvestment' },
+  { value: 'wallet', labelKey: 'accounts.typeWallet' },
+] as const
+
 function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
   return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
 }
@@ -723,7 +734,8 @@ function AccountDialog({
             }
             const isConnected = !!account?.connection_id
             onSave({
-              ...(!isConnected && { name, type, balance: parseFloat(balance), balance_date: balanceDate, currency }),
+              ...(!isConnected && { name, balance: parseFloat(balance), balance_date: balanceDate, currency }),
+              type,
               display_name: displayName.trim() || null,
               ...(isCC && {
                 credit_limit: creditLimit !== '' ? parseFloat(creditLimit) : null,
@@ -749,6 +761,21 @@ function AccountDialog({
               <p className="text-xs text-muted-foreground">{t('accounts.displayNameHint')}</p>
             </div>
           )}
+          {account?.connection_id && (
+            <div className="space-y-2">
+              <Label>{t('accounts.accountType')}</Label>
+              <select
+                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                value={type}
+                onChange={(e) => setType(e.target.value)}
+              >
+                {ACCOUNT_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{t(o.labelKey)}</option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground">{t('accounts.typeOverrideHint')}</p>
+            </div>
+          )}
           {!account?.connection_id && (
             <>
               <div className="grid grid-cols-2 gap-4">
@@ -759,11 +786,9 @@ function AccountDialog({
                     value={type}
                     onChange={(e) => setType(e.target.value)}
                   >
-                    <option value="checking">{t('accounts.typeChecking')}</option>
-                    <option value="savings">{t('accounts.typeSavings')}</option>
-                    <option value="credit_card">{t('accounts.typeCreditCard')}</option>
-                    <option value="investment">{t('accounts.typeInvestment')}</option>
-                    <option value="wallet">{t('accounts.typeWallet')}</option>
+                    {ACCOUNT_TYPE_OPTIONS.map((o) => (
+                      <option key={o.value} value={o.value}>{t(o.labelKey)}</option>
+                    ))}
                   </select>
                 </div>
                 <div className="space-y-2">


### PR DESCRIPTION
Closes #271

## What

Let users override the **account type** of a bank-connected account from the account edit dialog. The Type selector — previously shown only for manual accounts — now appears for connected accounts too, and the API accepts `type` edits on them.

## Why

Providers sometimes misreport the account type. As reported in the issue, Enable Banking labels an mBank **savings** account as **checking**. Type isn't just cosmetic — it drives how accounts are grouped and, for credit cards, whether the balance is treated as a liability in net worth. Users had no way to correct it.

The sync pipeline only writes `type` when it first creates an account and never overwrites it on later syncs, so a user override persists across syncs **without** needing a separate override column or migration.

## Changes

- **`account_service.update_account`** — add `type` to the editable-field whitelist for connected accounts. When the override moves an account off `credit_card`, stale card metadata (limit, cycle days, brand/level) is cleared so it isn't left in a half-credit-card state.
- **`accounts.tsx`** — show the Type selector for connected accounts with a hint that the override survives syncs; always send `type` on save. The type option list is extracted to a shared `ACCOUNT_TYPE_OPTIONS` constant (used by both the manual and connected selectors).
- **i18n** — new `accounts.typeOverrideHint` string (en, pt-BR, es, it, pl).

## How to Test

1. Connect a bank and sync so you have a connected account.
2. Open the account's edit dialog — the **Type** dropdown now appears, with a hint that the override won't be reverted by syncs.
3. Change the type (e.g. Checking → Savings) and save — the account updates immediately.
4. Trigger a re-sync — the override is preserved.
5. Override a connected card to a non-card type — credit-card-only fields are dropped.

Verified in Chrome against a connected NuBank account (Checking → Savings → back).

## Checklist

- [x] Backend tests pass (`pytest` — new `test_account_service` cases for override persistence + card-metadata clearing, plus existing account suites)
- [x] Backend lints clean (`ruff`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (en, pt-BR, es, it, pl)