### PR TITLE
fix(accounts): spin sync icon only on the account being synced

### DIFF
--- a/frontend/src/pages/accounts.tsx
+++ b/frontend/src/pages/accounts.tsx
@@ -373,9 +373,9 @@ export default function AccountsPage() {
                             size="sm"
                             className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground"
                             onClick={() => syncMutation.mutate(conn.id)}
-                            disabled={syncMutation.isPending}
+                            disabled={syncMutation.isPending && syncMutation.variables === conn.id}
                           >
-                            <RefreshCw size={14} className={syncMutation.isPending ? 'animate-spin' : ''} />
+                            <RefreshCw size={14} className={syncMutation.isPending && syncMutation.variables === conn.id ? 'animate-spin' : ''} />
                           </Button>
                           <Button
                             variant="ghost"


### PR DESCRIPTION
Closes #357

## Problem
Clicking the sync icon on one bank connection animated (and disabled) the sync icon on **every** connection, even though only the clicked account was actually syncing.

## Cause
There's a single shared `syncMutation`. Each row rendered its spinner/disabled state from `syncMutation.isPending`, which is global to the mutation — so any in-flight sync lit up all rows.

## Fix
Scope the pending state to the connection being synced by comparing the mutation's `variables` (the id passed to `mutate`) with the row's `conn.id`:

```tsx
disabled={syncMutation.isPending && syncMutation.variables === conn.id}
className={syncMutation.isPending && syncMutation.variables === conn.id ? 'animate-spin' : ''}
```

## Verification
Tested in the browser with two bank connections (NuBank + Revolut): clicking NuBank's sync icon spins/disables only NuBank, while Revolut's icon stays static and enabled. `tsc -b` and `lint` pass (0 errors).