### PR TITLE
feat(categories): add search to category picker and filter list

### DIFF
--- a/frontend/src/components/category-filter-content.tsx
+++ b/frontend/src/components/category-filter-content.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { X } from 'lucide-react'
+import { Search, X } from 'lucide-react'
 import {
   DropdownMenuCheckboxItem,
   DropdownMenuGroup,
@@ -8,10 +8,12 @@ import {
   DropdownMenuLabel,
 } from '@/components/ui/dropdown-menu'
 import type { Category, CategoryGroup } from '@/types'
+import { normalizeText } from '@/lib/utils'
 
 function toggleInArray(arr: string[], id: string): string[] {
   return arr.includes(id) ? arr.filter((x) => x !== id) : [...arr, id]
 }
+
 
 interface CategoryFilterContentProps {
   categoryIds: string[]
@@ -33,12 +35,11 @@ export function CategoryFilterContent({
   onKeepOpen,
 }: CategoryFilterContentProps) {
   const { t } = useTranslation()
+  const [search, setSearch] = useState('')
 
   const displayCategoryGroups = useMemo(() => {
     const ungrouped = (categories ?? []).filter((c) => !c.group_id)
-    if (ungrouped.length === 0) return groups
-
-    return [
+    const baseGroups = ungrouped.length === 0 ? groups : [
       ...groups,
       {
         id: 'ungrouped-virtual',
@@ -46,27 +47,64 @@ export function CategoryFilterContent({
         categories: ungrouped,
       } as CategoryGroup,
     ]
-  }, [categories, groups, t])
+
+    if (!search.trim()) return baseGroups
+
+    const query = normalizeText(search)
+    return baseGroups
+      .map((g) => ({
+        ...g,
+        categories: g.categories.filter((c) =>
+          normalizeText(c.name).includes(query)
+        ),
+      }))
+      .filter((g) => g.categories.length > 0)
+  }, [categories, groups, search, t])
+
+  const showUncategorized = useMemo(() => {
+    if (!search.trim()) return true
+    return normalizeText(t('transactions.uncategorized')).includes(normalizeText(search))
+  }, [search, t])
 
   return (
     <>
-      <DropdownMenuCheckboxItem
-        checked={filterUncategorized}
-        onSelect={(e) => {
-          e.preventDefault()
-          onKeepOpen?.()
-          onUncategorizedChange(!filterUncategorized)
-        }}
-        className="gap-2 rounded-sm py-1.5 text-[13px]"
-      >
-        <span className="min-w-0 flex-1 truncate text-left italic text-muted-foreground">
-          {t('transactions.uncategorized')}
-        </span>
-      </DropdownMenuCheckboxItem>
-      <div className="my-1 h-px bg-border/60" />
+      <div className="px-2 py-1.5 border-b border-border/50 sticky top-0 bg-popover z-10">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 size-3 text-muted-foreground/60" />
+          <input
+            type="text"
+            placeholder={t('transactions.searchCategory')}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="w-full rounded-md border border-input bg-transparent pl-7 pr-2.5 py-1 text-xs outline-hidden placeholder:text-muted-foreground/60 focus-visible:border-ring focus-visible:ring-[2px] focus-visible:ring-ring/25"
+          />
+        </div>
+      </div>
+      {showUncategorized && (
+        <>
+          <DropdownMenuCheckboxItem
+            checked={filterUncategorized}
+            onSelect={(e) => {
+              e.preventDefault()
+              onKeepOpen?.()
+              onUncategorizedChange(!filterUncategorized)
+            }}
+            className="gap-2 rounded-sm py-1.5 text-[13px]"
+          >
+            <span className="min-w-0 flex-1 truncate text-left italic text-muted-foreground">
+              {t('transactions.uncategorized')}
+            </span>
+          </DropdownMenuCheckboxItem>
+          <div className="my-1 h-px bg-border/60" />
+        </>
+      )}
       {displayCategoryGroups.length === 0 ? (
         <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
-          {t('transactions.filtersBar.noOptions')}
+          {search.trim()
+            ? t('transactions.noCategoryFound')
+            : t('transactions.filtersBar.noOptions')}
         </div>
       ) : (
         displayCategoryGroups.map((group) => (

--- a/frontend/src/components/category-select.tsx
+++ b/frontend/src/components/category-select.tsx
@@ -1,7 +1,10 @@
-import { useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { ChevronDownIcon, CheckIcon } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem } from '@/components/ui/command'
 import type { Category, CategoryGroup } from '@/types'
+import { cn, normalizeText } from '@/lib/utils'
 
 interface CategorySelectProps {
   value: string
@@ -12,21 +15,25 @@ interface CategorySelectProps {
   disabled?: boolean
   className?: string
   allowNone?: boolean
-  contentProps?: React.ComponentProps<typeof SelectContent>
+  contentProps?: React.ComponentProps<typeof PopoverContent>
 }
+
 
 export function CategorySelect({
   value,
   onChange,
   categories,
   groups,
-  placeholder = 'Select category',
+  placeholder,
   disabled = false,
-  className = "w-full border border-border rounded-md px-3 py-2 text-sm bg-background disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]",
+  className,
   allowNone = false,
   contentProps,
 }: CategorySelectProps) {
+  const [open, setOpen] = useState(false)
   const { t } = useTranslation()
+
+  const resolvedPlaceholder = placeholder ?? t('transactions.selectCategory', 'Select category')
 
   const displayGroups = useMemo(() => {
     const ungrouped = (categories ?? []).filter((c) => !c.group_id)
@@ -42,42 +49,101 @@ export function CategorySelect({
     ]
   }, [categories, groups, t])
 
+  const selectedCategory = useMemo(() => {
+    return (categories ?? []).find((c) => c.id === value)
+  }, [categories, value])
+
   return (
-    <Select
-      value={value === '' ? (allowNone ? 'none' : undefined) : value}
-      onValueChange={(nextValue) => {
-        onChange(nextValue === 'none' ? '' : nextValue)
-      }}
-      disabled={disabled}
-    >
-      <SelectTrigger className={className}>
-        <SelectValue placeholder={placeholder} />
-      </SelectTrigger>
-      <SelectContent position="popper" {...contentProps}>
-        {allowNone && (
-          <SelectItem value="none" className="italic text-muted-foreground">
-            {t('transactions.noCategory')}
-          </SelectItem>
-        )}
-        {displayGroups.map((group) => (
-          <SelectGroup key={group.id}>
-            <SelectLabel className="px-2 py-1.5 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
-              {group.name}
-            </SelectLabel>
-            {group.categories.map((cat) => (
-              <SelectItem key={cat.id} value={cat.id}>
-                {cat.color ? (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            "flex w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm text-left shadow-xs transition-[color,box-shadow] outline-hidden focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 dark:hover:bg-input/50 h-9 cursor-pointer",
+            className
+          )}
+        >
+          <span className="flex items-center gap-2 min-w-0 truncate">
+            {selectedCategory ? (
+              <>
+                {selectedCategory.color ? (
                   <span
                     className="size-2.5 shrink-0 rounded-full border border-black/5"
-                    style={{ backgroundColor: cat.color }}
+                    style={{ backgroundColor: selectedCategory.color }}
                   />
                 ) : null}
-                <span>{cat.name}</span>
-              </SelectItem>
+                <span className="truncate">{selectedCategory.name}</span>
+              </>
+            ) : value === '' && allowNone ? (
+              <span className="italic text-muted-foreground truncate">{t('transactions.noCategory')}</span>
+            ) : (
+              <span className="text-muted-foreground truncate">{resolvedPlaceholder}</span>
+            )}
+          </span>
+          <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[var(--radix-popover-trigger-width)] p-0 overflow-hidden"
+        {...contentProps}
+      >
+        <Command
+          filter={(itemValue, search) => {
+            return normalizeText(itemValue).includes(normalizeText(search)) ? 1 : 0
+          }}
+        >
+          <CommandInput placeholder={t('transactions.searchCategory')} />
+          <CommandList>
+            <CommandEmpty>{t('transactions.noCategoryFound')}</CommandEmpty>
+            {allowNone && (
+              <CommandGroup>
+                <CommandItem
+                  value={`none ${t('transactions.noCategory')}`}
+                  onSelect={() => {
+                    onChange('')
+                    setOpen(false)
+                  }}
+                  className="italic text-muted-foreground cursor-pointer"
+                >
+                  <span className="flex-1">{t('transactions.noCategory')}</span>
+                  {value === '' && <CheckIcon className="size-4 shrink-0" />}
+                </CommandItem>
+              </CommandGroup>
+            )}
+            {displayGroups.map((group) => (
+              <CommandGroup key={group.id}>
+                <div className="px-2 py-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
+                  {group.name}
+                </div>
+                {group.categories.map((cat) => (
+                  <CommandItem
+                    key={cat.id}
+                    value={`${group.name} ${cat.name}`}
+                    onSelect={() => {
+                      onChange(cat.id)
+                      setOpen(false)
+                    }}
+                    className="cursor-pointer"
+                  >
+                    <div className="flex items-center gap-2 min-w-0 truncate flex-1">
+                      {cat.color ? (
+                        <span
+                          className="size-2.5 shrink-0 rounded-full border border-black/5"
+                          style={{ backgroundColor: cat.color }}
+                        />
+                      ) : null}
+                      <span className="truncate">{cat.name}</span>
+                    </div>
+                    {value === cat.id && <CheckIcon className="size-4 shrink-0" />}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
             ))}
-          </SelectGroup>
-        ))}
-      </SelectContent>
-    </Select>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/frontend/src/components/command-palette.tsx
+++ b/frontend/src/components/command-palette.tsx
@@ -33,7 +33,7 @@ import {
 } from 'lucide-react'
 
 import { search as searchApi, type SearchHit, type SearchHitType } from '@/lib/api'
-import { cn } from '@/lib/utils'
+import { cn, normalizeText } from '@/lib/utils'
 
 // ---------------------------------------------------------------------------
 // Static actions & navigation registry
@@ -237,11 +237,6 @@ function formatHitDate(iso: string | null, locale: string): string | null {
   }
 }
 
-// Accent- and case-insensitive substring match so that typing "regras"
-// matches "Regras", "orcamento" matches "Orçamentos", etc.
-function normalizeText(s: string): string {
-  return s.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
-}
 
 function matchesQuery(query: string, haystacks: Array<string | undefined>): boolean {
   const q = normalizeText(query.trim())

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -1,0 +1,121 @@
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div className="flex items-center border-b border-border px-3" data-slot="command-input-wrapper">
+      <SearchIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-9 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm text-muted-foreground"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground overflow-hidden p-1 [&_[data-value]]:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,11 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Accent- and case-insensitive normalization for substring matching.
+ * Strips diacritics so "orcamento" matches "Orçamento", etc.
+ */
+export function normalizeText(s: string): string {
+  return s.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -288,6 +288,8 @@
     "category": "Category",
     "account": "Account",
     "noCategory": "No category",
+    "searchCategory": "Search category...",
+    "noCategoryFound": "No category found.",
     "addManual": "Add Transaction",
     "duplicate": "Duplicate",
     "createRule": "Create Rule",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -288,6 +288,8 @@
     "category": "Categoría",
     "account": "Cuenta",
     "noCategory": "Sin categoría",
+    "searchCategory": "Buscar categoría...",
+    "noCategoryFound": "No se encontraron categorías.",
     "addManual": "Agregar transacción",
     "duplicate": "Duplicar",
     "createRule": "Crear regla",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -288,6 +288,8 @@
     "category": "Categoria",
     "account": "Conto",
     "noCategory": "Nessuna categoria",
+    "searchCategory": "Cerca categoria...",
+    "noCategoryFound": "Nessuna categoria trovata.",
     "addManual": "Aggiungi transazione",
     "duplicate": "Duplica",
     "createRule": "Crea regola",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -294,6 +294,8 @@
     "category": "Kategoria",
     "account": "Konto",
     "noCategory": "Brak kategorii",
+    "searchCategory": "Szukaj kategorii...",
+    "noCategoryFound": "Nie znaleziono żadnej kategorii.",
     "addManual": "Dodaj transakcję",
     "duplicate": "Duplikuj",
     "createRule": "Utwórz regułę",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -288,6 +288,8 @@
     "category": "Categoria",
     "account": "Conta",
     "noCategory": "Sem categoria",
+    "searchCategory": "Buscar categoria...",
+    "noCategoryFound": "Nenhuma categoria encontrada.",
     "addManual": "Adicionar Transação",
     "duplicate": "Duplicar",
     "createRule": "Criar Regra",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -288,6 +288,8 @@
     "category": "Категория",
     "account": "Счёт",
     "noCategory": "Без категории",
+    "searchCategory": "Поиск категории...",
+    "noCategoryFound": "Категория не найдена.",
     "addManual": "Добавить транзакцию",
     "duplicate": "Дублировать",
     "createRule": "Создать правило",

--- a/frontend/src/locales/uk.json
+++ b/frontend/src/locales/uk.json
@@ -288,6 +288,8 @@
     "category": "Категорія",
     "account": "Рахунок",
     "noCategory": "Без категорії",
+    "searchCategory": "Пошук категорії...",
+    "noCategoryFound": "Категорію не знайдено.",
     "addManual": "Додати транзакцію",
     "duplicate": "Дублювати",
     "createRule": "Створити правило",


### PR DESCRIPTION
## What

Add search/combobox support to category select dropdowns and transaction filters.

## Why

Allows users with large numbers of categories to quickly find and filter categories by typing.

## How to Test

1. Add/edit a transaction and select the category picker. Verify you can search categories by name or group, and that visual layout (uppercase group names, color dots, checkmarks) is fully preserved.
2. In the transactions page, use the category filter dropdown. Verify there is a search input, filtering categories dynamically.

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)

## Demo

https://github.com/user-attachments/assets/aa3ccd44-99c1-4fae-b976-a96c6947dd6e

