### PR TITLE
feat(frontend): replace calendar date picker with month picker

### DIFF
--- a/frontend/src/components/month-stepper.tsx
+++ b/frontend/src/components/month-stepper.tsx
@@ -1,4 +1,8 @@
+import { useState } from 'react'
 import { shiftMonth, monthLabel } from '@/lib/month-utils'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+import { MonthPicker } from '@/components/ui/monthpicker'
+import { resolveDateFnsLocale } from '@/lib/date-fns-locale'
 
 interface MonthStepperProps {
   /** Selected month as `"YYYY-MM"`. */
@@ -18,31 +22,46 @@ interface MonthStepperProps {
  * parent so the stepper stays a single source of truth on top of existing filters.
  */
 export function MonthStepper({ value, onChange, locale = 'pt-BR', prevLabel, nextLabel }: MonthStepperProps) {
+  const [open, setOpen] = useState(false)
   const label = monthLabel(value, locale).replace(/^\w/, (c) => c.toUpperCase())
+  const dateFnsLocale = resolveDateFnsLocale(locale)
+
   return (
     <div className="flex items-center gap-1 min-w-0">
       <button
         type="button"
         aria-label={prevLabel}
-        className="h-8 w-8 shrink-0 flex items-center justify-center rounded-lg border border-border bg-card text-muted-foreground hover:text-foreground transition-all text-base"
+        className="h-8 w-8 shrink-0 flex items-center justify-center rounded-lg border border-border bg-card text-muted-foreground hover:text-foreground transition-all text-base cursor-pointer"
         onClick={() => onChange(shiftMonth(value, -1))}
       >
         &#8249;
       </button>
-      {/* Compact on mobile (content width, truncates if cramped) so the month
-          stepper shares a single row with the page actions; full 160px on
-          desktop for a stable, centered label. */}
-      <span
-        aria-live="polite"
-        aria-atomic="true"
-        className="inline-flex items-center justify-center border border-border rounded-lg px-3 py-1.5 text-sm bg-card text-foreground min-w-0 sm:min-w-[160px] truncate"
-      >
-        {label}
-      </span>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center border border-border rounded-lg px-3 py-1.5 text-sm bg-card text-foreground min-w-0 sm:min-w-[160px] truncate hover:bg-muted/50 transition-all cursor-pointer"
+          >
+            {label}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="center" className="w-auto p-0">
+          <MonthPicker
+            locale={dateFnsLocale}
+            selectedMonth={new Date(`${value}-01T00:00:00`)}
+            onMonthSelect={(date) => {
+              if (!date) return
+              const newMonth = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
+              onChange(newMonth)
+              setOpen(false)
+            }}
+          />
+        </PopoverContent>
+      </Popover>
       <button
         type="button"
         aria-label={nextLabel}
-        className="h-8 w-8 shrink-0 flex items-center justify-center rounded-lg border border-border bg-card text-muted-foreground hover:text-foreground transition-all text-base"
+        className="h-8 w-8 shrink-0 flex items-center justify-center rounded-lg border border-border bg-card text-muted-foreground hover:text-foreground transition-all text-base cursor-pointer"
         onClick={() => onChange(shiftMonth(value, 1))}
       >
         &#8250;
@@ -50,3 +69,4 @@ export function MonthStepper({ value, onChange, locale = 'pt-BR', prevLabel, nex
     </div>
   )
 }
+

--- a/frontend/src/components/ui/monthpicker.tsx
+++ b/frontend/src/components/ui/monthpicker.tsx
@@ -1,0 +1,145 @@
+import * as React from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { format, type Locale } from 'date-fns'
+
+type Month = {
+  number: number
+  name: string
+}
+
+const MONTHS: Month[][] = [
+  [
+    { number: 0, name: 'Jan' },
+    { number: 1, name: 'Feb' },
+    { number: 2, name: 'Mar' },
+    { number: 3, name: 'Apr' },
+  ],
+  [
+    { number: 4, name: 'May' },
+    { number: 5, name: 'Jun' },
+    { number: 6, name: 'Jul' },
+    { number: 7, name: 'Aug' },
+  ],
+  [
+    { number: 8, name: 'Sep' },
+    { number: 9, name: 'Oct' },
+    { number: 10, name: 'Nov' },
+    { number: 11, name: 'Dec' },
+  ],
+]
+
+interface MonthPickerProps {
+  selectedMonth?: Date
+  onMonthSelect?: (date: Date) => void
+  locale?: Locale
+  className?: string
+  minDate?: Date
+  maxDate?: Date
+}
+
+function MonthPicker({
+  selectedMonth,
+  onMonthSelect,
+  locale,
+  className,
+  minDate,
+  maxDate,
+}: MonthPickerProps) {
+  const initialYear = selectedMonth?.getFullYear() ?? new Date().getFullYear()
+  const [menuYear, setMenuYear] = React.useState<number>(initialYear)
+
+  const selectedYear = selectedMonth?.getFullYear()
+  const selectedMonthIdx = selectedMonth?.getMonth()
+
+  const handlePrevYear = () => {
+    setMenuYear((prev) => prev - 1)
+  }
+
+  const handleNextYear = () => {
+    setMenuYear((prev) => prev + 1)
+  }
+
+  return (
+    <div className={cn('p-3 w-[252px]', className)}>
+      {/* Header: nav + year */}
+      <div className="flex items-center justify-between mb-3">
+        <button
+          type="button"
+          onClick={handlePrevYear}
+          disabled={minDate ? menuYear - 1 < minDate.getFullYear() : false}
+          className="size-7 inline-flex items-center justify-center rounded-lg border border-border bg-transparent text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors disabled:opacity-50 disabled:pointer-events-none cursor-pointer"
+        >
+          <ChevronLeft className="size-4" />
+        </button>
+        <span className="text-sm font-medium text-foreground capitalize px-2 py-1">
+          {menuYear}
+        </span>
+        <button
+          type="button"
+          onClick={handleNextYear}
+          disabled={maxDate ? menuYear + 1 > maxDate.getFullYear() : false}
+          className="size-7 inline-flex items-center justify-center rounded-lg border border-border bg-transparent text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors disabled:opacity-50 disabled:pointer-events-none cursor-pointer"
+        >
+          <ChevronRight className="size-4" />
+        </button>
+      </div>
+
+      {/* Months Grid */}
+      <table className="w-full border-collapse space-y-1">
+        <tbody>
+          {MONTHS.map((monthRow, rIdx) => (
+            <tr key={`row-${rIdx}`} className="flex w-full mt-2 gap-1">
+              {monthRow.map((m) => {
+                const monthDate = new Date(menuYear, m.number, 1)
+                const isSelected = selectedYear === menuYear && selectedMonthIdx === m.number
+
+                let isDisabled = false
+                if (minDate) {
+                  if (menuYear < minDate.getFullYear()) {
+                    isDisabled = true
+                  } else if (menuYear === minDate.getFullYear() && m.number < minDate.getMonth()) {
+                    isDisabled = true
+                  }
+                }
+                if (maxDate) {
+                  if (menuYear > maxDate.getFullYear()) {
+                    isDisabled = true
+                  } else if (menuYear === maxDate.getFullYear() && m.number > maxDate.getMonth()) {
+                    isDisabled = true
+                  }
+                }
+
+                const displayMonthName = locale
+                  ? format(monthDate, 'MMM', { locale })
+                  : m.name
+
+                return (
+                  <td key={m.number} className="h-10 w-1/4 text-center text-sm p-0 relative">
+                    <button
+                      type="button"
+                      disabled={isDisabled}
+                      onClick={() => onMonthSelect?.(monthDate)}
+                      className={cn(
+                        'h-full w-full rounded-lg text-sm capitalize transition-colors flex items-center justify-center cursor-pointer',
+                        isSelected
+                          ? 'bg-primary text-primary-foreground font-semibold'
+                          : 'text-foreground hover:bg-muted/60 disabled:opacity-30 disabled:pointer-events-none'
+                      )}
+                    >
+                      {displayMonthName}
+                    </button>
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+MonthPicker.displayName = 'MonthPicker'
+
+export { MonthPicker }

--- a/frontend/src/pages/budgets.tsx
+++ b/frontend/src/pages/budgets.tsx
@@ -18,7 +18,7 @@ import type { Budget } from '@/types'
 import { Pencil, Trash2, Plus, Repeat, CalendarIcon } from 'lucide-react'
 import { format } from 'date-fns'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
-import { Calendar } from '@/components/ui/calendar'
+import { MonthPicker } from '@/components/ui/monthpicker'
 import { PageHeader } from '@/components/page-header'
 import { CategoryIcon } from '@/components/category-icon'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
@@ -154,12 +154,10 @@ export default function BudgetsPage() {
                 </button>
               </PopoverTrigger>
               <PopoverContent align="center" className="w-auto p-0">
-                <Calendar
-                  mode="single"
+                <MonthPicker
                   locale={dateFnsLocale}
-                  selected={new Date(`${selectedMonth}-01T00:00:00`)}
-                  defaultMonth={new Date(`${selectedMonth}-01T00:00:00`)}
-                  onSelect={(date) => {
+                  selectedMonth={new Date(`${selectedMonth}-01T00:00:00`)}
+                  onMonthSelect={(date) => {
                     if (!date) return
                     setSelectedMonth(format(date, 'yyyy-MM'))
                     setMonthCalOpen(false)

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -11,7 +11,7 @@ import { toast } from 'sonner'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
-import { Calendar } from '@/components/ui/calendar'
+import { MonthPicker } from '@/components/ui/monthpicker'
 import {
   Table,
   TableBody,
@@ -468,12 +468,10 @@ export default function DashboardPage() {
                 </button>
               </PopoverTrigger>
               <PopoverContent align="center" className="w-auto p-0">
-                <Calendar
-                  mode="single"
+                <MonthPicker
                   locale={dateFnsLocale}
-                  selected={new Date(`${selectedMonth}-01T00:00:00`)}
-                  defaultMonth={new Date(`${selectedMonth}-01T00:00:00`)}
-                  onSelect={(date) => {
+                  selectedMonth={new Date(`${selectedMonth}-01T00:00:00`)}
+                  onMonthSelect={(date) => {
                     if (!date) return
                     const newMonth = format(date, 'yyyy-MM')
                     setSelectedMonth(newMonth)


### PR DESCRIPTION
## What

Replaces the daily date picker in the Dashboard, Budgets, and Transactions pages' month navigations with a dedicated Month Picker.

## Why

Since these views are scoped to the current month, selecting a specific day is redundant. A monthly selection grid streamlines navigation and offers a cleaner user experience.

## How to Test

1. Open the Dashboard page, click the month dropdown selector, and verify the 12-month grid appears.
2. Select a month and verify the dashboard updates.
3. Open the Budgets page and verify the same behavior.
4. Open the Transactions page, click on the month name inside the stepper, and verify the month picker opens and updates the transaction list on selection.


## Screenshots

#### Before

<img width="1314" height="810" alt="CleanShot 2026-07-04 at 19 45 02" src="https://github.com/user-attachments/assets/ce759c9e-bcce-4289-9097-9ecd1e7a0f77" />

### After
<img width="1281" height="668" alt="CleanShot 2026-07-04 at 20 06 45" src="https://github.com/user-attachments/assets/65bbbd7b-d183-4884-a8cd-9eb4719f50f5" />


## Related Issue

N/A

## Checklist

- [ ] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
- [ ] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))
