### PR TITLE
fix(auth): surface backend outages instead of masking them as invalid credentials

### DIFF
--- a/frontend/src/lib/auth-errors.ts
+++ b/frontend/src/lib/auth-errors.ts
@@ -1,0 +1,20 @@
+import type { AxiosError } from 'axios'
+
+/**
+ * Tells "the backend answered and rejected the request" apart from "the
+ * backend never produced a usable answer" (stopped, unreachable, or 5xx
+ * from a proxy in front of a dead service).
+ *
+ * The auth screens used to collapse every failure into "invalid
+ * credentials", so an outage looked like a wrong password (issue #318).
+ * Use this to surface a connectivity hint instead.
+ */
+export function isServerUnreachable(err: unknown): boolean {
+  const axiosErr = err as AxiosError
+  // No HTTP response at all: connection refused, DNS, timeout, CORS — the
+  // server never answered.
+  if (!axiosErr?.response) return true
+  // 5xx (500/502/503/504) — e.g. a reverse proxy returning 502 while the
+  // backend container is down.
+  return axiosErr.response.status >= 500
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -160,6 +160,7 @@
     "forgotPassword": "Forgot password?",
     "loginDescription": "Sign in to access your account",
     "invalidCredentials": "Invalid email or password",
+    "serverError": "Couldn't connect to the server. Check your connection or that the backend is running, then try again.",
     "noAccount": "Don't have an account?",
     "hasAccount": "Already have an account?",
     "changePassword": "Change password",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -160,6 +160,7 @@
     "forgotPassword": "¿Olvidaste tu contraseña?",
     "loginDescription": "Inicia sesión para acceder a tu cuenta",
     "invalidCredentials": "Correo o contraseña inválidos",
+    "serverError": "No se pudo conectar con el servidor. Comprueba tu conexión o que el backend esté en ejecución e inténtalo de nuevo.",
     "noAccount": "¿No tienes una cuenta?",
     "hasAccount": "¿Ya tienes una cuenta?",
     "changePassword": "Cambiar contraseña",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -133,6 +133,7 @@
     "forgotPassword": "Password dimenticata?",
     "loginDescription": "Accedi per usare il tuo account",
     "invalidCredentials": "Email o password non validi",
+    "serverError": "Impossibile connettersi al server. Controlla la connessione o che il backend sia in esecuzione e riprova.",
     "noAccount": "Non hai un account?",
     "hasAccount": "Hai già un account?",
     "changePassword": "Cambia password",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -160,6 +160,7 @@
     "forgotPassword": "Nie pamiętasz hasła?",
     "loginDescription": "Zaloguj się, aby uzyskać dostęp do konta",
     "invalidCredentials": "Nieprawidłowy e-mail lub hasło",
+    "serverError": "Nie można połączyć się z serwerem. Sprawdź połączenie lub czy backend działa, a następnie spróbuj ponownie.",
     "noAccount": "Nie masz konta?",
     "hasAccount": "Masz już konto?",
     "changePassword": "Zmień hasło",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -160,6 +160,7 @@
     "forgotPassword": "Esqueceu a senha?",
     "loginDescription": "Entre para acessar sua conta",
     "invalidCredentials": "E-mail ou senha incorretos",
+    "serverError": "Não foi possível conectar ao servidor. Verifique sua conexão ou se o backend está em execução e tente novamente.",
     "noAccount": "Não tem uma conta?",
     "hasAccount": "Já tem uma conta?",
     "changePassword": "Alterar senha",

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardFooter } from '@/components/ui/card'
 import { ShellLogo } from '@/components/shell-logo'
 import type { AxiosError } from 'axios'
+import { isServerUnreachable } from '@/lib/auth-errors'
 import { useTheme } from 'next-themes'
 import { setThemeBasedOnSystem } from '@/lib/theme-utils'
 
@@ -62,7 +63,9 @@ export default function LoginPage() {
       }
     } catch (err) {
       const axiosErr = err as AxiosError
-      if (axiosErr?.response?.status === 429) {
+      if (isServerUnreachable(err)) {
+        setError(t('auth.serverError'))
+      } else if (axiosErr?.response?.status === 429) {
         setError(t('auth.tooManyAttempts'))
       } else {
         setError(t('auth.invalidCredentials'))
@@ -85,7 +88,9 @@ export default function LoginPage() {
       navigate('/')
     } catch (err) {
       const axiosErr = err as AxiosError
-      if (axiosErr?.response?.status === 401) {
+      if (isServerUnreachable(err)) {
+        setError(t('auth.serverError'))
+      } else if (axiosErr?.response?.status === 401) {
         setError(t('auth.invalidCredentials'))
         // Token expired, go back to login
         setRequires2fa(false)

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardFooter } from '@/components/ui/card'
 import { CurrencySelect } from '@/components/currency-select'
 import { ShellLogo } from '@/components/shell-logo'
 import { setThemeBasedOnSystem } from '@/lib/theme-utils'
+import { isServerUnreachable } from '@/lib/auth-errors'
 import type { AxiosError } from 'axios'
 
 export default function RegisterPage() {
@@ -59,7 +60,9 @@ export default function RegisterPage() {
       navigate('/')
     } catch (err) {
       const axiosErr = err as AxiosError
-      if (axiosErr?.response?.status === 429) {
+      if (isServerUnreachable(err)) {
+        setError(t('auth.serverError'))
+      } else if (axiosErr?.response?.status === 429) {
         setError(t('auth.tooManyAttempts'))
       } else {
         setError(t('auth.registrationError'))


### PR DESCRIPTION
## Problem

Closes #318

When the backend is stopped or unreachable, the login screen still showed **"Invalid email or password"**. A reverse proxy in front of a dead backend returns a 502 (and a fully unreachable backend yields a network error with no HTTP response), but the catch block treated every non-429 failure as bad credentials — so an outage was indistinguishable from a typo'd password.

## Fix

- New helper `lib/auth-errors.ts` → `isServerUnreachable(err)`: returns `true` when there is no HTTP response (connection refused, DNS, timeout) or the status is 5xx (500/502/503/504).
- Applied it in the **login** (`handleSubmit` + 2FA `handleVerify2fa`) and **register** flows: an unreachable backend now shows a dedicated connectivity hint; a genuine 401 still shows "Invalid email or password"; 429 still shows the rate-limit message.
- Added `auth.serverError` to all five locales (en, pt-BR, es, it, pl).

## Verification (in browser)

1. **Backend stopped** → login shows *"Couldn't connect to the server. Check your connection or that the backend is running, then try again."* ✅
2. **Backend running + wrong password** → login still shows *"Invalid email or password"* ✅

`tsc -b` and ESLint pass clean on the changed files.