### PR TITLE
feat: support reading config secrets from file-based sources

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,15 @@
 from functools import lru_cache
+from os import getenv
+from pathlib import Path
 from urllib.parse import urlparse
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Use the same environment variable that systemd uses: https://systemd.io/CREDENTIALS/
+# If not defined, defaults to docker secrets defaults (https://docs.docker.com/compose/how-tos/use-secrets/)
+CREDENTIALS_DIRECTORY: list[Path] = [
+    Path(p) for p in getenv("CREDENTIALS_DIRECTORY", "/run/secrets").split(":") if p
+]
 
 
 class Settings(BaseSettings):
@@ -85,7 +93,9 @@ class Settings(BaseSettings):
     # OIDC login (works with Authentik, Pocket ID, and other standard OIDC providers)
     oidc_enabled: bool = False
     oidc_provider_name: str = "OIDC"
-    oidc_discovery_url: str = ""  # e.g. https://auth.example.com/application/o/securo/.well-known/openid-configuration
+    oidc_discovery_url: str = (
+        ""  # e.g. https://auth.example.com/application/o/securo/.well-known/openid-configuration
+    )
     oidc_client_id: str = ""
     oidc_client_secret: str = ""
     oidc_redirect_uri: str = ""  # defaults to {FRONTEND_URL}/api/auth/oidc/callback
@@ -115,7 +125,7 @@ class Settings(BaseSettings):
     # external dependency on the Brazilian government endpoint).
     tesouro_direto_enabled: bool = True
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", secrets_dir=CREDENTIALS_DIRECTORY)
 
 
 @lru_cache

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "alembic>=1.13.0",
     "asyncpg>=0.29.0",
     "pydantic>=2.5.0",
-    "pydantic-settings>=2.1.0",
+    "pydantic-settings>=2.5.0",
     "python-jose[cryptography]>=3.3.0",
     "cryptography==46.0.7",
     "passlib[bcrypt]>=1.7.4",

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+import pytest
+
+from app.core.config import Settings
+
+
+def write(dir: Path, name: str, value: str) -> None:
+    (dir / name).write_text(value)
+
+
+@pytest.fixture
+def secrets(tmp_path: Path):
+    d = tmp_path / "secrets"
+    d.mkdir()
+    return d
+
+
+def test_oidc_secret_reads_from_secrets_dir(secrets: Path):
+    write(secrets, "oidc_client_secret", "file-secret")
+
+    settings = Settings(_secrets_dir=str(secrets))
+    assert settings.oidc_client_secret == "file-secret"
+
+
+def test_oidc_secret_strips_whitespace(secrets: Path):
+    write(secrets, "oidc_client_secret", "  stripped-value  \n\n")
+
+    settings = Settings(_secrets_dir=str(secrets))
+    assert settings.oidc_client_secret == "stripped-value"
+
+
+def test_oidc_secret_inline_when_no_file(secrets: Path):
+    settings = Settings(
+        oidc_client_secret="inline-secret",
+        _secrets_dir=str(secrets),
+    )
+
+    assert settings.oidc_client_secret == "inline-secret"
+
+
+def test_oidc_secret_default_when_no_file(secrets: Path):
+    settings = Settings(_secrets_dir=str(secrets))
+
+    assert settings.oidc_client_secret == ""
+
+
+def test_multiple_secrets_dirs_merge(tmp_path: Path):
+    d1, d2 = tmp_path / "d1", tmp_path / "d2"
+    d1.mkdir()
+    d2.mkdir()
+
+    secrets = {
+        d1: {
+            "oidc_client_secret": "from-d1",
+            "oidc_provider_name": "Provider D1",
+        },
+        d2: {
+            "oidc_client_secret": "from-d2",
+            "oidc_client_id": "from-d2",
+        },
+    }
+    for directory, values in secrets.items():
+        for name, value in values.items():
+            write(directory, name, value)
+
+    expectedSecrets = {**secrets[d1], **secrets[d2]}
+    settings = Settings(_secrets_dir=[str(d1), str(d2)])
+
+    for key, expectedValue in expectedSecrets.items():
+        assert getattr(settings, key) == expectedValue


### PR DESCRIPTION
## What

Use pydantic-settings' built-in secrets_dir support to load sensitive configuration values from flat files, in addition to (or instead of) environment variables. Multiple secret directories are supported and are processed in order, with the last matching file taking precedence.

This enables configuration of  `oidc_client_secret` and any future secrets from file-based sources, such as Docker Secrets, systemd, or other environments where storing secrets in files is preferred.

## Why

At the moment, `oidc_client_secret`  can only be configured through an environment variable. In my deployment (using systemd), I'd rather avoid exposing sensitive credentials in plaintext environment variables.

Using secrets_dir provides a standard mechanism for managing secrets and reduces the need for custom configuration logic as additional secrets are introduced. It also aligns well with existing use cases, such as enable_banking_private_key_file.

If this approach looks good, I can follow up with a refactor of `enable_banking_private_key_file` to use the same `enable_banking_private_key` setting via secrets_dir, removing the need for a separate _file configuration option.

## How to Test

I've created a new set of tests in `backend/tests/test_config.py` with multiple scenarios.

Manual tests:

1. Create a temporary file that contains the `DATABASE_URL` value: `echo "postgresql+asyncpg://postgres:postgres@db:5432/securo" > /tmp/a`

2.  Apply the following patch to the `docker-compose.yml` file.

```
diff --git a/docker-compose.yml b/docker-compose.yml
index 398fb36c33..29d75198e8 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@
   in_pod: false

 x-backend-env: &backend-env
-  DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/securo
+  #DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/securo
   SECRET_KEY: ${SECRET_KEY:-dev-secret-change-in-production}
   DEBUG: ${DEBUG:-true}
   FRONTEND_URL: http://localhost:${FRONTEND_PORT:-3000}
@@ -77,6 +77,8 @@
     - agent_knowledge:/app/data/agent_knowledge
     - agent_embedding_models:/app/data/embedding_models
   restart: unless-stopped
+  secrets:
+    - database_url

 services:
   redis:
@@ -157,6 +159,10 @@
     ports:
       - "${AGENTS_MCP_EXTERNAL_HOST_PORT:-127.0.0.1:8765}:8765"

+secrets:
+  database_url:
+    file: /tmp/a
+
 volumes:
   pgdata:
   attachments:
```

3. Run docker-compose again with `docker compose up`

4. Everything should be working as expected; confirm that the change is working by making an invalid secret (e.g. `echo "postgresql+asyncpg://postgres:postgres@db:5432/secu" > /tmp/a``)

5. Run again, and the backend service must fail.

## Related Issue

Closes #___ (or link the issue this addresses).

## Checklist

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
- [ ] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))