### PR TITLE
feat(frontend): extract GroupForm and MemberForm, enable inline group/member creation on bulk assign

### DIFF
--- a/frontend/src/components/bulk-add-to-group-dialog.tsx
+++ b/frontend/src/components/bulk-add-to-group-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
@@ -52,7 +52,6 @@ export function BulkAddToGroupDialog({
             mounts fresh on every open and unmounts on close — no
             reset effects needed. */}
         <BulkAddToGroupForm
-          open={open}
           selectedCount={selectedCount}
           onCancel={onClose}
           onSubmit={onSubmit}
@@ -64,13 +63,11 @@ export function BulkAddToGroupDialog({
 }
 
 function BulkAddToGroupForm({
-  open,
   selectedCount,
   onCancel,
   onSubmit,
   isPending,
 }: {
-  open: boolean
   selectedCount: number
   onCancel: () => void
   onSubmit: (payload: BulkAddToGroupSubmission) => void
@@ -103,24 +100,6 @@ function BulkAddToGroupForm({
   // the map use defaults (selected, empty percent) so we don't need an
   // effect to seed the rows when the group query resolves.
   const [selectionByMember, setSelectionByMember] = useState<Record<string, MemberSelection>>({})
-
-  // Reset form states when modal is closed
-  useEffect(() => {
-    if (!open) {
-      setIsCreatingGroup(false)
-      setNewGroupName('')
-      setNewGroupKind('social')
-      setNewGroupCurrency(userCurrency)
-      setNewGroupNotes('')
-      setIsAddingMember(false)
-      setNewMemberName('')
-      setNewMemberEmail('')
-      setNewMemberLinkedUserId(null)
-      setExplicitGroupId(null)
-      setShareType('equal')
-      setSelectionByMember({})
-    }
-  }, [open, userCurrency])
 
   const { data: groups } = useQuery({
     queryKey: ['groups'],

--- a/frontend/src/components/bulk-add-to-group-dialog.tsx
+++ b/frontend/src/components/bulk-add-to-group-dialog.tsx
@@ -1,8 +1,10 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 
-import { groups as groupsApi } from '@/lib/api'
+import { groups as groupsApi, type GroupCreatePayload } from '@/lib/api'
+import { useAuth } from '@/contexts/auth-context'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -13,6 +15,9 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import type { GroupKind } from '@/types'
+import { GroupForm } from '@/components/group-form'
+import { MemberForm } from '@/components/member-form'
 
 type BulkShareType = 'equal' | 'percent'
 
@@ -47,6 +52,7 @@ export function BulkAddToGroupDialog({
             mounts fresh on every open and unmounts on close — no
             reset effects needed. */}
         <BulkAddToGroupForm
+          open={open}
           selectedCount={selectedCount}
           onCancel={onClose}
           onSubmit={onSubmit}
@@ -58,17 +64,36 @@ export function BulkAddToGroupDialog({
 }
 
 function BulkAddToGroupForm({
+  open,
   selectedCount,
   onCancel,
   onSubmit,
   isPending,
 }: {
+  open: boolean
   selectedCount: number
   onCancel: () => void
   onSubmit: (payload: BulkAddToGroupSubmission) => void
   isPending: boolean
 }) {
   const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const { user } = useAuth()
+  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+
+  // Track group creation state and fields
+  const [isCreatingGroup, setIsCreatingGroup] = useState(false)
+  const [newGroupName, setNewGroupName] = useState('')
+  const [newGroupKind, setNewGroupKind] = useState<GroupKind>('social')
+  const [newGroupCurrency, setNewGroupCurrency] = useState(userCurrency)
+  const [newGroupNotes, setNewGroupNotes] = useState('')
+
+  // Track member creation state and fields
+  const [isAddingMember, setIsAddingMember] = useState(false)
+  const [newMemberName, setNewMemberName] = useState('')
+  const [newMemberEmail, setNewMemberEmail] = useState('')
+  const [newMemberLinkedUserId, setNewMemberLinkedUserId] = useState<string | null>(null)
+
   // Track only the user's explicit group choice — the effective `groupId`
   // is derived below so we don't need an effect to "auto-pick" the first
   // group when data arrives.
@@ -78,6 +103,24 @@ function BulkAddToGroupForm({
   // the map use defaults (selected, empty percent) so we don't need an
   // effect to seed the rows when the group query resolves.
   const [selectionByMember, setSelectionByMember] = useState<Record<string, MemberSelection>>({})
+
+  // Reset form states when modal is closed
+  useEffect(() => {
+    if (!open) {
+      setIsCreatingGroup(false)
+      setNewGroupName('')
+      setNewGroupKind('social')
+      setNewGroupCurrency(userCurrency)
+      setNewGroupNotes('')
+      setIsAddingMember(false)
+      setNewMemberName('')
+      setNewMemberEmail('')
+      setNewMemberLinkedUserId(null)
+      setExplicitGroupId(null)
+      setShareType('equal')
+      setSelectionByMember({})
+    }
+  }, [open, userCurrency])
 
   const { data: groups } = useQuery({
     queryKey: ['groups'],
@@ -89,13 +132,61 @@ function BulkAddToGroupForm({
     [groups],
   )
 
+  const createGroupMutation = useMutation({
+    mutationFn: (payload: GroupCreatePayload) => groupsApi.create(payload),
+    onSuccess: (newGroup) => {
+      queryClient.invalidateQueries({ queryKey: ['groups'] })
+      setExplicitGroupId(newGroup.id)
+      setIsCreatingGroup(false)
+      setNewGroupName('')
+      setNewGroupNotes('')
+      toast.success(t('splitGroups.created'))
+    },
+    onError: () => toast.error(t('common.error')),
+  })
+
+  const handleCreateGroup = () => {
+    if (!newGroupName.trim()) return
+    createGroupMutation.mutate({
+      name: newGroupName.trim(),
+      kind: newGroupKind,
+      default_currency: newGroupCurrency,
+      notes: newGroupNotes.trim() || null,
+    })
+  }
+
+  const showCreateGroupForm = isCreatingGroup
+  const showCreateMemberForm = isAddingMember
   const groupId = explicitGroupId ?? ownedGroups[0]?.id ?? ''
 
   const { data: group } = useQuery({
     queryKey: ['groups', groupId],
     queryFn: () => groupsApi.get(groupId),
-    enabled: !!groupId,
+    enabled: !!groupId && !showCreateGroupForm && !showCreateMemberForm,
   })
+
+  const createMemberMutation = useMutation({
+    mutationFn: (payload: { name: string; email?: string | null; linked_user_id?: string | null }) =>
+      groupsApi.members.create(groupId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['groups', groupId] })
+      setIsAddingMember(false)
+      setNewMemberName('')
+      setNewMemberEmail('')
+      setNewMemberLinkedUserId(null)
+      toast.success(t('splitGroups.memberAdded'))
+    },
+    onError: () => toast.error(t('common.error')),
+  })
+
+  const handleCreateMember = () => {
+    if (!newMemberName.trim()) return
+    createMemberMutation.mutate({
+      name: newMemberName.trim(),
+      email: newMemberEmail.trim() || null,
+      linked_user_id: newMemberLinkedUserId,
+    })
+  }
 
   const rows = useMemo(
     () =>
@@ -153,19 +244,79 @@ function BulkAddToGroupForm({
     <>
       <DialogHeader>
         <DialogTitle>
-          {t('transactions.bulkAddToGroupTitle', { count: selectedCount })}
+          {showCreateGroupForm
+            ? t('splitGroups.add')
+            : showCreateMemberForm
+              ? t('splitGroups.addMember')
+              : t('transactions.bulkAddToGroupTitle', { count: selectedCount })}
         </DialogTitle>
       </DialogHeader>
 
-      {ownedGroups.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-2">
-          {t('splitGroups.splitNoGroups')}
-        </p>
+      {showCreateGroupForm ? (
+        <div className="space-y-4 py-2">
+          <GroupForm
+            name={newGroupName}
+            onChangeName={setNewGroupName}
+            kind={newGroupKind}
+            onChangeKind={setNewGroupKind}
+            defaultCurrency={newGroupCurrency}
+            onChangeDefaultCurrency={setNewGroupCurrency}
+            notes={newGroupNotes}
+            onChangeNotes={setNewGroupNotes}
+          />
+        </div>
+      ) : showCreateMemberForm ? (
+        <div className="space-y-4 py-2">
+          <MemberForm
+            name={newMemberName}
+            onChangeName={setNewMemberName}
+            email={newMemberEmail}
+            onChangeEmail={setNewMemberEmail}
+            linkedUserId={newMemberLinkedUserId}
+            onChangeLinkedUserId={setNewMemberLinkedUserId}
+          />
+        </div>
+      ) : ownedGroups.length === 0 ? (
+        <div className="space-y-2 py-4">
+          <p className="text-sm text-muted-foreground font-semibold">
+            {t('splitGroups.splitNoGroups')}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {t('splitGroups.splitNoGroupsLinkPrefix')}
+            <button
+              type="button"
+              onClick={() => {
+                setIsCreatingGroup(true)
+                setNewGroupName('')
+                setNewGroupCurrency(userCurrency)
+                setNewGroupNotes('')
+              }}
+              className="text-primary hover:underline font-semibold"
+            >
+              {t('splitGroups.splitNoGroupsLinkSuffix')}
+            </button>
+            .
+          </p>
+        </div>
       ) : (
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1">
-              <Label className="text-xs">{t('splitGroups.group')}</Label>
+              <div className="flex items-center justify-between">
+                <Label className="text-xs">{t('splitGroups.group')}</Label>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsCreatingGroup(true)
+                    setNewGroupName('')
+                    setNewGroupCurrency(userCurrency)
+                    setNewGroupNotes('')
+                  }}
+                  className="text-xs text-primary hover:underline font-medium"
+                >
+                  + {t('splitGroups.add')}
+                </button>
+              </div>
               <select
                 className="w-full border border-border rounded-md px-2 py-1.5 text-sm bg-background"
                 value={groupId}
@@ -193,12 +344,43 @@ function BulkAddToGroupForm({
             {t('transactions.bulkAddToGroupExactHint')}
           </p>
 
+          <div className="flex items-center justify-between border-t border-border pt-3">
+            <Label className="text-xs">{t('splitGroups.members')}</Label>
+            <button
+              type="button"
+              onClick={() => {
+                setIsAddingMember(true)
+                setNewMemberName('')
+                setNewMemberEmail('')
+                setNewMemberLinkedUserId(null)
+              }}
+              className="text-xs text-primary hover:underline font-medium"
+            >
+              + {t('splitGroups.addMember')}
+            </button>
+          </div>
+
           {group && (
             <div className="space-y-2 max-h-64 overflow-y-auto pr-1">
               {group.members.length === 0 ? (
-                <p className="text-xs text-muted-foreground">
-                  {t('splitGroups.splitNoMembers')}
-                </p>
+                <div className="py-4 text-center">
+                  <p className="text-sm text-muted-foreground mb-3">
+                    {t('splitGroups.splitNoMembers')}
+                  </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setIsAddingMember(true)
+                      setNewMemberName('')
+                      setNewMemberEmail('')
+                      setNewMemberLinkedUserId(null)
+                    }}
+                  >
+                    + {t('splitGroups.addMember')}
+                  </Button>
+                </div>
               ) : (
                 group.members.map((m) => {
                   const row = rows.find((r) => r.member_id === m.id)
@@ -263,15 +445,43 @@ function BulkAddToGroupForm({
       )}
 
       <DialogFooter>
-        <Button variant="ghost" onClick={onCancel} disabled={isPending}>
-          {t('common.cancel', 'Cancel')}
-        </Button>
-        <Button
-          onClick={handleSubmit}
-          disabled={!isValid || isPending || ownedGroups.length === 0}
-        >
-          {t('transactions.bulkAddToGroupSubmit')}
-        </Button>
+        {showCreateGroupForm ? (
+          <>
+            <Button variant="ghost" onClick={() => setIsCreatingGroup(false)} disabled={createGroupMutation.isPending}>
+              {t('common.cancel', 'Cancel')}
+            </Button>
+            <Button
+              onClick={handleCreateGroup}
+              disabled={!newGroupName.trim() || createGroupMutation.isPending}
+            >
+              {createGroupMutation.isPending ? t('common.saving') : t('splitGroups.add')}
+            </Button>
+          </>
+        ) : showCreateMemberForm ? (
+          <>
+            <Button variant="ghost" onClick={() => setIsAddingMember(false)} disabled={createMemberMutation.isPending}>
+              {t('common.cancel', 'Cancel')}
+            </Button>
+            <Button
+              onClick={handleCreateMember}
+              disabled={!newMemberName.trim() || createMemberMutation.isPending}
+            >
+              {createMemberMutation.isPending ? t('common.saving') : t('common.save')}
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button variant="ghost" onClick={onCancel} disabled={isPending}>
+              {t('common.cancel', 'Cancel')}
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={!isValid || isPending || ownedGroups.length === 0}
+            >
+              {t('transactions.bulkAddToGroupSubmit')}
+            </Button>
+          </>
+        )}
       </DialogFooter>
     </>
   )

--- a/frontend/src/components/group-form.tsx
+++ b/frontend/src/components/group-form.tsx
@@ -1,0 +1,96 @@
+import { useTranslation } from 'react-i18next'
+import { useQuery } from '@tanstack/react-query'
+import { currencies as currenciesApi } from '@/lib/api'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import type { GroupKind } from '@/types'
+
+export const KIND_OPTIONS: { value: GroupKind; tKey: string }[] = [
+  { value: 'social', tKey: 'splitGroups.kind.social' },
+  { value: 'cost_center', tKey: 'splitGroups.kind.cost_center' },
+  { value: 'project', tKey: 'splitGroups.kind.project' },
+  { value: 'client', tKey: 'splitGroups.kind.client' },
+  { value: 'other', tKey: 'splitGroups.kind.other' },
+]
+
+interface GroupFormProps {
+  name: string
+  onChangeName: (value: string) => void
+  kind: GroupKind
+  onChangeKind: (value: GroupKind) => void
+  defaultCurrency: string
+  onChangeDefaultCurrency: (value: string) => void
+  notes: string
+  onChangeNotes: (value: string) => void
+}
+
+export function GroupForm({
+  name,
+  onChangeName,
+  kind,
+  onChangeKind,
+  defaultCurrency,
+  onChangeDefaultCurrency,
+  notes,
+  onChangeNotes,
+}: GroupFormProps) {
+  const { t } = useTranslation()
+
+  const { data: supportedCurrencies } = useQuery({
+    queryKey: ['currencies'],
+    queryFn: currenciesApi.list,
+    staleTime: Infinity,
+  })
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label>{t('splitGroups.name')}</Label>
+        <Input
+          placeholder={t('splitGroups.name')}
+          value={name}
+          onChange={(e) => onChangeName(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>{t('splitGroups.kindLabel')}</Label>
+        <select
+          className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background h-9 focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
+          value={kind}
+          onChange={(e) => onChangeKind(e.target.value as GroupKind)}
+        >
+          {KIND_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {t(opt.tKey)}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-muted-foreground">{t('splitGroups.kindHint')}</p>
+      </div>
+      <div className="space-y-2">
+        <Label>{t('splitGroups.defaultCurrency')}</Label>
+        <select
+          className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background h-9 focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
+          value={defaultCurrency}
+          onChange={(e) => onChangeDefaultCurrency(e.target.value)}
+        >
+          {(supportedCurrencies ?? [
+            { code: defaultCurrency, symbol: defaultCurrency, name: defaultCurrency, flag: '' },
+          ]).map((c) => (
+            <option key={c.code} value={c.code}>
+              {c.flag} {c.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-2">
+        <Label>{t('splitGroups.notes')}</Label>
+        <textarea
+          className="w-full border border-input rounded-md px-3 py-2 text-sm bg-background resize-none h-20"
+          value={notes}
+          onChange={(e) => onChangeNotes(e.target.value)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/member-form.tsx
+++ b/frontend/src/components/member-form.tsx
@@ -1,0 +1,113 @@
+import { useTranslation } from 'react-i18next'
+import { useQuery } from '@tanstack/react-query'
+import { Link2 } from 'lucide-react'
+import { users as usersApi } from '@/lib/api'
+import { useAuth } from '@/contexts/auth-context'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+interface MemberFormProps {
+  name: string
+  onChangeName: (value: string) => void
+  email: string
+  onChangeEmail: (value: string) => void
+  linkedUserId: string | null
+  onChangeLinkedUserId: (value: string | null) => void
+}
+
+export function MemberForm({
+  name,
+  onChangeName,
+  email,
+  onChangeEmail,
+  linkedUserId,
+  onChangeLinkedUserId,
+}: MemberFormProps) {
+  const { t } = useTranslation()
+  const { user } = useAuth()
+
+  // Directory of all Securo users on the instance
+  const { data: userDirectory } = useQuery({
+    queryKey: ['users', 'directory'],
+    queryFn: () => usersApi.directory(),
+    staleTime: 60_000,
+  })
+
+  // Resolve a typed email to an existing Securo user
+  const trimmedEmail = email.trim()
+  const { data: lookupResult } = useQuery({
+    queryKey: ['users', 'lookup', trimmedEmail.toLowerCase()],
+    queryFn: () => usersApi.lookupByEmail(trimmedEmail),
+    enabled: trimmedEmail.length >= 3 && trimmedEmail.includes('@'),
+    staleTime: 60_000,
+    retry: false,
+  })
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label>{t('splitGroups.linkedUser')}</Label>
+        <select
+          className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background h-9 focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
+          value={linkedUserId ?? ''}
+          onChange={(e) => {
+            const id = e.target.value || null
+            onChangeLinkedUserId(id)
+            if (id) {
+              const picked = userDirectory?.find((u) => u.id === id)
+              if (picked) {
+                onChangeEmail(picked.email)
+                onChangeName(picked.email.split('@')[0])
+              }
+            }
+          }}
+        >
+          <option value="">{t('splitGroups.linkedUserNone')}</option>
+          {(userDirectory ?? []).map((u) => (
+            <option key={u.id} value={u.id}>
+              {u.email}
+              {u.id === user?.id ? ` (${t('splitGroups.you')})` : ''}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-muted-foreground">
+          {t('splitGroups.linkedUserHint')}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label>{t('splitGroups.memberName')}</Label>
+        <Input
+          value={name}
+          onChange={(e) => onChangeName(e.target.value)}
+          disabled={linkedUserId !== null}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label>{t('splitGroups.memberEmail')}</Label>
+        <Input
+          type="email"
+          value={email}
+          onChange={(e) => onChangeEmail(e.target.value)}
+          disabled={linkedUserId !== null}
+        />
+        {linkedUserId !== null ? (
+          <p className="text-xs text-emerald-600 inline-flex items-center gap-1">
+            <Link2 size={11} />
+            {t('splitGroups.willLinkToUser', { email })}
+          </p>
+        ) : lookupResult ? (
+          <p className="text-xs text-emerald-600 inline-flex items-center gap-1">
+            <Link2 size={11} />
+            {t('splitGroups.willLinkToUser', { email: lookupResult.email })}
+          </p>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            {t('splitGroups.memberEmailHint')}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1296,6 +1296,8 @@
     "date": "Datum",
     "splitTransaction": "Diese Transaktion aufteilen",
     "splitNoGroups": "Erstelle zuerst eine Gruppe, um eine Transaktion aufzuteilen.",
+    "splitNoGroupsLinkPrefix": "Du hast noch keine Gruppe. Du kannst ",
+    "splitNoGroupsLinkSuffix": "hier eine erstellen",
     "splitNoMembers": "Füge zuerst Mitglieder zur Gruppe hinzu.",
     "group": "Gruppe",
     "shareType": "Aufteilen nach",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1296,6 +1296,8 @@
     "date": "Date",
     "splitTransaction": "Split this transaction",
     "splitNoGroups": "Create a group first to split a transaction.",
+    "splitNoGroupsLinkPrefix": "You don't have a group yet. You can ",
+    "splitNoGroupsLinkSuffix": "create one here",
     "splitNoMembers": "Add members to the group first.",
     "group": "Group",
     "shareType": "Split by",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1296,6 +1296,8 @@
     "date": "Fecha",
     "splitTransaction": "Dividir esta transacción",
     "splitNoGroups": "Crea primero un grupo para dividir una transacción.",
+    "splitNoGroupsLinkPrefix": "Aún no tienes ningún grupo. Puedes ",
+    "splitNoGroupsLinkSuffix": "crear uno aquí",
     "splitNoMembers": "Añade primero miembros al grupo.",
     "group": "Grupo",
     "shareType": "Dividir por",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1296,6 +1296,8 @@
     "date": "Data",
     "splitTransaction": "Dividi questa transazione",
     "splitNoGroups": "Crea prima un gruppo per dividere una transazione.",
+    "splitNoGroupsLinkPrefix": "Non hai ancora un gruppo. Puoi ",
+    "splitNoGroupsLinkSuffix": "crearne uno qui",
     "splitNoMembers": "Aggiungi prima dei membri al gruppo.",
     "group": "Gruppo",
     "shareType": "Dividi per",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -1380,6 +1380,8 @@
     "date": "Data",
     "splitTransaction": "Podziel tę transakcję",
     "splitNoGroups": "Najpierw utwórz grupę, aby podzielić transakcję.",
+    "splitNoGroupsLinkPrefix": "Nie masz jeszcze grupy. Możesz ",
+    "splitNoGroupsLinkSuffix": "utworzyć ją tutaj",
     "splitNoMembers": "Najpierw dodaj członków do grupy.",
     "group": "Grupa",
     "shareType": "Podziel wg",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1296,6 +1296,8 @@
     "date": "Data",
     "splitTransaction": "Dividir esta transação",
     "splitNoGroups": "Crie um grupo antes de dividir uma transação.",
+    "splitNoGroupsLinkPrefix": "Você ainda não tem um grupo. Você pode ",
+    "splitNoGroupsLinkSuffix": "criar um aqui",
     "splitNoMembers": "Adicione membros ao grupo primeiro.",
     "group": "Grupo",
     "shareType": "Dividir por",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -1296,6 +1296,8 @@
     "date": "Дата",
     "splitTransaction": "Разделить эту транзакцию",
     "splitNoGroups": "Сначала создайте группу, чтобы разделить транзакцию.",
+    "splitNoGroupsLinkPrefix": "У вас еще нет группы. Вы можете ",
+    "splitNoGroupsLinkSuffix": "создать ее здесь",
     "splitNoMembers": "Сначала добавьте участников в группу.",
     "group": "Группа",
     "shareType": "Разделить по",

--- a/frontend/src/locales/uk.json
+++ b/frontend/src/locales/uk.json
@@ -1296,6 +1296,8 @@
     "date": "Дата",
     "splitTransaction": "Розділити цю транзакцію",
     "splitNoGroups": "Спочатку створіть групу, щоб розділити транзакцію.",
+    "splitNoGroupsLinkPrefix": "У вас ще немає групи. Ви можете ",
+    "splitNoGroupsLinkSuffix": "створити її тут",
     "splitNoMembers": "Спочатку додайте учасників до групи.",
     "group": "Група",
     "shareType": "Розділити за",

--- a/frontend/src/pages/group-detail.tsx
+++ b/frontend/src/pages/group-detail.tsx
@@ -26,12 +26,12 @@ import {
 
 import {
   groups as groupsApi,
-  users as usersApi,
   accounts as accountsApi,
   transactions as transactionsApi,
   type GroupMemberPayload,
   type GroupSettlementPayload,
 } from '@/lib/api'
+import { MemberForm } from '@/components/member-form'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
 import { Button } from '@/components/ui/button'
@@ -281,27 +281,6 @@ export default function GroupDetailPage() {
     })
   }
 
-  // Directory of all Securo users on the instance — populates the
-  // member-picker dropdown so the host can pick an existing account
-  // rather than typing its email.
-  const { data: userDirectory } = useQuery({
-    queryKey: ['users', 'directory'],
-    queryFn: () => usersApi.directory(),
-    enabled: memberDialogOpen,
-    staleTime: 60_000,
-  })
-
-  // Resolve a typed email to an existing Securo user, kept as a
-  // fallback for the "I know their email but they aren't in my list
-  // for some reason" path.
-  const trimmedEmail = memberEmail.trim()
-  const { data: lookupResult } = useQuery({
-    queryKey: ['users', 'lookup', trimmedEmail.toLowerCase()],
-    queryFn: () => usersApi.lookupByEmail(trimmedEmail),
-    enabled: trimmedEmail.length >= 3 && trimmedEmail.includes('@'),
-    staleTime: 60_000,
-    retry: false,
-  })
 
   // ── Settle-up ────────────────────────────────────────────────
   const [settleOpen, setSettleOpen] = useState(false)
@@ -977,76 +956,14 @@ export default function GroupDetailPage() {
             </DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
-            {/* Pick an existing Securo user, or leave as "non-user" to
-                add someone without an account (the most common case for
-                roommates/relatives who don't use the app yet). When a
-                user is picked, name+email come from their account and
-                the inputs are locked — switch back to "Sem vínculo" to
-                edit them by hand. */}
-            <div className="space-y-2">
-              <Label>{t('splitGroups.linkedUser')}</Label>
-              <select
-                className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background h-9 focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
-                value={memberLinkedUserId ?? ''}
-                onChange={(e) => {
-                  const id = e.target.value || null
-                  setMemberLinkedUserId(id)
-                  if (id) {
-                    const picked = userDirectory?.find((u) => u.id === id)
-                    if (picked) {
-                      // Always reflect the currently picked user — the
-                      // inputs are locked, so the source of truth is
-                      // whatever account is selected here.
-                      setMemberEmail(picked.email)
-                      setMemberName(picked.email.split('@')[0])
-                    }
-                  }
-                }}
-              >
-                <option value="">{t('splitGroups.linkedUserNone')}</option>
-                {(userDirectory ?? []).map((u) => (
-                  <option key={u.id} value={u.id}>
-                    {u.email}
-                    {u.id === user?.id ? ` (${t('splitGroups.you')})` : ''}
-                  </option>
-                ))}
-              </select>
-              <p className="text-xs text-muted-foreground">
-                {t('splitGroups.linkedUserHint')}
-              </p>
-            </div>
-            <div className="space-y-2">
-              <Label>{t('splitGroups.memberName')}</Label>
-              <Input
-                value={memberName}
-                onChange={(e) => setMemberName(e.target.value)}
-                disabled={memberLinkedUserId !== null}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>{t('splitGroups.memberEmail')}</Label>
-              <Input
-                type="email"
-                value={memberEmail}
-                onChange={(e) => setMemberEmail(e.target.value)}
-                disabled={memberLinkedUserId !== null}
-              />
-              {memberLinkedUserId !== null ? (
-                <p className="text-xs text-emerald-600 inline-flex items-center gap-1">
-                  <Link2 size={11} />
-                  {t('splitGroups.willLinkToUser', { email: memberEmail })}
-                </p>
-              ) : lookupResult ? (
-                <p className="text-xs text-emerald-600 inline-flex items-center gap-1">
-                  <Link2 size={11} />
-                  {t('splitGroups.willLinkToUser', { email: lookupResult.email })}
-                </p>
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  {t('splitGroups.memberEmailHint')}
-                </p>
-              )}
-            </div>
+            <MemberForm
+              name={memberName}
+              onChangeName={setMemberName}
+              email={memberEmail}
+              onChangeEmail={setMemberEmail}
+              linkedUserId={memberLinkedUserId}
+              onChangeLinkedUserId={setMemberLinkedUserId}
+            />
           </div>
           <DialogFooter className={editingMember ? 'flex justify-between sm:justify-between' : ''}>
             {editingMember && (

--- a/frontend/src/pages/groups.tsx
+++ b/frontend/src/pages/groups.tsx
@@ -4,12 +4,10 @@ import { useNavigate } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { groups as groupsApi, currencies as currenciesApi, type GroupCreatePayload } from '@/lib/api'
+import { groups as groupsApi, type GroupCreatePayload } from '@/lib/api'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Dialog,
@@ -18,19 +16,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { GroupForm } from '@/components/group-form'
 import { PageHeader } from '@/components/page-header'
 import { Archive, ChevronRight, Trash2, Users } from 'lucide-react'
 import type { Group, GroupKind } from '@/types'
 
 type StatusFilter = 'active' | 'archived' | 'all'
 
-const KIND_OPTIONS: { value: GroupKind; tKey: string }[] = [
-  { value: 'social', tKey: 'splitGroups.kind.social' },
-  { value: 'cost_center', tKey: 'splitGroups.kind.cost_center' },
-  { value: 'project', tKey: 'splitGroups.kind.project' },
-  { value: 'client', tKey: 'splitGroups.kind.client' },
-  { value: 'other', tKey: 'splitGroups.kind.other' },
-]
 
 export default function GroupsPage() {
   const { t } = useTranslation()
@@ -49,11 +41,6 @@ export default function GroupsPage() {
   const [defaultCurrency, setDefaultCurrency] = useState(userCurrency)
   const [notes, setNotes] = useState('')
 
-  const { data: supportedCurrencies } = useQuery({
-    queryKey: ['currencies'],
-    queryFn: currenciesApi.list,
-    staleTime: Infinity,
-  })
 
   const { data: list, isLoading } = useQuery({
     queryKey: ['groups', { includeArchived }],
@@ -242,46 +229,16 @@ export default function GroupsPage() {
             <DialogTitle>{editing ? t('splitGroups.edit') : t('splitGroups.add')}</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
-            <div className="space-y-2">
-              <Label>{t('splitGroups.name')}</Label>
-              <Input value={name} onChange={(e) => setName(e.target.value)} />
-            </div>
-            <div className="space-y-2">
-              <Label>{t('splitGroups.kindLabel')}</Label>
-              <select
-                className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background"
-                value={kind}
-                onChange={(e) => setKind(e.target.value as GroupKind)}
-              >
-                {KIND_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {t(opt.tKey)}
-                  </option>
-                ))}
-              </select>
-              <p className="text-xs text-muted-foreground">{t('splitGroups.kindHint')}</p>
-            </div>
-            <div className="space-y-2">
-              <Label>{t('splitGroups.defaultCurrency')}</Label>
-              <select
-                className="w-full border border-border rounded-md px-3 py-2 text-sm bg-background h-9 focus:outline-none focus-visible:ring-ring/30 focus-visible:ring-[2px]"
-                value={defaultCurrency}
-                onChange={(e) => setDefaultCurrency(e.target.value)}
-              >
-                {(supportedCurrencies ?? [{ code: defaultCurrency, symbol: defaultCurrency, name: defaultCurrency, flag: '' }]).map((c) => (
-                  <option key={c.code} value={c.code}>{c.flag} {c.name}</option>
-                ))}
-              </select>
-            </div>
-            <div className="space-y-2">
-              <Label>{t('splitGroups.notes')}</Label>
-              <textarea
-                className="w-full border border-input rounded-md px-3 py-2 text-sm bg-background resize-none"
-                rows={2}
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-              />
-            </div>
+            <GroupForm
+              name={name}
+              onChangeName={setName}
+              kind={kind}
+              onChangeKind={setKind}
+              defaultCurrency={defaultCurrency}
+              onChangeDefaultCurrency={setDefaultCurrency}
+              notes={notes}
+              onChangeNotes={setNotes}
+            />
             {editing && (
               <label className="text-sm text-muted-foreground inline-flex items-center gap-2 cursor-pointer">
                 <input


### PR DESCRIPTION
## What

Refactored group and member forms into reusable standalone components (`GroupForm` and `MemberForm`) and integrated them directly into the transaction bulk-add-to-group dialog. This resolves the issue where a user with no groups or a newly created empty group could not proceed with transaction split assignment directly from the transactions page.

The dialog now features:
- Inline group creation using `GroupForm`.
- Inline member addition using `MemberForm` (when a group has no members or via a `+ Add member` button).
- Full state resetting on modal close.

## Why

Implements a clean, non-deadlocked group assignment flow in the transactions section without duplicating React form code.

## How to Test

1. Navigate to the **Transactions** section.
2. Select one or more transactions and click the **Add to group** button.
3. If no groups exist, verify the inline link transitions to the Group creation form.
4. If a group has no members, verify that the prompt displays a `+ Add member` button.
5. Verify that saving a member immediately updates the splits checklist inside the dialog.
6. Verify that closing the dialog clears all form data (such as temporary names/emails and active tabs) so that it is reset upon reopening.

## Demo

https://github.com/user-attachments/assets/19243828-2bf8-4f48-9622-5b514f5c0225



## Related Issue

N/A

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
- [ ] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))
