### PR TITLE
fix(rules): clear form when creating a new rule after saving (#306)

### DIFF
--- a/frontend/src/pages/rules.tsx
+++ b/frontend/src/pages/rules.tsx
@@ -117,6 +117,21 @@ export default function RulesPage() {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [packsDialogOpen, setPacksDialogOpen] = useState(false)
   const [editing, setEditing] = useState<Rule | null>(null)
+  // Bumped on every open so the dialog remounts with fresh state instead of
+  // retaining the previously entered rule (issue #306).
+  const [dialogInstance, setDialogInstance] = useState(0)
+
+  function openCreate() {
+    setEditing(null)
+    setDialogInstance((n) => n + 1)
+    setDialogOpen(true)
+  }
+
+  function openEdit(rule: Rule) {
+    setEditing(rule)
+    setDialogInstance((n) => n + 1)
+    setDialogOpen(true)
+  }
 
   const { data: rulesList } = useQuery({
     queryKey: ['rules'],
@@ -251,7 +266,7 @@ export default function RulesPage() {
                   <RefreshCw size={12} />
                   <span className="hidden sm:inline">{t('rules.reapplyAll')}</span>
                 </Button>
-                <Button size="sm" className="gap-1.5 h-8" onClick={() => { setEditing(null); setDialogOpen(true) }}>
+                <Button size="sm" className="gap-1.5 h-8" onClick={openCreate}>
                   <Plus size={13} /> <span className="hidden sm:inline">{t('rules.add')}</span>
                 </Button>
               </div>
@@ -290,7 +305,7 @@ export default function RulesPage() {
                   'px-4 sm:px-5 py-3 hover:bg-muted transition-colors',
                   canWrite && 'cursor-pointer',
                 )}
-                onClick={() => { if (canWrite) { setEditing(rule); setDialogOpen(true) } }}
+                onClick={() => { if (canWrite) openEdit(rule) }}
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">
@@ -338,7 +353,7 @@ export default function RulesPage() {
       />
 
       <RuleDialog
-        key={editing?.id ?? 'new'}
+        key={dialogInstance}
         open={dialogOpen}
         onClose={() => { setDialogOpen(false); setEditing(null) }}
         rule={editing}


### PR DESCRIPTION
## Summary

Fixes #306 — after saving a rule and clicking **Add** again, the "New Rule" form was pre-filled with the previously entered rule's data. A page refresh was needed to get an empty form. Only the create path was affected; edit worked correctly.

## Root cause

`RuleDialog` initializes its internal state (name, conditions, actions, etc.) from props **once on mount**, and only resets that state when its React `key` changes. The key was `editing?.id ?? 'new'`, which resolves to the constant string `'new'` for every create. After a successful save the dialog merely hides (`open=false`) without unmounting, so the next "Add" reused the stale state. Edit was unaffected because each rule's `id` produced a distinct key.

## Fix

Introduce a `dialogInstance` counter that increments every time the dialog is opened (for both create and edit) and use it as the `RuleDialog` key. This forces a fresh remount on every open, guaranteeing an empty form for new rules while preserving the populated form for edits.

## Verification

Reproduced and verified the fix in the running app (Docker):

- **Before:** create a rule → Save → click Add → form shows the previous rule's name and conditions.
- **After:** create a rule → Save → click Add → form is empty (name placeholder, priority 0, empty condition, no category).

Test rules created during verification were cleaned up. `tsc -b` and `eslint` pass (no new warnings).