### PR TITLE
fix(prod): set container TZ so bank sync uses local calendar day

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ ENABLE_BANKING_OAUTH_REDIRECT_URI=http://localhost:${FRONTEND_PORT:-3000}/oauth/
 # OIDC_ADMIN_ROLES=securo-admins
 # OIDC_WORKSPACE_ROLE_MAP={"securo-owners":"owner","securo-editors":"editor","securo-viewers":"viewer"}
 
+# Timezone (optional) — set to your local tz so bank sync uses the expected calendar day. Defaults to UTC.
+# TZ=Europe/London
+
 # Host ports (optional) — change these to avoid conflicts with other services
 ## Default values are set in docker-compose.yml and docker-compose.prod.yml.
 ## Example:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,7 +8,7 @@ x-podman:
   in_pod: false
 
 x-backend-env: &backend-env
-  TZ: ${TZ:-Europe/London}
+  TZ: ${TZ:-UTC}
   DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/securo
   SECRET_KEY: ${SECRET_KEY:-dev-secret-change-in-production}
   DEBUG: ${DEBUG:-false}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,6 +8,7 @@ x-podman:
   in_pod: false
 
 x-backend-env: &backend-env
+  TZ: ${TZ:-Europe/London}
   DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/securo
   SECRET_KEY: ${SECRET_KEY:-dev-secret-change-in-production}
   DEBUG: ${DEBUG:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-podman:
   in_pod: false
 
 x-backend-env: &backend-env
-  TZ: ${TZ:-Europe/London}
+  TZ: ${TZ:-UTC}
   DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/securo
   SECRET_KEY: ${SECRET_KEY:-dev-secret-change-in-production}
   DEBUG: ${DEBUG:-true}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ x-podman:
   in_pod: false
 
 x-backend-env: &backend-env
+  TZ: ${TZ:-Europe/London}
   DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/securo
   SECRET_KEY: ${SECRET_KEY:-dev-secret-change-in-production}
   DEBUG: ${DEBUG:-true}


### PR DESCRIPTION
## What

Add TZ env in docker-compose file

## Why

This wasn't explicit that this was needed

## How to Test

Steps to verify the changes work:

1. Set TZ as some timezone
2. `docker compose -f docker-compose.prod.yml exec -T celery-worker date` should show a different value than UTC

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
