### PR TITLE
fix: make external MCP server URL configurable (#384)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,8 @@ ENABLE_BANKING_OAUTH_REDIRECT_URI=http://localhost:${FRONTEND_PORT:-3000}/oauth/
 #   2) COMPOSE_PROFILES so `docker compose up` starts the mcp-server container
 # AGENTS_ENABLED=true
 # COMPOSE_PROFILES=agents
+# Public URL external agents use to reach the built-in MCP server, shown in the
+# UI token panel. Leave unset to derive it from the browser (host:8765). Set it
+# when the MCP server is exposed behind an ingress/reverse proxy on a custom
+# host, subpath, or standard 80/443 port instead of :8765.
+# AGENTS_EXTERNAL_MCP_URL=https://securo.example.com/mcp

--- a/backend/app/agents/api/info.py
+++ b/backend/app/agents/api/info.py
@@ -19,4 +19,6 @@ async def get_agents_info():
         "default_similarity_threshold": s.default_similarity_threshold,
         "extra_mcp_servers_configured": bool(s.extra_mcp_servers.strip()),
         "mcp_external_ttl_days": s.mcp_external_ttl_days,
+        # Empty string means "let the frontend derive it from window.location".
+        "external_mcp_url": s.external_mcp_url.strip(),
     }

--- a/backend/app/agents/config.py
+++ b/backend/app/agents/config.py
@@ -9,7 +9,16 @@ class AgentSettings(BaseSettings):
     enabled: bool = False
 
     # Built-in MCP server URL. The mcp-server container speaks JSON-RPC 2.0.
+    # This is the internal address the backend uses to reach the container.
     builtin_mcp_url: str = "http://mcp-server:8765/mcp"
+
+    # Public URL external agents use to reach the built-in MCP server, shown
+    # in the UI token panel. Leave blank to have the frontend derive it from
+    # the browser location (``<protocol>//<hostname>:8765/mcp``). Set this
+    # when the MCP server is exposed behind an ingress/reverse proxy on a
+    # custom host, subpath, or standard 80/443 port instead of ``:8765``.
+    # Example: "https://securo.example.com/mcp".
+    external_mcp_url: str = ""
 
     # Comma-separated extra MCP servers users can plug in (URL[|name]).
     # Example: "http://my-tools:9000/mcp|my-tools,http://other:9001/mcp"

--- a/backend/tests/test_agents_api.py
+++ b/backend/tests/test_agents_api.py
@@ -84,6 +84,31 @@ async def test_agents_info_exposes_mcp_external_ttl(client: AsyncClient, auth_he
     assert body["mcp_external_ttl_days"] >= 1
 
 
+async def test_agents_info_exposes_external_mcp_url(client: AsyncClient, auth_headers: dict):
+    """The frontend uses external_mcp_url (empty by default) so deployments
+    behind an ingress can override the hardcoded :8765 endpoint."""
+    r = await client.get("/api/agents/info", headers=auth_headers)
+    body = r.json()
+    assert "external_mcp_url" in body
+    assert isinstance(body["external_mcp_url"], str)
+
+
+async def test_agents_info_returns_configured_external_mcp_url(
+    client: AsyncClient, auth_headers: dict, monkeypatch
+):
+    """When AGENTS_EXTERNAL_MCP_URL is set, it is surfaced verbatim (trimmed)."""
+    from app.agents import config
+
+    config.get_agent_settings.cache_clear()
+    monkeypatch.setenv("AGENTS_EXTERNAL_MCP_URL", "  https://securo.example.com/mcp  ")
+    try:
+        r = await client.get("/api/agents/info", headers=auth_headers)
+        assert r.json()["external_mcp_url"] == "https://securo.example.com/mcp"
+    finally:
+        monkeypatch.delenv("AGENTS_EXTERNAL_MCP_URL", raising=False)
+        config.get_agent_settings.cache_clear()
+
+
 # --- External MCP tokens ---------------------------------------------------
 
 async def test_mcp_tokens_requires_auth(client: AsyncClient):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,10 @@ x-backend-env: &backend-env
   # zero cost. Run `docker compose --profile agents up` after enabling.
   AGENTS_ENABLED: ${AGENTS_ENABLED:-false}
   AGENTS_BUILTIN_MCP_URL: ${AGENTS_BUILTIN_MCP_URL:-http://mcp-server:8765/mcp}
+  # Public URL external agents use to reach the built-in MCP server, shown in
+  # the "External MCP access" panel. Blank → the UI derives it from the browser
+  # (host:8765). Set when the MCP server sits behind an ingress/reverse proxy.
+  AGENTS_EXTERNAL_MCP_URL: ${AGENTS_EXTERNAL_MCP_URL:-}
   AGENTS_EXTRA_MCP_SERVERS: ${AGENTS_EXTRA_MCP_SERVERS:-}
   AGENTS_MCP_JWT_SECRET: ${AGENTS_MCP_JWT_SECRET:-dev-mcp-secret-change-in-production}
   # TTL for tokens minted from /agents/connections → "External MCP access".

--- a/frontend/src/components/agents/mcp-external-panel.tsx
+++ b/frontend/src/components/agents/mcp-external-panel.tsx
@@ -94,7 +94,13 @@ export function McpExternalPanel() {
 
   if (!info) return null
 
-  const url = `${window.location.protocol}//${window.location.hostname}:8765/mcp`
+  // Prefer the backend-configured URL (AGENTS_EXTERNAL_MCP_URL) so deployments
+  // behind an ingress/reverse proxy can point at a custom host/subpath/port.
+  // Fall back to the direct :8765 endpoint derived from the browser location,
+  // which matches the default Docker Compose setup.
+  const url =
+    info.external_mcp_url ||
+    `${window.location.protocol}//${window.location.hostname}:8765/mcp`
 
   // The first three snippets are universal regardless of client choice.
   const universalSnippets: Snippet[] = result

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1382,6 +1382,7 @@ export const agents = {
       default_similarity_threshold: number
       extra_mcp_servers_configured: boolean
       mcp_external_ttl_days: number
+      external_mcp_url: string
     }
   },
   mcpTokens: {


### PR DESCRIPTION
Fixes #384.

## Problem
The "External MCP access" panel hardcoded the endpoint to `<hostname>:8765/mcp`. Behind an ingress / reverse proxy (Kubernetes, Caddy/Nginx) where port `8765` isn't publicly exposed, external clients fail to connect.

## Change
- New `AGENTS_EXTERNAL_MCP_URL` setting (blank by default), surfaced through `/agents/info`.
- The UI prefers it when set, and falls back to the browser-derived `:8765` endpoint when blank — so the default Docker Compose behavior is unchanged.
- Wired the var through `docker-compose.yml` and documented it in `.env.example`.

## Verification
- Backend: added tests for the new `info` field (default empty + configured/trimmed). Full `test_agents_api.py` passes (22).
- Visual: drove Chrome against the running stack. With the var unset the panel shows `http://127.0.0.1:8765/mcp` (unchanged); with `AGENTS_EXTERNAL_MCP_URL=https://securo.example.com/mcp` the endpoint, curl example, and client-config snippets all resolve to the ingress URL.