### PR TITLE
feat(categories): add income and expense flow types

### DIFF
--- a/backend/alembic/versions/064_category_flow_types.py
+++ b/backend/alembic/versions/064_category_flow_types.py
@@ -1,0 +1,100 @@
+"""add category flow types
+
+Revision ID: 064
+Revises: 063
+Create Date: 2026-06-30
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "064"
+down_revision: Union[str, None] = "063"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+INCOME_GROUP_NAMES = (
+    "income",
+    "renda",
+    "ingresos",
+    "entrate",
+    "przychody",
+    "доходы",
+    "доходи",
+)
+
+INCOME_CATEGORY_NAMES = (
+    "salary & income",
+    "salário & renda",
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "category_groups",
+        sa.Column("flow_type", sa.String(20), nullable=True),
+    )
+    op.add_column(
+        "categories",
+        sa.Column("flow_type", sa.String(20), nullable=True),
+    )
+
+    income_group_names_sql = ", ".join(f"'{name}'" for name in INCOME_GROUP_NAMES)
+    income_category_names_sql = ", ".join(f"'{name}'" for name in INCOME_CATEGORY_NAMES)
+
+    op.execute(
+        f"""
+        UPDATE category_groups
+        SET flow_type = CASE
+            WHEN lower(name) IN ({income_group_names_sql}) THEN 'income'
+            ELSE 'expense'
+        END
+        WHERE flow_type IS NULL
+        """
+    )
+    op.execute(
+        f"""
+        UPDATE categories
+        SET flow_type = CASE
+            WHEN group_id IN (
+                SELECT id FROM category_groups WHERE flow_type = 'income'
+            ) THEN 'income'
+            WHEN lower(name) IN ({income_category_names_sql}) THEN 'income'
+            ELSE 'expense'
+        END
+        WHERE flow_type IS NULL
+        """
+    )
+
+    op.alter_column(
+        "category_groups",
+        "flow_type",
+        nullable=False,
+        server_default="expense",
+    )
+    op.alter_column(
+        "categories",
+        "flow_type",
+        nullable=False,
+        server_default="expense",
+    )
+    op.create_index(
+        "ix_category_groups_workspace_flow_type",
+        "category_groups",
+        ["workspace_id", "flow_type"],
+    )
+    op.create_index(
+        "ix_categories_workspace_flow_type",
+        "categories",
+        ["workspace_id", "flow_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_categories_workspace_flow_type", table_name="categories")
+    op.drop_index("ix_category_groups_workspace_flow_type", table_name="category_groups")
+    op.drop_column("categories", "flow_type")
+    op.drop_column("category_groups", "flow_type")

--- a/backend/app/api/categories.py
+++ b/backend/app/api/categories.py
@@ -1,6 +1,7 @@
 import uuid
+from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_async_session
@@ -17,10 +18,11 @@ router = APIRouter(prefix="/api/categories", tags=["categories"])
 
 @router.get("", response_model=list[CategoryRead])
 async def list_categories(
+    flow_type: Optional[str] = Query(None, pattern="^(income|expense)$"),
     ctx: WorkspaceContext = Depends(current_workspace),
     session: AsyncSession = Depends(get_async_session),
 ):
-    return await category_service.get_categories(session, ctx.workspace.id)
+    return await category_service.get_categories(session, ctx.workspace.id, flow_type)
 
 
 @router.post("", response_model=CategoryRead, status_code=status.HTTP_201_CREATED)
@@ -29,7 +31,10 @@ async def create_category(
     ctx: WorkspaceContext = Depends(current_writable_workspace),
     session: AsyncSession = Depends(get_async_session),
 ):
-    return await category_service.create_category(session, ctx.workspace.id, ctx.user_id, data)
+    try:
+        return await category_service.create_category(session, ctx.workspace.id, ctx.user_id, data)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.patch("/{category_id}", response_model=CategoryRead)
@@ -39,7 +44,10 @@ async def update_category(
     ctx: WorkspaceContext = Depends(current_writable_workspace),
     session: AsyncSession = Depends(get_async_session),
 ):
-    category = await category_service.update_category(session, category_id, ctx.workspace.id, data)
+    try:
+        category = await category_service.update_category(session, category_id, ctx.workspace.id, data)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     if not category:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
     return category

--- a/backend/app/api/category_groups.py
+++ b/backend/app/api/category_groups.py
@@ -1,6 +1,7 @@
 import uuid
+from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_async_session
@@ -17,10 +18,11 @@ router = APIRouter(prefix="/api/category-groups", tags=["category-groups"])
 
 @router.get("", response_model=list[CategoryGroupRead])
 async def list_groups(
+    flow_type: Optional[str] = Query(None, pattern="^(income|expense)$"),
     ctx: WorkspaceContext = Depends(current_workspace),
     session: AsyncSession = Depends(get_async_session),
 ):
-    return await category_group_service.get_groups(session, ctx.workspace.id)
+    return await category_group_service.get_groups(session, ctx.workspace.id, flow_type)
 
 
 @router.post("", response_model=CategoryGroupRead, status_code=status.HTTP_201_CREATED)
@@ -39,7 +41,10 @@ async def update_group(
     ctx: WorkspaceContext = Depends(current_writable_workspace),
     session: AsyncSession = Depends(get_async_session),
 ):
-    group = await category_group_service.update_group(session, group_id, ctx.workspace.id, data)
+    try:
+        group = await category_group_service.update_group(session, group_id, ctx.workspace.id, data)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     if not group:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
     return group

--- a/backend/app/api/transactions.py
+++ b/backend/app/api/transactions.py
@@ -197,9 +197,12 @@ async def bulk_categorize(
     ctx: WorkspaceContext = Depends(current_writable_workspace),
     session: AsyncSession = Depends(get_async_session),
 ):
-    count = await transaction_service.bulk_update_category(
-        session, ctx.workspace.id, data.transaction_ids, data.category_id
-    )
+    try:
+        count = await transaction_service.bulk_update_category(
+            session, ctx.workspace.id, data.transaction_ids, data.category_id
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     return {"updated": count}
 
 

--- a/backend/app/models/category.py
+++ b/backend/app/models/category.py
@@ -24,6 +24,7 @@ class Category(Base):
     name: Mapped[str] = mapped_column(String(100))
     icon: Mapped[str] = mapped_column(String(50), default="circle-help")
     color: Mapped[str] = mapped_column(String(7), default="#6B7280")
+    flow_type: Mapped[str] = mapped_column(String(20), default="expense", server_default="expense")
     is_system: Mapped[bool] = mapped_column(Boolean, default=False)
 
     # Flag for "money that moves rather than money earned or spent".

--- a/backend/app/models/category_group.py
+++ b/backend/app/models/category_group.py
@@ -23,6 +23,7 @@ class CategoryGroup(Base):
     name: Mapped[str] = mapped_column(String(100))
     icon: Mapped[str] = mapped_column(String(50), default="folder")
     color: Mapped[str] = mapped_column(String(7), default="#6B7280")
+    flow_type: Mapped[str] = mapped_column(String(20), default="expense", server_default="expense")
     position: Mapped[int] = mapped_column(Integer, default=0)
     is_system: Mapped[bool] = mapped_column(Boolean, default=False)
 

--- a/backend/app/schemas/category.py
+++ b/backend/app/schemas/category.py
@@ -1,13 +1,16 @@
 import uuid
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict
+
+CategoryFlowType = Literal["income", "expense"]
 
 
 class CategoryBase(BaseModel):
     name: str
     icon: str = "circle-help"
     color: str = "#6B7280"
+    flow_type: CategoryFlowType = "expense"
 
 
 class CategoryCreate(CategoryBase):
@@ -20,6 +23,7 @@ class CategoryUpdate(BaseModel):
     name: Optional[str] = None
     icon: Optional[str] = None
     color: Optional[str] = None
+    flow_type: Optional[CategoryFlowType] = None
     group_id: Optional[uuid.UUID] = None
     treat_as_transfer: Optional[bool] = None
     is_ignored: Optional[bool] = None
@@ -29,6 +33,7 @@ class CategoryRead(CategoryBase):
     id: uuid.UUID
     user_id: uuid.UUID
     group_id: Optional[uuid.UUID] = None
+    flow_type: CategoryFlowType
     is_system: bool
     treat_as_transfer: bool = False
     is_ignored: bool = False

--- a/backend/app/schemas/category_group.py
+++ b/backend/app/schemas/category_group.py
@@ -1,15 +1,18 @@
 import uuid
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict
 
 from app.schemas.category import CategoryRead
+
+CategoryFlowType = Literal["income", "expense"]
 
 
 class CategoryGroupBase(BaseModel):
     name: str
     icon: str = "folder"
     color: str = "#6B7280"
+    flow_type: CategoryFlowType = "expense"
     position: int = 0
 
 
@@ -21,6 +24,7 @@ class CategoryGroupUpdate(BaseModel):
     name: Optional[str] = None
     icon: Optional[str] = None
     color: Optional[str] = None
+    flow_type: Optional[CategoryFlowType] = None
     position: Optional[int] = None
 
 

--- a/backend/app/services/category_group_service.py
+++ b/backend/app/services/category_group_service.py
@@ -41,6 +41,8 @@ CATEGORY_TO_GROUP = {
     "other": "other",
 }
 
+INCOME_GROUP_KEYS = {"income"}
+
 
 def _resolve_group_name(key: str, lang: str) -> str:
     entry = DEFAULT_GROUPS_I18N.get(key, {})
@@ -63,6 +65,7 @@ async def create_default_groups(
             name=name,
             icon=data["icon"],
             color=data["color"],
+            flow_type="income" if key in INCOME_GROUP_KEYS else "expense",
             position=data["position"],
             is_system=True,
         )
@@ -72,13 +75,20 @@ async def create_default_groups(
     return groups
 
 
-async def get_groups(session: AsyncSession, workspace_id: uuid.UUID) -> list[CategoryGroup]:
-    result = await session.execute(
+async def get_groups(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    flow_type: Optional[str] = None,
+) -> list[CategoryGroup]:
+    query = (
         select(CategoryGroup)
         .where(CategoryGroup.workspace_id == workspace_id)
         .options(selectinload(CategoryGroup.categories))
         .order_by(CategoryGroup.position)
     )
+    if flow_type:
+        query = query.where(CategoryGroup.flow_type == flow_type)
+    result = await session.execute(query)
     return list(result.scalars().all())
 
 
@@ -111,6 +121,12 @@ async def update_group(
         return None
 
     for key, value in data.model_dump(exclude_unset=True).items():
+        if key == "flow_type" and value != group.flow_type:
+            child_id = await session.scalar(
+                select(Category.id).where(Category.group_id == group.id).limit(1)
+            )
+            if child_id is not None:
+                raise ValueError("Cannot change flow type while group has categories")
         setattr(group, key, value)
 
     await session.commit()

--- a/backend/app/services/category_service.py
+++ b/backend/app/services/category_service.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.category import Category
+from app.models.category_group import CategoryGroup
 from app.schemas.category import CategoryCreate, CategoryUpdate
 from app.services.category_group_service import CATEGORY_TO_GROUP, create_default_groups
 
@@ -32,6 +33,12 @@ DEFAULT_CATEGORIES_I18N = {
     "taxes":         {"en": "Taxes & Fees",     "pt-BR": "Impostos & Taxas",    "icon": "landmark",         "color": "#78716C"},
     "other":         {"en": "Other",         "pt-BR": "Outros",         "icon": "circle-help",      "color": "#6B7280"},
 }
+
+INCOME_CATEGORY_KEYS = {"salary"}
+
+
+def flow_type_for_category_key(key: str) -> str:
+    return "income" if key in INCOME_CATEGORY_KEYS else "expense"
 
 
 async def create_default_categories(
@@ -81,6 +88,7 @@ async def create_default_categories(
             name=name,
             icon=data["icon"],
             color=data["color"],
+            flow_type=flow_type_for_category_key(key),
             is_system=True,
             group_id=group.id if group else None,
             treat_as_transfer=data.get("treat_as_transfer", False),
@@ -91,11 +99,16 @@ async def create_default_categories(
     return categories
 
 
-async def get_categories(session: AsyncSession, workspace_id: uuid.UUID) -> list[Category]:
+async def get_categories(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    flow_type: Optional[str] = None,
+) -> list[Category]:
+    query = select(Category).where(Category.workspace_id == workspace_id)
+    if flow_type:
+        query = query.where(Category.flow_type == flow_type)
     result = await session.execute(
-        select(Category)
-        .where(Category.workspace_id == workspace_id)
-        .order_by(Category.is_system.desc(), Category.name)
+        query.order_by(Category.flow_type, Category.is_system.desc(), Category.name)
     )
     return list(result.scalars().all())
 
@@ -111,13 +124,55 @@ async def get_category(
     return result.scalar_one_or_none()
 
 
+async def _validate_group_for_category(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    group_id: Optional[uuid.UUID],
+    flow_type: str,
+) -> None:
+    if group_id is None:
+        return
+    group = await session.get(CategoryGroup, group_id)
+    if group is None or group.workspace_id != workspace_id:
+        raise ValueError("Category group not found")
+    if group.flow_type != flow_type:
+        raise ValueError("Category flow type must match group flow type")
+
+
+def category_flow_for_transaction_type(transaction_type: str) -> str:
+    return "income" if transaction_type == "credit" else "expense"
+
+
+async def validate_category_for_transaction(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    category_id: Optional[uuid.UUID],
+    transaction_type: str,
+) -> None:
+    if category_id is None:
+        return
+    category = await get_category(session, category_id, workspace_id)
+    if category is None:
+        raise ValueError("Category not found")
+    expected_flow = category_flow_for_transaction_type(transaction_type)
+    if category.flow_type != expected_flow:
+        raise ValueError(
+            f"Category flow type '{category.flow_type}' is not valid for "
+            f"{transaction_type} transactions"
+        )
+
+
 async def create_category(
     session: AsyncSession,
     workspace_id: uuid.UUID,
     user_id: uuid.UUID,
     data: CategoryCreate,
 ) -> Category:
-    category = Category(user_id=user_id, workspace_id=workspace_id, **data.model_dump())
+    payload = data.model_dump()
+    await _validate_group_for_category(
+        session, workspace_id, payload.get("group_id"), payload["flow_type"]
+    )
+    category = Category(user_id=user_id, workspace_id=workspace_id, **payload)
     session.add(category)
     await session.commit()
     await session.refresh(category)
@@ -134,7 +189,12 @@ async def update_category(
     if not category:
         return None
 
-    for key, value in data.model_dump(exclude_unset=True).items():
+    update_data = data.model_dump(exclude_unset=True)
+    next_flow_type = update_data.get("flow_type", category.flow_type)
+    next_group_id = update_data.get("group_id", category.group_id)
+    await _validate_group_for_category(session, workspace_id, next_group_id, next_flow_type)
+
+    for key, value in update_data.items():
         setattr(category, key, value)
 
     await session.commit()

--- a/backend/app/services/rule_service.py
+++ b/backend/app/services/rule_service.py
@@ -10,7 +10,11 @@ from app.models.category import Category
 from app.models.transaction import Transaction
 from app.schemas.rule import RuleCreate, RuleExportPayload, RuleImportResponse, RuleUpdate
 from app.services.rule_engine import evaluate_conditions, apply_rule_actions
-from app.services.category_service import DEFAULT_CATEGORIES_I18N
+from app.services.category_service import (
+    DEFAULT_CATEGORIES_I18N,
+    flow_type_for_category_key,
+    validate_category_for_transaction,
+)
 
 
 class DuplicateRuleError(Exception):
@@ -467,7 +471,7 @@ def _resolve_categories_by_internal_key(
     which language the user's categories were created in.
     """
     key_to_id: dict[str, str] = {}
