### PR TITLE
fix(migrations): re-chain OIDC migration to 060 to clear duplicate 055

### DIFF
--- a/backend/alembic/versions/060_oidc_identity_linking.py
+++ b/backend/alembic/versions/060_oidc_identity_linking.py
@@ -1,16 +1,23 @@
 """add oidc identity linking to users
 
-Revision ID: 055
-Revises: 054
+Revision ID: 060
+Revises: 059
 Create Date: 2026-06-05
+
+Re-chained from the original "055" to 060 to resolve a duplicate revision id:
+the OIDC feature and the bank-connection-logo feature (#294) both shipped a
+migration numbered 055, leaving two alembic heads so `alembic upgrade head`
+failed on startup. This migration is additive (users.oidc_issuer/oidc_subject
++ indexes + unique constraint), so re-ordering it after the current head is
+safe; it simply applies on the next upgrade.
 """
 
 from alembic import op
 import sqlalchemy as sa
 
 
-revision = "055"
-down_revision = "054"
+revision = "060"
+down_revision = "059"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## What

The OIDC identity-linking migration and the bank-connection-logo migration (#294) both shipped as revision `055` / `down_revision 054`. Merged together on `main` this leaves a **duplicate revision id and two alembic heads**, so the backend fails `alembic upgrade head` on startup and **won't boot** — and a fresh deploy can't migrate. Same class of bug as #299.

Re-chains the OIDC migration after the current head so history is linear and unique:

`058 → 059 (asset_transactions) → 060 (oidc)`

The migration is additive (`users.oidc_issuer` / `oidc_subject` + indexes + unique constraint), so re-ordering it is safe — it simply applies on the next upgrade.

## Why

Right now `main` is **broken for any fresh deploy / backend restart** (multiple heads → `alembic upgrade head` fails). This is urgent and independent of any feature work.

## How to Test

1. On `main`: start the backend → it crash-loops with `Multiple head revisions are present`.
2. On this branch: `alembic heads` shows a single head (`060`); the backend boots.
3. From a DB at `059`, `alembic upgrade head` applies `060` cleanly and adds the OIDC columns.

## Checklist

- [x] Backend boots; single alembic head (`060`)
- [x] Migration applies cleanly from `059` (verified on a real DB)
- [x] Additive + reversible (`downgrade` drops the column/indexes)