### PR TITLE
fix: refresh transactions after on-the-fly rule creation

### DIFF
--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -586,11 +586,17 @@ export default function TransactionsPage() {
 
   const createRuleMutation = useMutation({
     mutationFn: (data: Omit<Rule, 'id' | 'user_id'>) => rulesApi.create(data),
-    onSuccess: () => {
+    onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ['rules'] })
       setCreateRuleOpen(false)
       setCreateRuleInitialData(undefined)
-      toast.success(t('rules.created'))
+      const applied = result.applied_count ?? 0
+      if (applied > 0) {
+        invalidateAfterTxMutation()
+        toast.success(t('rules.createdAndApplied', { count: applied }))
+      } else {
+        toast.success(t('rules.created'))
+      }
     },
     onError: (error: unknown) => {
       const err = error as { response?: { status?: number } }


### PR DESCRIPTION
## What

Refreshes financial queries after creating a categorization rule from the Transactions page when the backend reports that the new rule applied to existing transactions.

## Why

Creating a rule from a transaction applies the rule server-side, but the Transactions page only refreshed the rules cache. The visible transaction list could therefore continue showing the old category until a manual refresh.

## How to Test

1. `docker compose exec frontend npm run build`
2. `docker compose exec frontend npm run lint -- src/pages/transactions.tsx` exits 0 with existing repo warnings.
3. In the local app, open a transaction, create a matching rule with a category action, and confirm the Transactions list refreshes to show the new category without a manual page refresh.

## Screenshots

https://github.com/user-attachments/assets/d837bfbb-eac6-4666-ab2b-882638abc5af


## Checklist

- [ ] Backend tests pass (`pytest`) - not run; frontend cache invalidation change
- [ ] Frontend lints clean (`npm run lint`) - command exits 0, but existing warnings remain
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed) - reuses existing strings
