### PR TITLE
feat(currency): add Guatemalan Quetzal (GTQ) support

### DIFF
--- a/backend/app/api/currencies.py
+++ b/backend/app/api/currencies.py
@@ -32,6 +32,7 @@ CURRENCY_META = {
     "IDR": {"symbol": "Rp", "name": "Indonesian Rupiah", "flag": "\U0001F1EE\U0001F1E9"},
     "DOP": {"symbol": "RD$", "name": "Peso Dominicano", "flag": "\U0001F1E9\U0001F1F4"},
     "RUB": {"symbol": "₽", "name": "Russian Ruble", "flag": "\U0001F1F7\U0001F1FA"},
+    "GTQ": {"symbol": "Q", "name": "Guatemalan Quetzal", "flag": "\U0001F1EC\U0001F1F9"},
 }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -62,7 +62,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/frontend/src/components/currency-select.tsx
+++ b/frontend/src/components/currency-select.tsx
@@ -30,6 +30,7 @@ export const CURRENCIES = [
   { code: 'CLP', flag: '\u{1F1E8}\u{1F1F1}', symbol: '$' },
   { code: 'DOP', flag: '\u{1F1E9}\u{1F1F4}', symbol: 'RD$' },
   { code: 'RUB', flag: '\u{1F1F7}\u{1F1FA}', symbol: '₽' },
+  { code: 'GTQ', flag: '\u{1F1EC}\u{1F1F9}', symbol: 'Q' },
 ] as const
 
 interface CurrencySelectProps {

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -57,6 +57,7 @@ const CURRENCY_LOCALE: Record<string, string> = {
   IDR: 'id-ID',
   DOP: 'es-DO',
   RUB: 'ru-RU',
+  GTQ: 'es-GT',
 }
 
 /**


### PR DESCRIPTION
Closes #359

Adds the Guatemalan Quetzal (GTQ) as a supported currency.

- **Name:** Guatemalan Quetzal
- **Code:** GTQ (ISO 4217)
- **Symbol:** Q
- **Flag:** 🇬🇹 · **Locale:** `es-GT`

Same four-file footprint as previous currency additions (e.g. RUB #355):
- `backend/app/api/currencies.py` — `CURRENCY_META` entry
- `backend/app/core/config.py` — added to `supported_currencies`
- `frontend/src/components/currency-select.tsx` — `CURRENCIES` list
- `frontend/src/lib/format.ts` — `CURRENCY_LOCALE` mapping

Verified: GTQ appears in both the workspace Default-currency picker and the setup/register currency selector with the correct flag and label; `/api/currencies` returns the new entry; and Open Exchange Rates covers GTQ, so FX conversion works. Backend `ruff`, frontend `lint` + `tsc -b` all pass.