### PR TITLE
fix: correct date sort toggle on transactions page (#383)

### DIFF
--- a/frontend/src/components/transactions-grid-columns.tsx
+++ b/frontend/src/components/transactions-grid-columns.tsx
@@ -173,10 +173,14 @@ export function useTransactionsGridState(): TransactionsGridState {
   const toggleSort = useCallback((id: ColumnId) => {
     const def = COL_BY_ID[id]
     if (!def || !def.sortable) return
+    // Two-state toggle: first click on a column sorts descending, then every
+    // subsequent click flips the direction. We intentionally never cycle back
+    // to an unsorted state: the backend's implicit default is date-descending,
+    // so a "cleared" sort was visually identical to date-desc and made the
+    // header look like it toggled between the same two orders (issue #383).
     setSort(prev => {
       if (prev.by !== id) return { by: id, dir: 'desc' }
-      if (prev.dir === 'desc') return { by: id, dir: 'asc' }
-      return { by: null, dir: 'desc' }
+      return { by: id, dir: prev.dir === 'desc' ? 'asc' : 'desc' }
     })
   }, [])
 


### PR DESCRIPTION
## What

Fixes the transactions table sort toggle, which appeared to "stop working" after a couple of clicks on a column header (#383).

## Why

The sort used a three-state cycle: `desc → asc → none`. In the `none` state no sort param is sent, so the backend falls back to its implicit default of **date-descending** — visually identical to the explicit `desc` state on the Date column. Clicking the header therefore looked like it repeated the same order and toggling seemed broken.

## Change

Make it a two-state toggle (`desc ↔ asc`): every click flips the direction and produces a distinct, correct result. First click on a new column still defaults to descending.

## Verification

Logged in, applied the Expense filter, and clicked the Date header repeatedly:
- Click 1 → `sort_dir=desc` (newest first)
- Click 2 → `sort_dir=asc` (oldest first, ↑ indicator)
- Click 3 → back to `desc` (newest first, ↓ indicator) — served instantly from cache, results still update correctly

Every click now toggles the order and updates the list.