### PR TITLE
feat(ui): configurable rows per page for tables

### DIFF
--- a/frontend/src/components/import-review-table.tsx
+++ b/frontend/src/components/import-review-table.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ImportReviewTransaction, Category, CategoryGroup } from '@/types'
 import { formatCurrency } from '@/lib/format'
@@ -13,8 +13,13 @@ import {
 import { Input } from '@/components/ui/input'
 import { CategorySelect } from '@/components/category-select'
 import { CategoryFilterDropdown } from '@/components/category-filter-dropdown'
-
-const PAGE_SIZE = 50
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 
 interface ImportReviewTableProps {
   transactions: ImportReviewTransaction[]
@@ -58,6 +63,14 @@ export function ImportReviewTable({
   onPageChange,
 }: ImportReviewTableProps) {
   const { t } = useTranslation()
+  const [pageSize, setPageSize] = useState<number>(() => {
+    try {
+      const stored = localStorage.getItem('securo.import.pageSize')
+      return stored ? Number(stored) : 50
+    } catch {
+      return 50
+    }
+  })
 
   const hasCategoryFilter = filterCategoryIds.length > 0 || filterUncategorized
 
@@ -83,9 +96,9 @@ export function ImportReviewTable({
     })
   }, [transactions, searchQuery, filterCategoryIds, filterUncategorized, hasCategoryFilter, statusFilter])
 
-  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize))
   const safePage = Math.min(currentPage, totalPages)
