### PR TITLE
fix(goals): accept asset tracking type when updating a goal

### DIFF
--- a/backend/app/schemas/goal.py
+++ b/backend/app/schemas/goal.py
@@ -52,8 +52,8 @@ class GoalUpdate(BaseModel):
     @field_validator("tracking_type")
     @classmethod
     def validate_tracking_type(cls, v: Optional[str]) -> Optional[str]:
-        if v is not None and v not in ("manual", "account", "net_worth"):
-            raise ValueError("tracking_type must be manual, account, or net_worth")
+        if v is not None and v not in ("manual", "account", "asset", "net_worth"):
+            raise ValueError("tracking_type must be manual, account, asset, or net_worth")
         return v
 
 

--- a/backend/tests/test_goals_api.py
+++ b/backend/tests/test_goals_api.py
@@ -230,6 +230,42 @@ async def test_update_goal_status(client: AsyncClient, auth_headers: dict, test_
 
 
 @pytest.mark.asyncio
+async def test_update_goal_tracking_type(client: AsyncClient, auth_headers: dict, test_user: User):
+    resp = await client.post(
+        "/api/goals",
+        json={"name": "Tracking Goal", "target_amount": "1000.00", "tracking_type": "manual"},
+        headers=auth_headers,
+    )
+    goal_id = resp.json()["id"]
+
+    for tracking_type in ("manual", "account", "asset", "net_worth"):
+        response = await client.patch(
+            f"/api/goals/{goal_id}",
+            json={"tracking_type": tracking_type},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["tracking_type"] == tracking_type
+
+
+@pytest.mark.asyncio
+async def test_update_goal_invalid_tracking_type(client: AsyncClient, auth_headers: dict, test_user: User):
+    resp = await client.post(
+        "/api/goals",
+        json={"name": "Bad Tracking", "target_amount": "1000.00", "tracking_type": "manual"},
+        headers=auth_headers,
+    )
+    goal_id = resp.json()["id"]
+
+    response = await client.patch(
+        f"/api/goals/{goal_id}",
+        json={"tracking_type": "invalid"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_update_goal_invalid_status(client: AsyncClient, auth_headers: dict, test_user: User):
     resp = await client.post(
         "/api/goals",


### PR DESCRIPTION
## Problem

Updating a goal with `tracking_type: "asset"` always fails with a 422. `GoalUpdate.validate_tracking_type` only accepts `manual`, `account`, and `net_worth`, while `GoalCreate` also accepts `asset` — so an asset-tracked goal can be created but never edited, since the edit form resends the tracking type on every save.

```json
{"detail":[{"type":"value_error","loc":["body","tracking_type"],
  "msg":"Value error, tracking_type must be manual, account, or net_worth",
  "input":"asset"}]}
```

Reported by José Francisco on Discord.

## Fix

Add `asset` to the `GoalUpdate` tracking_type validator, mirroring `GoalCreate`.

## Tests

- `test_update_goal_tracking_type` — PATCH succeeds for all four tracking types
- `test_update_goal_invalid_tracking_type` — invalid value still returns 422
- Full goal suite passes (75 tests)
- Verified manually in the browser: editing an asset-tracked goal returned 422 before, 200 after