-    non_name_fields = {"icon", "color", "treat_as_transfer"}
+    non_name_fields = {"icon", "color", "flow_type", "treat_as_transfer"}
     for internal_key, data in DEFAULT_CATEGORIES_I18N.items():
         for field, value in data.items():
             if field in non_name_fields:
@@ -611,7 +615,7 @@ async def _ensure_categories_for_keys(
     )
     from app.services.category_service import DEFAULT_CATEGORIES_I18N
 
-    non_name_fields = {"icon", "color", "treat_as_transfer", "position"}
+    non_name_fields = {"icon", "color", "flow_type", "treat_as_transfer", "position"}
 
     def variants(data: dict) -> set[str]:
         return {v for k, v in data.items() if k not in non_name_fields}
@@ -661,6 +665,7 @@ async def _ensure_categories_for_keys(
             name=gdata.get(lang, gdata["en"]),
             icon=gdata["icon"],
             color=gdata["color"],
+            flow_type="income" if gkey == "income" else "expense",
             position=gdata["position"],
             is_system=True,
         )
@@ -676,6 +681,7 @@ async def _ensure_categories_for_keys(
             name=data.get(lang, data["en"]),
             icon=data["icon"],
             color=data["color"],
+            flow_type=flow_type_for_category_key(key),
             is_system=True,
             group_id=target_group.id if target_group else None,
             treat_as_transfer=data.get("treat_as_transfer", False),
@@ -970,7 +976,18 @@ async def apply_rules_to_transaction(
         conditions = rule.conditions or []
         actions = rule.actions or []
         if evaluate_conditions(rule.conditions_op, conditions, transaction):
+            before_category_id = transaction.category_id
             category_set = apply_rule_actions(actions, transaction, category_set)
+            try:
+                await validate_category_for_transaction(
+                    session,
+                    transaction.workspace_id,
+                    transaction.category_id,
+                    transaction.type,
+                )
+            except ValueError:
+                transaction.category_id = before_category_id
+                category_set = before_category_id is not None
 
 
 async def apply_single_rule(
@@ -1005,7 +1022,17 @@ async def apply_single_rule(
         if not evaluate_conditions(rule.conditions_op, conditions, tx):
             continue
         before = (tx.category_id, tx.payee_id, tx.notes, tx.is_ignored)
+        before_category_id = tx.category_id
         apply_rule_actions(actions, tx, category_already_set=tx.category_id is not None)
+        try:
+            await validate_category_for_transaction(
+                session,
+                tx.workspace_id,
+                tx.category_id,
+                tx.type,
+            )
+        except ValueError:
+            tx.category_id = before_category_id
         if before != (tx.category_id, tx.payee_id, tx.notes, tx.is_ignored):
             count += 1
 
@@ -1047,10 +1074,21 @@ async def apply_all_rules(session: AsyncSession, workspace_id: uuid.UUID) -> int
             if evaluate_conditions(rule.conditions_op, conditions, tx):
                 if not matched:
                     # First match: reset so rules are applied from scratch
-                    tx.category_id = None
                     tx.notes = None
                     matched = True
+                before_category_id = tx.category_id
+                before_category_set = category_set
                 category_set = apply_rule_actions(actions, tx, category_set)
+                try:
+                    await validate_category_for_transaction(
+                        session,
+                        tx.workspace_id,
+                        tx.category_id,
+                        tx.type,
+                    )
+                except ValueError:
+                    tx.category_id = before_category_id
+                    category_set = before_category_set
 
         if matched:
             count += 1

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -18,6 +18,7 @@ from app.models.payee import Payee
 from app.schemas.transaction import TransactionCreate, TransactionUpdate, TransferCreate
 from app.schemas.transaction_split import TransactionSplitInput, TransactionSplitsInput
 from app.services import split_service
+from app.services.category_service import validate_category_for_transaction
 from app.services.credit_card_service import apply_effective_date
 from app.services.rule_service import apply_rules_to_transaction
 from app.services.fx_rate_service import stamp_primary_amount, convert as fx_convert
@@ -648,6 +649,10 @@ async def create_transaction(
     if not account:
         raise ValueError("Account not found")
 
+    await validate_category_for_transaction(
+        session, workspace_id, data.category_id, data.type
+    )
+
     # Resolve currency: explicit value > account currency
     currency = data.currency or account.currency
 
@@ -672,6 +677,9 @@ async def create_transaction(
     # Apply rules only if no explicit category provided
     if not data.category_id:
         await apply_rules_to_transaction(session, user_id, transaction)
+        await validate_category_for_transaction(
+            session, workspace_id, transaction.category_id, transaction.type
+        )
 
     # Stamp primary currency amount (manual override or auto)
     if data.amount_primary is not None or data.fx_rate_used is not None:
@@ -1132,6 +1140,11 @@ async def update_transaction(
     for key, value in update_data.items():
         setattr(transaction, key, value)
 
+    if "category_id" in update_data or "type" in update_data:
+        await validate_category_for_transaction(
+            session, workspace_id, transaction.category_id, transaction.type
+        )
+
     if has_fx_override:
         _apply_fx_override(
             transaction,
@@ -1196,6 +1209,22 @@ async def bulk_update_category(
     transaction_ids: list[uuid.UUID],
     category_id: Optional[uuid.UUID] = None,
 ) -> int:
+    if category_id is not None:
+        tx_types = (
+            await session.execute(
+                select(Transaction.type)
+                .where(
+                    Transaction.id.in_(transaction_ids),
+                    Transaction.workspace_id == workspace_id,
+                )
+                .distinct()
+            )
+        ).scalars().all()
+        for tx_type in tx_types:
+            await validate_category_for_transaction(
+                session, workspace_id, category_id, tx_type
+            )
+
     result = await session.execute(
         update(Transaction)
         .where(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -280,10 +280,10 @@ def admin_auth_headers(admin_auth_token: str) -> dict:
 async def test_categories(session: AsyncSession, test_user: User) -> list[Category]:
     """Create test categories."""
     categories = []
-    for name, icon, color in [
-        ("Alimentação", "🍔", "#F59E0B"),
-        ("Transporte", "🚗", "#3B82F6"),
-        ("Receita", "💼", "#22C55E"),
+    for name, icon, color, flow_type in [
+        ("Alimentação", "🍔", "#F59E0B", "expense"),
+        ("Transporte", "🚗", "#3B82F6", "expense"),
+        ("Receita", "💼", "#22C55E", "income"),
     ]:
         cat = Category(
             id=uuid.uuid4(),
@@ -291,6 +291,7 @@ async def test_categories(session: AsyncSession, test_user: User) -> list[Catego
             name=name,
             icon=icon,
             color=color,
+            flow_type=flow_type,
             is_system=True,
         )
         session.add(cat)

--- a/backend/tests/test_category_group_service.py
+++ b/backend/tests/test_category_group_service.py
@@ -40,6 +40,8 @@ async def test_create_default_groups(session: AsyncSession, test_user, test_work
     # All should be system groups
     for g in groups.values():
         assert g.is_system is True
+    assert groups["income"].flow_type == "income"
+    assert groups["housing"].flow_type == "expense"
 
 
 @pytest.mark.asyncio
@@ -86,6 +88,18 @@ async def test_get_groups_ordered_by_position(session: AsyncSession, test_user, 
 
     positions = [g.position for g in groups]
     assert positions == sorted(positions)
+
+
+@pytest.mark.asyncio
+async def test_get_groups_filters_by_flow_type(session: AsyncSession, test_user, test_workspace):
+    await create_default_groups(session, test_user.id)
+    await session.commit()
+
+    income_groups = await get_groups(session, test_workspace.id, flow_type="income")
+    expense_groups = await get_groups(session, test_workspace.id, flow_type="expense")
+
+    assert {g.name for g in income_groups} == {"Renda"}
+    assert "Renda" not in {g.name for g in expense_groups}
 
 
 @pytest.mark.asyncio
@@ -161,6 +175,37 @@ async def test_update_group(session: AsyncSession, test_user, test_workspace):
     assert updated.name == "New"
     assert updated.color == "#222222"
     assert updated.icon == "x"  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_update_group_rejects_flow_change_with_categories(
+    session: AsyncSession, test_user, test_workspace
+):
+    group = await create_group(
+        session,
+        test_workspace.id, test_user.id,
+        CategoryGroupCreate(name="Has Children", icon="folder", color="#111111"),
+    )
+    session.add(
+        Category(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            name="ChildCat",
+            icon="star",
+            color="#0000FF",
+            is_system=False,
+            group_id=group.id,
+        )
+    )
+    await session.commit()
+
+    with pytest.raises(ValueError, match="Cannot change flow type"):
+        await update_group(
+            session,
+            group.id,
+            test_workspace.id,
+            CategoryGroupUpdate(flow_type="income"),
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_category_service.py
+++ b/backend/tests/test_category_service.py
@@ -37,6 +37,8 @@ async def test_create_default_categories(session: AsyncSession, test_user, test_
 
     for cat in categories:
         assert cat.is_system is True
+    assert {c.name for c in categories if c.flow_type == "income"} == {"Salário & Renda"}
+    assert "Alimentação" in {c.name for c in categories if c.flow_type == "expense"}
 
 
 @pytest.mark.asyncio
@@ -111,6 +113,17 @@ async def test_get_categories_ordered(session: AsyncSession, test_user, test_wor
 
 
 @pytest.mark.asyncio
+async def test_get_categories_filters_by_flow_type(session: AsyncSession, test_user, test_workspace):
+    await create_default_categories(session, test_user.id, lang="pt-BR")
+
+    income_categories = await get_categories(session, test_workspace.id, flow_type="income")
+    expense_categories = await get_categories(session, test_workspace.id, flow_type="expense")
+
+    assert {c.name for c in income_categories} == {"Salário & Renda"}
+    assert "Salário & Renda" not in {c.name for c in expense_categories}
+
+
+@pytest.mark.asyncio
 async def test_get_categories_excludes_other_users(
     session: AsyncSession, test_user, test_workspace, test_categories
 ):
@@ -149,6 +162,33 @@ async def test_create_category_with_group(session: AsyncSession, test_user, test
         CategoryCreate(name="WithGroup", icon="star", color="#FFF", group_id=group.id),
     )
     assert cat.group_id == group.id
+
+
+@pytest.mark.asyncio
+async def test_create_category_rejects_group_with_different_flow(
+    session: AsyncSession, test_user, test_workspace
+):
+    from app.schemas.category_group import CategoryGroupCreate
+    from app.services.category_group_service import create_group
+
+    group = await create_group(
+        session,
+        test_workspace.id, test_user.id,
+        CategoryGroupCreate(name="Income", icon="folder", color="#000", flow_type="income"),
+    )
+
+    with pytest.raises(ValueError, match="must match group"):
+        await create_category(
+            session,
+            test_workspace.id, test_user.id,
+            CategoryCreate(
+                name="Expense In Income",
+                icon="star",
+                color="#FFF",
+                flow_type="expense",
+                group_id=group.id,
+            ),
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_rule_service.py
+++ b/backend/tests/test_rule_service.py
@@ -455,6 +455,57 @@ async def test_apply_all_rules_preserves_manual_categories(
     assert count == 1
 
 
+@pytest.mark.asyncio
+async def test_apply_all_rules_reverts_incompatible_category_rule(
+    session: AsyncSession, test_user, test_workspace, test_categories
+):
+    account = Account(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        name="InvalidRuleCat",
+        type="checking",
+        balance=Decimal("1000"),
+        currency="BRL",
+    )
+    session.add(account)
+    await session.commit()
+
+    original_cat = test_categories[0]
+    income_cat = test_categories[2]
+    txn = Transaction(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        account_id=account.id,
+        description="BAD INCOME RULE",
+        amount=Decimal("20"),
+        date=date(2025, 4, 4),
+        type="debit",
+        source="manual",
+        category_id=original_cat.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(txn)
+    await session.commit()
+
+    await create_rule(
+        session,
+        test_workspace.id, test_user.id,
+        RuleCreate(
+            name="Invalid income category on debit",
+            conditions_op="or",
+            conditions=[RuleCondition(field="description", op="contains", value="BAD INCOME")],
+            actions=[RuleAction(op="set_category", value=str(income_cat.id))],
+            priority=10,
+        ),
+    )
+
+    count = await apply_all_rules(session, test_workspace.id)
+
+    await session.refresh(txn)
+    assert count == 1
+    assert txn.category_id == original_cat.id
+
+
 # ---------------------------------------------------------------------------
 # create_default_rules / install_rule_pack / get_installed_packs
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_transaction_service.py
+++ b/backend/tests/test_transaction_service.py
@@ -128,6 +128,23 @@ async def test_create_transaction_with_category_skips_rules(
 
 
 @pytest.mark.asyncio
+async def test_create_transaction_rejects_category_with_different_flow(
+    session: AsyncSession, test_user, test_workspace, test_categories, txn_account
+):
+    data = TransactionCreate(
+        description="Income with expense category",
+        amount=Decimal("500.00"),
+        date=date(2025, 3, 10),
+        type="credit",
+        account_id=txn_account.id,
+        category_id=test_categories[0].id,
+    )
+
+    with pytest.raises(ValueError, match="not valid for credit"):
+        await create_transaction(session, test_workspace.id, test_user.id, data)
+
+
+@pytest.mark.asyncio
 async def test_create_transaction_invalid_account(session: AsyncSession, test_user, test_workspace):
     data = TransactionCreate(
         description="Orphan",
@@ -589,6 +606,30 @@ async def test_bulk_update_category_clear(
 
     await session.refresh(txn)
     assert txn.category_id is None
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_category_rejects_mixed_flow(
+    session: AsyncSession, test_user, test_workspace, test_categories, txn_account
+):
+    income_txn = Transaction(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        account_id=txn_account.id,
+        description="Income",
+        amount=Decimal("100"),
+        date=date(2025, 3, 1),
+        type="credit",
+        source="manual",
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(income_txn)
+    await session.commit()
+
+    with pytest.raises(ValueError, match="not valid for credit"):
+        await bulk_update_category(
+            session, test_workspace.id, [income_txn.id], category_id=test_categories[0].id
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_transactions_api.py
+++ b/backend/tests/test_transactions_api.py
@@ -483,7 +483,7 @@ async def test_update_transaction_all_fields(
             "date": "2026-12-25",
             "type": "credit",
             "currency": "USD",
-            "category_id": str(test_categories[0].id),
+            "category_id": str(test_categories[2].id),
         },
     )
     assert response.status_code == 200
@@ -493,7 +493,7 @@ async def test_update_transaction_all_fields(
     assert data["date"] == "2026-12-25"
     assert data["type"] == "credit"
     assert data["currency"] == "USD"
-    assert data["category_id"] == str(test_categories[0].id)
+    assert data["category_id"] == str(test_categories[2].id)
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/category-select.tsx
+++ b/frontend/src/components/category-select.tsx
@@ -15,6 +15,7 @@ interface CategorySelectProps {
   disabled?: boolean
   className?: string
   allowNone?: boolean
+  flowType?: Category['flow_type']
   contentProps?: React.ComponentProps<typeof PopoverContent>
 }
 
@@ -28,6 +29,7 @@ export function CategorySelect({
   disabled = false,
   className,
   allowNone = false,
+  flowType,
   contentProps,
 }: CategorySelectProps) {
   const [open, setOpen] = useState(false)
@@ -36,18 +38,27 @@ export function CategorySelect({
   const resolvedPlaceholder = placeholder ?? t('transactions.selectCategory', 'Select category')
 
   const displayGroups = useMemo(() => {
-    const ungrouped = (categories ?? []).filter((c) => !c.group_id)
-    if (ungrouped.length === 0) return groups
+    const visibleCategories = flowType
+      ? (categories ?? []).filter((c) => c.flow_type === flowType)
+      : (categories ?? [])
+    const visibleGroups = (groups ?? [])
+      .filter((group) => !flowType || group.flow_type === flowType)
+      .map((group) => ({
+        ...group,
+        categories: group.categories.filter((cat) => !flowType || cat.flow_type === flowType),
+      }))
+    const ungrouped = visibleCategories.filter((c) => !c.group_id)
+    if (ungrouped.length === 0) return visibleGroups
 
     return [
-      ...groups,
+      ...visibleGroups,
       {
         id: 'ungrouped-virtual',
         name: t('groups.noGroup'),
         categories: ungrouped,
       } as CategoryGroup,
     ]
-  }, [categories, groups, t])
+  }, [categories, flowType, groups, t])
 
   const selectedCategory = useMemo(() => {
     return (categories ?? []).find((c) => c.id === value)

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -425,6 +425,15 @@ function TransactionForm({
   const [isIgnored, setIsIgnored] = useState(seed?.is_ignored ?? false)
   const [togglingIgnore, setTogglingIgnore] = useState(false)
   const [addToRuleOpen, setAddToRuleOpen] = useState(false)
+  const categoryFlowType: Category['flow_type'] = type === 'credit' ? 'income' : 'expense'
+
+  useEffect(() => {
+    if (!categoryId) return
+    const selectedCategory = categories.find((category) => category.id === categoryId)
+    if (selectedCategory && selectedCategory.flow_type !== categoryFlowType) {
+      setCategoryId('')
+    }
+  }, [categories, categoryFlowType, categoryId])
 
   const { data: rulesList, isLoading: rulesLoading } = useQuery({
     queryKey: ['rules'],
@@ -842,6 +851,7 @@ function TransactionForm({
             onChange={setCategoryId}
             categories={categories}
             groups={categoryGroups}
+            flowType={categoryFlowType}
             allowNone={true}
           />
         </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -251,9 +251,15 @@ export const auth = {
 }
 
 // Categories
+const parseCategoryFlowType = (value: unknown): Category['flow_type'] | undefined =>
+  value === 'income' || value === 'expense' ? value : undefined
+
 export const categories = {
-  list: async (): Promise<Category[]> => {
-    const { data } = await api.get('/categories')
+  list: async (flowType?: unknown): Promise<Category[]> => {
+    const categoryFlowType = parseCategoryFlowType(flowType)
+    const { data } = await api.get('/categories', {
+      params: categoryFlowType ? { flow_type: categoryFlowType } : undefined,
+    })
     return data
   },
   create: async (category: Partial<Category>): Promise<Category> => {
@@ -271,8 +277,11 @@ export const categories = {
 
 // Category Groups
 export const categoryGroups = {
-  list: async (): Promise<CategoryGroup[]> => {
-    const { data } = await api.get('/category-groups')
+  list: async (flowType?: unknown): Promise<CategoryGroup[]> => {
+    const categoryFlowType = parseCategoryFlowType(flowType)
+    const { data } = await api.get('/category-groups', {
+      params: categoryFlowType ? { flow_type: categoryFlowType } : undefined,
+    })
     return data
   },
   create: async (group: Partial<CategoryGroup>): Promise<CategoryGroup> => {

--- a/frontend/src/pages/categories.tsx
+++ b/frontend/src/pages/categories.tsx
@@ -47,12 +47,14 @@ export default function CategoriesPage() {
   const [editingCat, setEditingCat] = useState<Category | null>(null)
   const [formIcon, setFormIcon] = useState('circle-help')
   const [formColor, setFormColor] = useState('#6366f1')
+  const [formFlowType, setFormFlowType] = useState<Category['flow_type']>('expense')
   const [formTreatAsTransfer, setFormTreatAsTransfer] = useState(false)
   const [formIgnoreTransfer, setFormIgnoreTransfer] = useState(false)
   const [groupDialogOpen, setGroupDialogOpen] = useState(false)
   const [editingGroup, setEditingGroup] = useState<CategoryGroup | null>(null)
   const [groupFormIcon, setGroupFormIcon] = useState('folder')
   const [groupFormColor, setGroupFormColor] = useState('#6B7280')
+  const [groupFormFlowType, setGroupFormFlowType] = useState<CategoryGroup['flow_type']>('expense')
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
 
   const { data: groups } = useQuery({
@@ -112,6 +114,7 @@ export default function CategoriesPage() {
     setEditingCat(cat)
     setFormIcon(cat?.icon ?? 'circle-help')
     setFormColor(cat?.color ?? '#6366f1')
+    setFormFlowType(cat?.flow_type ?? 'expense')
     setFormTreatAsTransfer(cat?.treat_as_transfer ?? false)
     setCatDialogOpen(true)
   }
@@ -120,6 +123,7 @@ export default function CategoriesPage() {
     setEditingGroup(group)
     setGroupFormIcon(group?.icon ?? 'folder')
     setGroupFormColor(group?.color ?? '#6B7280')
+    setGroupFormFlowType(group?.flow_type ?? 'expense')
     setGroupDialogOpen(true)
   }
 
@@ -277,6 +281,7 @@ export default function CategoriesPage() {
                 name: formData.get('name') as string,
                 icon: formData.get('icon') as string,
                 color: formData.get('color') as string,
+                flow_type: formData.get('flow_type') as Category['flow_type'],
                 group_id: (formData.get('group_id') as string) || null,
                 treat_as_transfer: formTreatAsTransfer,
                 is_ignored: formIgnoreTransfer
@@ -294,6 +299,18 @@ export default function CategoriesPage() {
               <Input name="name" defaultValue={editingCat?.name ?? ''} required />
             </div>
             <div className="space-y-2">
+              <Label>{t('transactions.type')}</Label>
+              <select
+                name="flow_type"
+                value={formFlowType}
+                onChange={(e) => setFormFlowType(e.target.value as Category['flow_type'])}
+                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+              >
+                <option value="expense">{t('transactions.expense')}</option>
+                <option value="income">{t('transactions.income')}</option>
+              </select>
+            </div>
+            <div className="space-y-2">
               <Label>{t('categories.group')}</Label>
               <select
                 name="group_id"
@@ -301,7 +318,7 @@ export default function CategoriesPage() {
                 className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
               >
                 <option value="">{t('categories.noGroup')}</option>
-                {groups?.map((g) => (
+                {groups?.filter((g) => g.flow_type === formFlowType).map((g) => (
                   <option key={g.id} value={g.id}>{g.name}</option>
                 ))}
               </select>
@@ -366,6 +383,7 @@ export default function CategoriesPage() {
                 name: formData.get('name') as string,
                 icon: formData.get('icon') as string,
                 color: formData.get('color') as string,
+                flow_type: formData.get('flow_type') as CategoryGroup['flow_type'],
                 position: parseInt(formData.get('position') as string) || 0,
               }
               if (editingGroup) {
@@ -383,6 +401,18 @@ export default function CategoriesPage() {
             <div className="space-y-2">
               <Label>{t('groups.position')}</Label>
               <Input name="position" type="number" defaultValue={editingGroup?.position?.toString() ?? '0'} />
+            </div>
+            <div className="space-y-2">
+              <Label>{t('transactions.type')}</Label>
+              <select
+                name="flow_type"
+                value={groupFormFlowType}
+                onChange={(e) => setGroupFormFlowType(e.target.value as CategoryGroup['flow_type'])}
+                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+              >
+                <option value="expense">{t('transactions.expense')}</option>
+                <option value="income">{t('transactions.income')}</option>
+              </select>
             </div>
             <div className="space-y-2">
               <Label>{t('groups.color')}</Label>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -85,6 +85,7 @@ export interface Category {
   name: string
   icon: string
   color: string
+  flow_type: 'income' | 'expense'
   is_system: boolean
   treat_as_transfer: boolean
   is_ignored: boolean
@@ -96,6 +97,7 @@ export interface CategoryGroup {
   name: string
   icon: string
   color: string
+  flow_type: 'income' | 'expense'
   position: number
   is_system: boolean
   categories: Category[]


### PR DESCRIPTION
﻿## What

Adds income/expense flow types to categories and category groups.

- Adds `flow_type` to category groups and categories via migration `064_category_flow_types.py`
- Backfills existing default income groups/categories as `income`; defaults everything else to `expense`
- Adds API filters for category/group flow type
- Validates that category groups and transaction categories match the expected flow
- Filters category choices in the frontend based on transaction type
- Adds focused backend coverage for filtering and validation

## Why

Categories used for income and expenses should not be interchangeable. This prevents assigning expense categories to credit transactions or income categories to debit transactions, while keeping the existing default category structure intact.

## How to Test

1. `cd backend && python -m pytest tests/test_category_group_service.py tests/test_category_service.py tests/test_categories_api.py tests/test_transaction_service.py`
2. `cd backend && python -m pytest tests/test_rule_service.py tests/test_new_rules_api.py tests/test_rule_engine.py tests/test_transactions_api.py`
3. `cd backend && python -m ruff check app tests/test_category_group_service.py tests/test_category_service.py tests/test_categories_api.py tests/test_transaction_service.py tests/test_transactions_api.py tests/test_rule_service.py`
4. `cd frontend && npm run lint`
5. `cd frontend && npm run build`

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
