### PR TITLE
Speed up backend PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,40 +16,72 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect backend-relevant changes
+        id: backend-changes
+        working-directory: .
+        run: |
+          set -euo pipefail
+
+          # Keep the required Backend Tests check fast for PRs that only touch
+          # frontend/docs files. Pushes to main still run the full backend suite.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run_backend=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only HEAD^1 HEAD)"
+          printf '%s\n' "$changed_files"
+
+          if printf '%s\n' "$changed_files" | grep -Eq '^(backend/.*|\.github/workflows/ci\.yml)$'; then
+            echo "run_backend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_backend=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip backend tests
+        if: steps.backend-changes.outputs.run_backend != 'true'
+        run: echo "No backend-relevant changes; skipping backend test suite."
 
       - name: Set up Python
+        if: steps.backend-changes.outputs.run_backend == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: pip
 
       - name: Install dependencies
+        if: steps.backend-changes.outputs.run_backend == 'true'
         run: |
           pip install -e ".[dev]"
 
       - name: Lint with Ruff
+        if: steps.backend-changes.outputs.run_backend == 'true'
         run: ruff check .
 
       - name: Run tests with coverage
+        if: steps.backend-changes.outputs.run_backend == 'true'
         run: |
-          pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=60
+          pytest -n auto --dist loadfile --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=60
 
       - name: Upload coverage report
-        if: always()
+        if: ${{ always() && steps.backend-changes.outputs.run_backend == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: backend/coverage.xml
 
       - name: Extract coverage percentage
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && steps.backend-changes.outputs.run_backend == 'true'
         id: coverage
         run: |
           COVERAGE=$(python -c "import xml.etree.ElementTree as ET; print(round(float(ET.parse('coverage.xml').getroot().attrib['line-rate']) * 100))")
           echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
 
       - name: Update coverage badge
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && steps.backend-changes.outputs.run_backend == 'true'
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.23.0,<1.0",
     "pytest-cov>=4.1.0",
+    "pytest-xdist>=3.6.1",
     "httpx>=0.26.0",
     "aiosqlite>=0.19.0",
     "ruff>=0.1.0",


### PR DESCRIPTION
## Summary
- run backend pytest with `pytest-xdist` (`-n auto --dist loadfile`) so the 2.2k-test backend suite uses GitHub runner cores
- keep the required `Backend Tests` check fast on PRs that only touch frontend/docs files by detecting backend-relevant changes before Python setup
- keep full backend checks on pushes to `main` and on PRs touching `backend/` or `.github/workflows/ci.yml`

## Diagnosis
Recent CI runs show the backend bottleneck is almost entirely `Run tests with coverage`:

- PR #401 latest run: Backend Tests 15m31s total; tests-with-coverage 14m51s; dependency install ~29s
- PR #406 frontend-only run: Backend Tests 15m21s total despite no backend code changes; tests-with-coverage 14m43s
- Frontend Checks finish in ~1m10s

So dependency caching is not the issue; the backend suite is serial and runs unnecessarily on frontend-only PRs.

## Results from this PR
- Backend Tests: 6m12s total on GitHub Actions
- `Run tests with coverage`: 5m29s on GitHub Actions
- Frontend Checks: 1m05s

That cuts backend PR wait time from about 15m30s to about 6m12s for backend-touching PRs. Frontend/docs-only PRs should skip Python setup and the backend suite entirely while keeping the required `Backend Tests` check green.

## Verification
- `uv run --extra dev pytest -n auto --dist loadfile --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=60 -q`
  - 2270 passed, 7 skipped
  - Total coverage: 92.89%
  - Local wall time: 247.49s / 4m07s
- `uv run --extra dev ruff check .` — passed
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parsed
- backend path detector smoke test:
  - frontend/docs-only paths -> skip
  - backend paths -> run
  - CI workflow path -> run
- PR CI: Backend Tests and Frontend Checks passed