### PR TITLE
feat(rules): group rule extensions by category and make dropdown searchable

### DIFF
--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -7,11 +7,13 @@ import { useAuth } from '@/contexts/auth-context'
 import { currencies as currenciesApi, transactions as transactionsApi, settings as settingsApi, payees as payeesApi, rules as rulesApi } from '@/lib/api'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { normalizeRuleMatchValue } from '@/lib/rule-match-utils'
-import { cn } from '@/lib/utils'
+import { cn, normalizeText } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { DatePickerInput } from '@/components/ui/date-picker-input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem } from '@/components/ui/command'
 import {
   Dialog,
   DialogContent,
@@ -20,7 +22,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog'
-import { AlertTriangle, ChevronDown, ChevronLeft, Download, Eye, EyeClosed, Paperclip, Upload, X, FileText, Plus, Unlink, SlidersHorizontal, ListPlus } from 'lucide-react'
+import { AlertTriangle, ChevronDown, ChevronLeft, Download, Eye, EyeClosed, Paperclip, Upload, X, FileText, Plus, Unlink, SlidersHorizontal, ListPlus, Check } from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -1116,6 +1118,7 @@ function TransactionForm({
           transactionDescription={transaction.description}
           rules={extendableRules}
           categories={categories}
+          categoryGroups={categoryGroups}
           loadingRules={rulesLoading}
           loading={extendRuleMutation.isPending}
           onSubmit={({ rule, condition }) => extendRuleMutation.mutate({ rule, condition })}
@@ -1131,6 +1134,7 @@ function AddTransactionToRuleDialog({
   transactionDescription,
   rules,
   categories,
+  categoryGroups,
   loadingRules,
   loading,
   onSubmit,
@@ -1140,12 +1144,14 @@ function AddTransactionToRuleDialog({
   transactionDescription: string
   rules: Rule[]
   categories: Category[]
+  categoryGroups: CategoryGroup[]
   loadingRules: boolean
   loading: boolean
   onSubmit: (data: { rule: Rule; condition: RuleCondition }) => void
 }) {
   const { t } = useTranslation()
   const [ruleId, setRuleId] = useState('')
+  const [openCombobox, setOpenCombobox] = useState(false)
   const [matchOp, setMatchOp] = useState<'contains' | 'starts_with'>('contains')
   const [matchText, setMatchText] = useState(transactionDescription)
 
@@ -1154,10 +1160,42 @@ function AddTransactionToRuleDialog({
     : rules[0]?.id ?? ''
   const selectedRule = rules.find(rule => rule.id === effectiveRuleId) ?? null
 
-  function getCategoryName(rule: Rule): string {
-    const categoryId = getRuleCategoryId(rule)
-    return categories.find(category => category.id === categoryId)?.name ?? t('transactions.category')
-  }
+  const groupedRules = useMemo(() => {
+    const groupsMap: { [categoryId: string]: { categoryName: string; rules: Rule[] } } = {}
+
+    for (const rule of rules) {
+      const categoryId = getRuleCategoryId(rule) ?? 'uncategorized'
+      let categoryName = t('transactions.uncategorized')
+
+      if (categoryId !== 'uncategorized') {
+        const category = categories.find(c => c.id === categoryId)
+        if (category) {
+          categoryName = category.name
+          if (category.group_id) {
+            const group = categoryGroups.find(g => g.id === category.group_id)
+            if (group) {
+              categoryName = `${group.name} > ${category.name}`
+            }
+          }
+        } else {
+          categoryName = t('transactions.category')
+        }
+      }
+
+      if (!groupsMap[categoryId]) {
+        groupsMap[categoryId] = {
+          categoryName,
+          rules: [],
+        }
+      }
+      groupsMap[categoryId].rules.push(rule)
+    }
+
+    return Object.entries(groupsMap).map(([categoryId, data]) => ({
+      categoryId,
+      ...data,
+    }))
+  }, [rules, categories, categoryGroups, t])
 
   function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
@@ -1188,32 +1226,62 @@ function AddTransactionToRuleDialog({
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
             <Label>{t('transactions.existingRule')}</Label>
-            <Select
-              value={effectiveRuleId}
-              onValueChange={setRuleId}
-              disabled={loadingRules || loading || rules.length === 0}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue
-                  className="min-w-0 flex-1 text-left [&_span]:items-start [&_span]:text-left"
-                  placeholder={loadingRules
-                    ? t('common.loading')
-                    : t('transactions.noExistingRules')}
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {rules.map(rule => (
-                  <SelectItem key={rule.id} value={rule.id}>
-                    <span className="flex w-full min-w-0 flex-col items-start text-left">
-                      <span className="w-full truncate">{rule.name}</span>
-                      <span className="w-full text-xs text-muted-foreground truncate">
-                        {getCategoryName(rule)}
-                      </span>
-                    </span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Popover open={openCombobox} onOpenChange={setOpenCombobox}>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  disabled={loadingRules || loading || rules.length === 0}
+                  className="flex w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm text-left shadow-xs transition-[color,box-shadow] outline-hidden focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 dark:hover:bg-input/50 h-9 cursor-pointer"
+                >
+                  <span className="flex-1 truncate text-left">
+                    {loadingRules ? (
+                      t('common.loading')
+                    ) : selectedRule ? (
+                      selectedRule.name
+                    ) : (
+                      t('transactions.noExistingRules')
+                    )}
+                  </span>
+                  <ChevronDown className="size-4 shrink-0 opacity-50" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="start"
+                className="w-[var(--radix-popover-trigger-width)] p-0 overflow-hidden"
+              >
+                <Command
+                  filter={(itemValue, search) => {
+                    return normalizeText(itemValue).includes(normalizeText(search)) ? 1 : 0
+                  }}
+                >
+                  <CommandInput placeholder={t('transactions.searchRule', 'Search rule...')} />
+                  <CommandList className="max-h-[300px] overflow-y-auto">
+                    <CommandEmpty>{t('transactions.noRulesFound', 'No rules found.')}</CommandEmpty>
+                    {groupedRules.map((group) => (
+                      <CommandGroup key={group.categoryId}>
+                        <div className="px-2 py-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
+                          {group.categoryName}
+                        </div>
+                        {group.rules.map((rule) => (
+                          <CommandItem
+                            key={rule.id}
+                            value={`${group.categoryName} ${rule.name}`}
+                            onSelect={() => {
+                              setRuleId(rule.id)
+                              setOpenCombobox(false)
+                            }}
+                            className="flex items-center justify-between gap-2 cursor-pointer"
+                          >
+                            <span className="flex-1 truncate">{rule.name}</span>
+                            {effectiveRuleId === rule.id && <Check className="size-4 shrink-0" />}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    ))}
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
             {!loadingRules && rules.length === 0 && (
               <p className="text-xs text-muted-foreground">{t('transactions.noExistingRules')}</p>
             )}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -290,6 +290,8 @@
     "noCategory": "Keine Kategorie",
     "searchCategory": "Kategorie suchen...",
     "noCategoryFound": "Keine Kategorie gefunden.",
+    "searchRule": "Regel suchen...",
+    "noRulesFound": "Keine Regeln gefunden.",
     "addManual": "Transaktion hinzufügen",
     "duplicate": "Duplizieren",
     "createRule": "Regel erstellen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -290,6 +290,8 @@
     "noCategory": "No category",
     "searchCategory": "Search category...",
     "noCategoryFound": "No category found.",
+    "searchRule": "Search rule...",
+    "noRulesFound": "No rules found.",
     "addManual": "Add Transaction",
     "duplicate": "Duplicate",
     "createRule": "Create Rule",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -290,6 +290,8 @@
     "noCategory": "Sin categoría",
     "searchCategory": "Buscar categoría...",
     "noCategoryFound": "No se encontraron categorías.",
+    "searchRule": "Buscar regla...",
+    "noRulesFound": "No se encontraron reglas.",
     "addManual": "Agregar transacción",
     "duplicate": "Duplicar",
     "createRule": "Crear regla",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -290,6 +290,8 @@
     "noCategory": "Nessuna categoria",
     "searchCategory": "Cerca categoria...",
     "noCategoryFound": "Nessuna categoria trovata.",
+    "searchRule": "Cerca regola...",
+    "noRulesFound": "Nessuna regola trovata.",
     "addManual": "Aggiungi transazione",
     "duplicate": "Duplica",
     "createRule": "Crea regola",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -296,6 +296,8 @@
     "noCategory": "Brak kategorii",
     "searchCategory": "Szukaj kategorii...",
     "noCategoryFound": "Nie znaleziono żadnej kategorii.",
+    "searchRule": "Szukaj reguły...",
+    "noRulesFound": "Nie znaleziono reguł.",
     "addManual": "Dodaj transakcję",
     "duplicate": "Duplikuj",
     "createRule": "Utwórz regułę",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -290,6 +290,8 @@
     "noCategory": "Sem categoria",
     "searchCategory": "Buscar categoria...",
     "noCategoryFound": "Nenhuma categoria encontrada.",
+    "searchRule": "Buscar regra...",
+    "noRulesFound": "Nenhuma regra encontrada.",
     "addManual": "Adicionar Transação",
     "duplicate": "Duplicar",
     "createRule": "Criar Regra",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -290,6 +290,8 @@
     "noCategory": "Без категории",
     "searchCategory": "Поиск категории...",
     "noCategoryFound": "Категория не найдена.",
+    "searchRule": "Поиск правила...",
+    "noRulesFound": "Правила не найдены.",
     "addManual": "Добавить транзакцию",
     "duplicate": "Дублировать",
     "createRule": "Создать правило",

--- a/frontend/src/locales/uk.json
+++ b/frontend/src/locales/uk.json
@@ -290,6 +290,8 @@
     "noCategory": "Без категорії",
     "searchCategory": "Пошук категорії...",
     "noCategoryFound": "Категорію не знайдено.",
+    "searchRule": "Пошук правила...",
+    "noRulesFound": "Правил не знайдено.",
     "addManual": "Додати транзакцію",
     "duplicate": "Дублювати",
     "createRule": "Створити правило",


### PR DESCRIPTION
## What

Refactor the `AddTransactionToRuleDialog` rule selector to use a searchable combobox and group rules by category instead of displaying repetitive category subtitles.

## Why

- Currently, the dialog uses a standard `Select` which can be difficult to navigate when the user has many rules.
- Under each rule name, it repeats the category name, causing visual clutter. Grouping them under category headers makes the list shorter, cleaner, and much easier to browse.

## How to Test

1. Open a transaction edit dialog, click the "Create Rule" action dropdown, and choose "Add to existing rule".
2. Verify the rule selector is a Popover/Command combobox where you can search by rule name or category/group name.
3. Verify rules are grouped under category headers (e.g. `BILLING > Hosting`, `FOOD > Restaurants`) and no longer repeat subtitles.

## Checklist

- [ ] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)

## Demo

Before
<img width="942" height="794" alt="CleanShot 2026-06-30 at 01 09 45@2x" src="https://github.com/user-attachments/assets/c7b98a4d-a5ad-4e0f-9083-fccff68e81ff" />

After
<img width="908" height="950" alt="CleanShot 2026-06-30 at 01 32 48@2x" src="https://github.com/user-attachments/assets/1336d92a-8857-4f5d-8661-4925dfc66f0c" />
