### PR TITLE
feat(currency): add Philippine Peso (PHP) support

### DIFF
--- a/backend/app/api/currencies.py
+++ b/backend/app/api/currencies.py
@@ -33,6 +33,7 @@ CURRENCY_META = {
     "DOP": {"symbol": "RD$", "name": "Peso Dominicano", "flag": "\U0001F1E9\U0001F1F4"},
     "RUB": {"symbol": "₽", "name": "Russian Ruble", "flag": "\U0001F1F7\U0001F1FA"},
     "GTQ": {"symbol": "Q", "name": "Guatemalan Quetzal", "flag": "\U0001F1EC\U0001F1F9"},
+    "PHP": {"symbol": "₱", "name": "Philippine Peso", "flag": "\U0001F1F5\U0001F1ED"},
 }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -62,7 +62,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ,PHP"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/frontend/src/components/currency-select.tsx
+++ b/frontend/src/components/currency-select.tsx
@@ -31,6 +31,7 @@ export const CURRENCIES = [
   { code: 'DOP', flag: '\u{1F1E9}\u{1F1F4}', symbol: 'RD$' },
   { code: 'RUB', flag: '\u{1F1F7}\u{1F1FA}', symbol: '₽' },
   { code: 'GTQ', flag: '\u{1F1EC}\u{1F1F9}', symbol: 'Q' },
+  { code: 'PHP', flag: '\u{1F1F5}\u{1F1ED}', symbol: '₱' },
 ] as const
 
 interface CurrencySelectProps {

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -58,6 +58,7 @@ const CURRENCY_LOCALE: Record<string, string> = {
   DOP: 'es-DO',
   RUB: 'ru-RU',
   GTQ: 'es-GT',
+  PHP: 'en-PH',
 }
 
 /**


### PR DESCRIPTION
Closes #358

Adds the Philippine Peso (PHP) as a supported currency.

- **Name:** Philippine Peso
- **Code:** PHP (ISO 4217)
- **Symbol:** ₱
- **Flag:** 🇵🇭 · **Locale:** `en-PH`

Same four-file footprint as previous currency additions:
- `backend/app/api/currencies.py` — `CURRENCY_META` entry
- `backend/app/core/config.py` — added to `supported_currencies`
- `frontend/src/components/currency-select.tsx` — `CURRENCIES` list
- `frontend/src/lib/format.ts` — `CURRENCY_LOCALE` mapping

Verified: PHP appears in the setup/register currency selector (and the workspace Default-currency picker, same component) rendering the 🇵🇭 flag and ₱ symbol; `/api/currencies` returns the new entry; and Open Exchange Rates covers PHP, so FX conversion works. Backend `ruff`, frontend `lint` + `tsc -b` all pass.