### PR TITLE
fix: Run frontend as rootless container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -114,7 +114,7 @@ services:
   frontend:
     image: ghcr.io/securo-finance/securo-frontend:latest
     ports:
-      - "${FRONTEND_PORT:-3000}:80"
+      - "${FRONTEND_PORT:-3000}:8080"
     environment:
       BACKEND_URL: http://backend:8000
       FRONTEND_URL: http://localhost:3000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,9 +12,9 @@ COPY . .
 RUN npm run build
 
 # Serve with nginx
-FROM nginx:alpine
+FROM nginxinc/nginx-unprivileged:alpine
 
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY default.conf.template /etc/nginx/templates/default.conf.template
 
-EXPOSE 80
+EXPOSE 8080

--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     root /usr/share/nginx/html;
     index index.html;
 


### PR DESCRIPTION
## What

This PR changes the base image of the frontend container to `nginxinc/nginx-unprivileged:alpine`

## Why

For security reasons container should not run as root user. Currently this was not possible as the user of the regular `nginx` binds to port 80 which is not allowed for non root users. The `nginx-unprivileged:alpine` container image binds to port 8080 and runs the container by default as user 1001 to avoid this risk.

This introduces a potential breaking change as the port mapping of the frontend container has to be changed in running instances.

## How to Test

Adjust the content of the [docker-compose.prod.yml](https://github.com/securo-finance/securo/blob/main/docker-compose.prod.yml) like this:

```
frontend:
  # image: ghcr.io/securo-finance/securo-frontend:latest
  build:
    context: ./frontend
    dockerfile: Dockerfile
  user: 1000:1000
```

This should work with the changes from this PR but not on the current main branch.

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
