### PR TITLE
fix: stop grouping assets in the pie chart  into "others"group when t…

### DIFF
--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -437,12 +437,16 @@ export default function ReportsPage() {
       const otherValue = Math.round((innerTotal - topSum) * 100) / 100
       for (const item of significant) result.push(item)
       if (otherValue > 0.005) {
-        result.push({
-          name: otherLabel(g),
-          value: otherValue,
-          color: OTHER_SLICE_COLOR,
-          children: rest.length > 0 ? rest : undefined,
-        })
+        if (rest.length === 1) {
+          result.push(rest[0])
+        } else {
+          result.push({
+            name: otherLabel(g),
+            value: otherValue,
+            color: OTHER_SLICE_COLOR,
+            children: rest.length > 0 ? rest : undefined,
+          })
+        }
       }
     }
 


### PR DESCRIPTION
## What
Small tweak on the grouping and color choosing of the pie chart of networth reports page. 
The idea is to stop grouping assets if there is only one of that kind, avoiding neighbor sessions of gray color if possible.
In my use case, most of my chart is covered by assets, and the sum of both accounts and liablities falls below the grouping threshold, but there is only one of each. this ends up creating 3 neighnbor sessionss in gray, "other assets', "other accounts" and "other liablities".  


Below there are screenshots of before and after


https://github.com/user-attachments/assets/84c9b9da-90c7-4092-878d-aff4f843520f

<img width="419" height="363" alt="Screenshot 2026-07-03 at 21 31 04" src="https://github.com/user-attachments/assets/522d8d92-9517-4dcb-a6c4-96a4cb2aa56a" />


## Checklist

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
- [ ] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))
