### PR TITLE
fix: preserve transfer categories and clear fx overrides

### DIFF
--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -923,7 +923,6 @@ async def link_existing_as_transfer(
     transfer_pair_id = uuid.uuid4()
     for tx in txns:
         tx.transfer_pair_id = transfer_pair_id
-        tx.category_id = None  # transfers are excluded from category reports
 
     await session.commit()
     for tx in txns:
@@ -1002,9 +1001,8 @@ async def create_transfer_counterpart(
     apply_effective_date(counterpart_tx, to_account)
     session.add(counterpart_tx)
 
-    # Link the anchor into the pair; transfers are excluded from category reports.
+    # Link the anchor into the pair; reports exclude transfer_pair_id.
     anchor.transfer_pair_id = transfer_pair_id
-    anchor.category_id = None
 
     await session.flush()
     await stamp_primary_amount(session, user_id, counterpart_tx)
@@ -1122,9 +1120,9 @@ async def update_transaction(
                 raise ValueError("Cannot move transfer to the same account as its paired transaction")
 
     # Pop FX override fields before generic setattr loop
+    has_fx_override = "amount_primary" in update_data or "fx_rate_used" in update_data
     override_amount_primary = update_data.pop("amount_primary", None)
     override_fx_rate = update_data.pop("fx_rate_used", None)
-    has_fx_override = override_amount_primary is not None or override_fx_rate is not None
 
     restamp_fields = {"amount", "currency", "date"}
     needs_restamp = bool(restamp_fields & update_data.keys())
@@ -1133,12 +1131,17 @@ async def update_transaction(
         setattr(transaction, key, value)
 
     if has_fx_override:
-        _apply_fx_override(
-            transaction,
-            transaction.amount,
-            override_amount_primary,
-            override_fx_rate,
-        )
+        if override_amount_primary is None and override_fx_rate is None:
+            transaction.amount_primary = None
+            transaction.fx_rate_used = None
+            await stamp_primary_amount(session, user_id, transaction)
+        else:
+            _apply_fx_override(
+                transaction,
+                transaction.amount,
+                override_amount_primary,
+                override_fx_rate,
+            )
     elif needs_restamp:
         await stamp_primary_amount(session, user_id, transaction)
 

--- a/backend/tests/test_fx_rates.py
+++ b/backend/tests/test_fx_rates.py
@@ -1257,6 +1257,43 @@ class TestManualFxOverride:
         assert data["fx_rate_used"] == 5.5
 
     @pytest.mark.asyncio
+    async def test_update_clear_fx_override_restamps(
+        self,
+        client: AsyncClient,
+        auth_headers,
+        test_user: User,
+        session: AsyncSession,
+        fx_rates,
+    ):
+        usd_account = await _make_account(session, test_user, currency="USD")
+        resp = await client.post(
+            "/api/transactions",
+            headers=auth_headers,
+            json={
+                "account_id": str(usd_account.id),
+                "description": "Clear override",
+                "amount": "100.00",
+                "date": date.today().isoformat(),
+                "type": "debit",
+                "currency": "USD",
+                "amount_primary": "550.00",
+                "fx_rate_used": "5.5",
+            },
+        )
+        assert resp.status_code == 201
+        txn_id = resp.json()["id"]
+
+        resp2 = await client.patch(
+            f"/api/transactions/{txn_id}",
+            headers=auth_headers,
+            json={"amount_primary": None, "fx_rate_used": None},
+        )
+        assert resp2.status_code == 200
+        data = resp2.json()
+        assert data["amount_primary"] == 500.0
+        assert data["fx_rate_used"] == 5.0
+
+    @pytest.mark.asyncio
     async def test_update_without_fx_override_auto_stamps(
         self,
         client: AsyncClient,

--- a/backend/tests/test_transactions_api_coverage.py
+++ b/backend/tests/test_transactions_api_coverage.py
@@ -315,6 +315,37 @@ async def test_transfer_candidates_not_found(client: AsyncClient, auth_headers, 
 
 
 @pytest.mark.asyncio
+async def test_link_transfer_preserves_categories(
+    client: AsyncClient, auth_headers, test_transactions, test_categories
+):
+    other = await _manual_account(client, auth_headers, "Destino linkado")
+    debit = test_transactions[0]
+    credit_resp = await client.post(
+        "/api/transactions",
+        headers=auth_headers,
+        json={
+            "account_id": other,
+            "category_id": str(test_categories[2].id),
+            "description": "Linked credit",
+            "amount": "25.50",
+            "date": date.today().isoformat(),
+            "type": "credit",
+        },
+    )
+    assert credit_resp.status_code == 201, credit_resp.text
+
+    resp = await client.post(
+        "/api/transactions/link-transfer",
+        headers=auth_headers,
+        json={"transaction_ids": [str(debit.id), credit_resp.json()["id"]]},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["debit"]["category_id"] == str(debit.category_id)
+    assert data["credit"]["category_id"] == str(test_categories[2].id)
+
+
+@pytest.mark.asyncio
 async def test_create_counterpart(
     client: AsyncClient, auth_headers, test_account: Account, test_transactions
 ):
@@ -326,7 +357,9 @@ async def test_create_counterpart(
         json={"to_account_id": other},
     )
     assert resp.status_code == 201, resp.text
-    assert resp.json()["transfer_pair_id"]
+    data = resp.json()
+    assert data["transfer_pair_id"]
+    assert data["debit"]["category_id"] == str(tx.category_id)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_transfer_api.py
+++ b/backend/tests/test_transfer_api.py
@@ -875,14 +875,14 @@ async def test_create_counterpart_rejects_already_linked(
 
 
 @pytest.mark.asyncio
-async def test_create_counterpart_clears_anchor_category(
+async def test_create_counterpart_preserves_anchor_category(
     client: AsyncClient,
     auth_headers,
     test_account: Account,
     second_account: Account,
     test_categories,
 ):
-    """Marking a categorized transaction as a transfer clears its category."""
+    """Marking a categorized transaction as a transfer keeps its category."""
     create_response = await client.post(
         "/api/transactions",
         json={
@@ -910,7 +910,7 @@ async def test_create_counterpart_clears_anchor_category(
         f"/api/transactions/{anchor['id']}", headers=auth_headers
     )
     assert refreshed.status_code == 200
-    assert refreshed.json()["category_id"] is None
+    assert refreshed.json()["category_id"] == str(test_categories[0].id)
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -369,6 +369,9 @@ function TransactionForm({
   const [fxRate, setFxRate] = useState(
     seed?.fx_rate_used != null ? seed.fx_rate_used.toString() : ''
   )
+  const [hadInitialFx] = useState(
+    !!transaction && (seed?.amount_primary != null || seed?.fx_rate_used != null)
+  )
   const [isRecurring, setIsRecurring] = useState(false)
   const [frequency, setFrequency] = useState<'monthly' | 'weekly' | 'yearly'>('monthly')
   const [endDate, setEndDate] = useState('')
@@ -597,6 +600,10 @@ function TransactionForm({
         }
         if (showConversion && fxRate) {
           fxFields.fx_rate_used = parseFloat(fxRate)
+        }
+        if (showConversion && hadInitialFx && !convertedAmount && !fxRate) {
+          fxFields.amount_primary = null
+          fxFields.fx_rate_used = null
         }
         // Active CC account ⇒ surface effective_bill_date in the payload
         // (sent both for synced and manual edits since the user can hand-


### PR DESCRIPTION
## What
- preserve transfer categories during transaction updates
- clear manual FX overrides when edited transaction currency data changes
- cover transfer and FX edit behavior in tests

## Why
Transaction edits should not leave stale FX overrides or break transfer category state.

## How to Test
- `cd backend && .venv/bin/ruff check app/services/transaction_service.py tests/test_fx_rates.py tests/test_transactions_api_coverage.py tests/test_transfer_api.py`
- `cd backend && .venv/bin/pytest -q tests/test_fx_rates.py tests/test_transactions_api_coverage.py tests/test_transfer_api.py` -> 119 passed
- `cd frontend && npm run lint && npm run build` -> passed with existing warnings

## Checklist
- [x] Backend tests pass (targeted pytest)
- [x] Frontend lints clean enough for current repo baseline (0 errors; existing warnings remain where applicable)
- [x] Frontend builds (where applicable)
- [x] Translations updated (if user-facing strings changed)