### PR TITLE
fix: re-resolve backend DNS in nginx to avoid 502s after redeploy

### DIFF
--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -3,9 +3,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # API proxy to backend
+    # API proxy to backend.
+    # Resolve the backend hostname at request time via Docker's embedded DNS
+    # instead of caching the IP at startup. Without this, Nginx pins the
+    # upstream IP when the config loads and returns 502s after the backend
+    # container is recreated with a new IP (e.g. selective redeploys where the
+    # frontend container is left running). Using a variable in proxy_pass forces
+    # re-resolution; the resolver below is the Docker daemon's internal DNS.
     location /api/ {
-        proxy_pass ${BACKEND_URL};
+        resolver 127.0.0.11 valid=5s;
+        set $upstream ${BACKEND_URL};
+        proxy_pass $upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Fixes #298.

## Problem
Nginx substitutes `${BACKEND_URL}` via `envsubst` at startup, producing a static `proxy_pass http://backend:8000;`. Nginx resolves that hostname once when loading the config and caches the IP. On a **selective** redeploy (Portainer GitOps recreating only the backend), the frontend container keeps running with the stale IP and serves 502s until manually restarted.

## Fix
In `frontend/default.conf.template`, point `proxy_pass` at a variable and add Docker's embedded DNS resolver, so the backend hostname is re-resolved at request time:

```nginx
resolver 127.0.0.11 valid=5s;
set $upstream ${BACKEND_URL};
proxy_pass $upstream;
```

No new environment variables — `${BACKEND_URL}` is still substituted at startup as before; only the resolution timing changes. Since `proxy_pass` has no URI part, the original request URI (incl. query string) is forwarded unchanged, preserving existing behavior.

## Verification
Reproduced the bug and confirmed the fix with a throwaway Docker network, forcing the backend to come back on a new IP after recreation:

| Config | Backend IP change | Before recreate | After recreate |
|---|---|---|---|
| Old (static `proxy_pass`) | .0.2 → .0.4 | 200 | **502** |
| New (resolver + variable) | .0.2 → .0.4 | 200 | **200** |

Also rendered the template through the real nginx image (`envsubst` + `nginx -t`) — config is valid and `$upstream`/`$host` are correctly left for nginx to evaluate.