-  const pageItems = filtered.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE)
+  const pageItems = filtered.slice((safePage - 1) * pageSize, safePage * pageSize)
 
   return (
     <div>
@@ -198,25 +211,58 @@ export function ImportReviewTable({
       </div>
 
       {/* Pagination */}
-      {totalPages > 1 && (
-        <div className="px-5 py-3 border-t border-border flex items-center justify-between text-sm">
-          <button
-            className="text-muted-foreground hover:text-foreground disabled:opacity-30"
-            disabled={safePage <= 1}
-            onClick={() => onPageChange(safePage - 1)}
-          >
-            ← {t('common.previous', 'Previous')}
-          </button>
-          <span className="text-xs text-muted-foreground">
-            {t('import.page', { current: safePage, total: totalPages })}
-          </span>
-          <button
-            className="text-muted-foreground hover:text-foreground disabled:opacity-30"
-            disabled={safePage >= totalPages}
-            onClick={() => onPageChange(safePage + 1)}
-          >
-            {t('common.next', 'Next')} →
-          </button>
+      {filtered.length > 10 && (
+        <div className="px-5 py-3 border-t border-border flex flex-col sm:flex-row items-center justify-between gap-4 text-sm">
+          {totalPages > 1 ? (
+            <div className="flex items-center gap-4">
+              <button
+                className="text-muted-foreground hover:text-foreground disabled:opacity-30 font-medium"
+                disabled={safePage <= 1}
+                onClick={() => onPageChange(safePage - 1)}
+              >
+                ← {t('common.previous', 'Previous')}
+              </button>
+              <span className="text-xs text-muted-foreground">
+                {t('import.page', { current: safePage, total: totalPages })}
+              </span>
+              <button
+                className="text-muted-foreground hover:text-foreground disabled:opacity-30 font-medium"
+                disabled={safePage >= totalPages}
+                onClick={() => onPageChange(safePage + 1)}
+              >
+                {t('common.next', 'Next')} →
+              </button>
+            </div>
+          ) : (
+            <div className="hidden sm:block" />
+          )}
+
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">{t('common.rowsPerPage', 'Rows per page')}</span>
+            <Select
+              value={String(pageSize)}
+              onValueChange={(val) => {
+                const nextSize = Number(val)
+                setPageSize(nextSize)
+                onPageChange(1)
+                try {
+                  localStorage.setItem('securo.import.pageSize', String(nextSize))
+                } catch {
+                  // ignored
+                }
+              }}
+            >
+              <SelectTrigger className="w-[70px] h-8 text-xs">
+                <SelectValue placeholder={pageSize} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="10">10</SelectItem>
+                <SelectItem value="20">20</SelectItem>
+                <SelectItem value="50">50</SelectItem>
+                <SelectItem value="100">100</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1185,7 +1185,8 @@
     "showLess": "Weniger anzeigen",
     "showMore": "+{{count}} weitere",
     "previous": "Vorherige",
-    "next": "Nächste"
+    "next": "Nächste",
+    "rowsPerPage": "Zeilen pro Seite"
   },
   "splitGroups": {
     "title": "Gruppen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1185,7 +1185,8 @@
     "showLess": "Show less",
     "showMore": "+{{count}} more",
     "previous": "Previous",
-    "next": "Next"
+    "next": "Next",
+    "rowsPerPage": "Rows per page"
   },
   "splitGroups": {
     "title": "Groups",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1185,7 +1185,8 @@
     "showLess": "Mostrar menos",
     "showMore": "+{{count}} más",
     "previous": "Anterior",
-    "next": "Siguiente"
+    "next": "Siguiente",
+    "rowsPerPage": "Filas por página"
   },
   "splitGroups": {
     "title": "Grupos",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1185,7 +1185,8 @@
     "showLess": "Mostra meno",
     "showMore": "+{{count}} altri",
     "previous": "Precedente",
-    "next": "Successivo"
+    "next": "Successivo",
+    "rowsPerPage": "Righe per pagina"
   },
   "splitGroups": {
     "title": "Gruppi",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -1263,7 +1263,8 @@
     "showMore_many": "+{{count}} więcej",
     "showMore_other": "+{{count}} więcej",
     "previous": "Poprzedni",
-    "next": "Następny"
+    "next": "Następny",
+    "rowsPerPage": "Wierszy na stronę"
   },
   "splitGroups": {
     "title": "Grupy",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1185,7 +1185,8 @@
     "showLess": "Mostrar menos",
     "showMore": "Mostrar +{{count}}",
     "previous": "Anterior",
-    "next": "Próximo"
+    "next": "Próximo",
+    "rowsPerPage": "Linhas por página"
   },
   "splitGroups": {
     "title": "Grupos",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -1185,7 +1185,8 @@
     "showLess": "Показать меньше",
     "showMore": "+{{count}} ещё",
     "previous": "Назад",
-    "next": "Далее"
+    "next": "Далее",
+    "rowsPerPage": "Строк на странице"
   },
   "splitGroups": {
     "title": "Группы",

--- a/frontend/src/locales/uk.json
+++ b/frontend/src/locales/uk.json
@@ -1185,7 +1185,8 @@
     "showLess": "Показати менше",
     "showMore": "+{{count}} ще",
     "previous": "Назад",
-    "next": "Далі"
+    "next": "Далі",
+    "rowsPerPage": "Рядків на сторінці"
   },
   "splitGroups": {
     "title": "Групи",

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -10,6 +10,13 @@ import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { Calendar } from '@/components/ui/calendar'
 import {
@@ -360,7 +367,14 @@ export default function DashboardPage() {
     isIgnored: boolean
   }
 
-  const TX_PER_PAGE = 10
+  const [txPerPage, setTxPerPage] = useState<number>(() => {
+    try {
+      const stored = localStorage.getItem('securo.dashboard.pageSize')
+      return stored ? Number(stored) : 10
+    } catch {
+      return 10
+    }
+  })
   const allDisplayRows = useMemo(() => {
     const rows: DisplayRow[] = []
     for (const tx of currentMonthTxs?.items ?? []) {
@@ -428,8 +442,8 @@ export default function DashboardPage() {
     return rows
   }, [currentMonthTxs, projectedTxs, txSortDesc, groupNameById])
 
-  const txTotalPages = Math.ceil(allDisplayRows.length / TX_PER_PAGE)
-  const pagedRows = allDisplayRows.slice((txPage - 1) * TX_PER_PAGE, txPage * TX_PER_PAGE)
+  const txTotalPages = Math.ceil(allDisplayRows.length / txPerPage)
+  const pagedRows = allDisplayRows.slice((txPage - 1) * txPerPage, txPage * txPerPage)
   const txListLoading = currentTxLoading || projectedTxLoading
 
   // Savings rate display
@@ -1090,27 +1104,61 @@ export default function DashboardPage() {
                   ))}
                 </TableBody>
               </Table>
-              {txTotalPages > 1 && (
-                <div className="flex items-center justify-center gap-2 py-4 border-t border-border">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={txPage <= 1}
-                    onClick={() => setTxPage(txPage - 1)}
-                  >
-                    {t('dashboard.previous')}
-                  </Button>
-                  <span className="text-sm text-muted-foreground">
-                    {txPage} / {txTotalPages}
-                  </span>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={txPage >= txTotalPages}
-                    onClick={() => setTxPage(txPage + 1)}
-                  >
-                    {t('dashboard.next')}
-                  </Button>
+              {allDisplayRows.length > 10 && (
+                <div className="flex flex-col sm:flex-row items-center justify-between gap-4 px-5 py-4 border-t border-border">
+                  <div className="hidden sm:block w-32" />
+                  {txTotalPages > 1 ? (
+                    <div className="flex items-center justify-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={txPage <= 1}
+                        onClick={() => setTxPage(txPage - 1)}
+                      >
+                        {t('dashboard.previous')}
+                      </Button>
+                      <span className="text-sm text-muted-foreground">
+                        {txPage} / {txTotalPages}
+                      </span>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={txPage >= txTotalPages}
+                        onClick={() => setTxPage(txPage + 1)}
+                      >
+                        {t('dashboard.next')}
+                      </Button>
+                    </div>
+                  ) : (
+                    <div className="hidden sm:block" />
+                  )}
+
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-muted-foreground">{t('common.rowsPerPage', 'Rows per page')}</span>
+                    <Select
+                      value={String(txPerPage)}
+                      onValueChange={(val) => {
+                        const nextLimit = Number(val)
+                        setTxPerPage(nextLimit)
+                        setTxPage(1)
+                        try {
+                          localStorage.setItem('securo.dashboard.pageSize', String(nextLimit))
+                        } catch {
+                          // ignored
+                        }
+                      }}
+                    >
+                      <SelectTrigger className="w-[70px] h-8 text-xs">
+                        <SelectValue placeholder={txPerPage} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="10">10</SelectItem>
+                        <SelectItem value="20">20</SelectItem>
+                        <SelectItem value="50">50</SelectItem>
+                        <SelectItem value="100">100</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
                 </div>
               )}
             </>

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -20,6 +20,13 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
   Table,
   TableBody,
   TableCell,
@@ -85,6 +92,14 @@ export default function TransactionsPage() {
   const userCurrency = user?.preferences?.currency_display ?? 'USD'
   const queryClient = useQueryClient()
   const [page, setPage] = useState(1)
+  const [limit, setLimit] = useState<number>(() => {
+    try {
+      const stored = localStorage.getItem('securo.transactions.pageSize')
+      return stored ? Number(stored) : 20
+    } catch {
+      return 20
+    }
+  })
   const [filterAccountIds, setFilterAccountIds] = useState<string[]>([])
   const [filterCategoryIds, setFilterCategoryIds] = useState<string[]>(() => {
     const initial = searchParams.get('category_id')
@@ -316,12 +331,12 @@ export default function TransactionsPage() {
     && activeAccountIds !== null && activeAccountIds.length === 0
 
   const { data, isLoading } = useQuery({
-    queryKey: ['transactions', page, effectiveAccountIds, filterCategoryIds, filterUncategorized, filterPayee, filterGroupId, filterType, filterFrom, filterTo, filterMinAmount, filterMaxAmount, searchQuery, tagFilters, grid.sortBy, grid.sortDir],
+    queryKey: ['transactions', page, limit, effectiveAccountIds, filterCategoryIds, filterUncategorized, filterPayee, filterGroupId, filterType, filterFrom, filterTo, filterMinAmount, filterMaxAmount, searchQuery, tagFilters, grid.sortBy, grid.sortDir],
     enabled: !noAccounts,
     queryFn: () =>
       transactions.list({
         page,
-        limit: 20,
+        limit,
         account_ids: effectiveAccountIds.length > 0 ? effectiveAccountIds : undefined,
         category_ids: filterCategoryIds.length > 0 ? filterCategoryIds : undefined,
         payee_id: filterPayee || undefined,
@@ -358,6 +373,7 @@ export default function TransactionsPage() {
     sort_by: grid.sortBy,
     sort_dir: grid.sortDir,
     page,
+    limit,
   }
   const ctxKey = JSON.stringify(ctxFilters) + ':' + (data?.total ?? '')
   useRegisterPageChatContext(
@@ -365,7 +381,7 @@ export default function TransactionsPage() {
       path: '/transactions',
       label: 'Transactions',
       summary: data?.total != null
-        ? `${data.total} transaction(s) match the active filters (showing page ${page}, 20 per page).`
+        ? `${data.total} transaction(s) match the active filters (showing page ${page}, ${limit} per page).`
         : 'Transactions list with active filters.',
       filters: ctxFilters,
     },
@@ -699,7 +715,7 @@ export default function TransactionsPage() {
       ? t('transactions.linkTransferInvalidPair')
       : undefined
 
-  const totalPages = data ? Math.ceil(data.total / 20) : 0
+  const totalPages = data ? Math.ceil(data.total / limit) : 0
 
   const isTransferCategoryPromptOpen = !!pendingTransferCategoryUpdate
 
@@ -1410,27 +1426,61 @@ export default function TransactionsPage() {
       </div>
 
       {/* Pagination */}
-      {totalPages > 1 && (
-        <div className={`flex items-center justify-center gap-2 ${selectedIds.size > 0 ? 'pb-16' : ''}`}>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={page <= 1}
-            onClick={() => setPage(page - 1)}
-          >
-            {t('transactions.previous')}
-          </Button>
-          <span className="text-sm text-muted-foreground">
-            {page} / {totalPages}
-          </span>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={page >= totalPages}
-            onClick={() => setPage(page + 1)}
-          >
-            {t('transactions.next')}
-          </Button>
+      {data && data.total > 10 && (
+        <div className={`flex flex-col sm:flex-row items-center justify-between gap-4 py-4 ${selectedIds.size > 0 ? 'pb-20' : ''}`}>
+          <div className="hidden sm:block w-32" />
+          {totalPages > 1 ? (
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage(page - 1)}
+              >
+                {t('transactions.previous')}
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {page} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage(page + 1)}
+              >
+                {t('transactions.next')}
+              </Button>
+            </div>
+          ) : (
+            <div className="hidden sm:block" />
+          )}
+
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">{t('common.rowsPerPage', 'Rows per page')}</span>
+            <Select
+              value={String(limit)}
+              onValueChange={(val) => {
+                const nextLimit = Number(val)
+                setLimit(nextLimit)
+                setPage(1)
+                try {
+                  localStorage.setItem('securo.transactions.pageSize', String(nextLimit))
+                } catch {
+                  // ignored
+                }
+              }}
+            >
+              <SelectTrigger className="w-[70px] h-8 text-xs">
+                <SelectValue placeholder={limit} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="10">10</SelectItem>
+                <SelectItem value="20">20</SelectItem>
+                <SelectItem value="50">50</SelectItem>
+                <SelectItem value="100">100</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## What

- Replaced hardcoded default limit values for pagination across paginated tables with dynamic limit states.
- Implemented configurable "Rows per page" selectors for the Transactions page, Dashboard period transactions card, and the Import Review table.
- Added states loading from and persisting to `localStorage` for page size configuration (keying by transactions, dashboard, and import lists respectively).
- Updated translations for `"rowsPerPage"` in all locales: German, English, Spanish, Italian, Polish, Portuguese, Russian, Ukrainian.

## Why

Allow users to select how many elements they want to display per page (10, 20, 50, or 100) to give them a wider view of their transactions, while preserving their layout preference across sessions.


## Screnshoots

https://github.com/user-attachments/assets/77f8e875-fac0-4f53-af2c-1b0d6c5d3de6


## How to Test

Steps to verify the changes work:

1. Navigate to the **Transactions Page** and check the page size dropdown on the bottom right.
2. Select different page sizes (e.g. 50 or 100) and verify that the items per page dynamically updates and the pagination pages count is re-calculated.
3. Reload or navigate away and back, and verify the chosen page size persists.
4. Verify the same on the **Dashboard** period transactions list and the **Import Review** table.

## Related Issue

N/A

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
- [x] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))
