### PR TITLE
fix(prod): add restart policy to db and redis

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -66,6 +66,7 @@ x-backend-base: &backend-base
 services:
   redis:
     image: docker.io/library/redis:7-alpine
+    restart: unless-stopped
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 5s
@@ -77,6 +78,7 @@ services:
     # that bundles the pgvector extension, required by the agents
     # knowledge-base (RAG) migration introduced in v0.11.0.
     image: ${DB_IMAGE:-docker.io/pgvector/pgvector:pg16}
+    restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ x-backend-base: &backend-base
 services:
   redis:
     image: docker.io/library/redis:7-alpine
+    restart: unless-stopped
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 5s
@@ -77,6 +78,7 @@ services:
     # that ships the `vector` extension. Required for the agents
     # knowledge base; harmless when AGENTS_ENABLED=false.
     image: ${DB_IMAGE:-docker.io/pgvector/pgvector:pg16}
+    restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
## What

Added restart policy to db and redis in the prod docker-compose

## Why

Only backend-base carried restart: unless-stopped; db and redis had none. After a host reboot the data services stayed down while backend/celery restart-looped against unresolvable hostnames, taking the whole stack offline. Add restart: unless-stopped to both so they recover automatically.

## How to Test

Reup your stack
Restart the host
You should be able to login

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
