### PR TITLE
refactor: use SecretStr for all credential settings

### DIFF
--- a/backend/app/agents/services/crypto.py
+++ b/backend/app/agents/services/crypto.py
@@ -21,7 +21,7 @@ _SALT = b"securo-agents-llm-keys-v1"
 
 @functools.lru_cache(maxsize=1)
 def _fernet() -> Fernet:
-    secret = get_settings().secret_key.encode("utf-8")
+    secret = get_settings().secret_key.get_secret_value().encode("utf-8")
     raw = hashlib.pbkdf2_hmac("sha256", secret, _SALT, iterations=100_000, dklen=32)
     return Fernet(base64.urlsafe_b64encode(raw))
 

--- a/backend/app/api/oidc_auth.py
+++ b/backend/app/api/oidc_auth.py
@@ -106,7 +106,7 @@ async def _exchange_code(discovery: dict[str, Any], code: str, code_verifier: st
     data = {
         "grant_type": "authorization_code",
         "client_id": settings.oidc_client_id,
-        "client_secret": settings.oidc_client_secret,
+        "client_secret": settings.oidc_client_secret.get_secret_value(),
         "code": code,
         "redirect_uri": _redirect_uri(),
         "code_verifier": code_verifier,

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -73,7 +73,7 @@ bearer_transport = BearerTransport(tokenUrl="api/auth/login")
 
 def get_jwt_strategy() -> JWTStrategy:
     return JWTStrategy(
-        secret=settings.secret_key,
+        secret=settings.secret_key.get_secret_value(),
         lifetime_seconds=settings.access_token_expire_minutes * 60,
     )
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,6 +3,7 @@ from os import getenv
 from pathlib import Path
 from urllib.parse import urlparse
 
+from pydantic import SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Use the same environment variable that systemd uses: https://systemd.io/CREDENTIALS/
@@ -21,18 +22,18 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/securo"
 
     # Auth
-    secret_key: str = "change-me-in-production"
+    secret_key: SecretStr = SecretStr("change-me-in-production")
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 60 * 24  # 24 hours
 
     # Pluggy
     pluggy_client_id: str = ""
-    pluggy_client_secret: str = ""
+    pluggy_client_secret: SecretStr = SecretStr("")
     pluggy_oauth_redirect_uri: str = "http://localhost:5173/oauth/callback"
 
     # Enable Banking (European PSD2 banks)
     enable_banking_app_id: str = ""
-    enable_banking_private_key: str = ""  # raw PEM; supports \n-escaped envs
+    enable_banking_private_key: SecretStr = SecretStr("")  # raw PEM; supports \n-escaped envs
     enable_banking_private_key_file: str = ""  # path to PEM file; takes precedence
     enable_banking_api_url: str = "https://api.enablebanking.com"
     enable_banking_oauth_redirect_uri: str = "http://localhost:5173/oauth/callback"
@@ -83,8 +84,8 @@ class Settings(BaseSettings):
     # S3 Storage (for future use)
     storage_s3_bucket: str = ""
     storage_s3_region: str = ""
-    storage_s3_access_key: str = ""
-    storage_s3_secret_key: str = ""
+    storage_s3_access_key: SecretStr = SecretStr("")
+    storage_s3_secret_key: SecretStr = SecretStr("")
     storage_s3_endpoint_url: str = ""  # for S3-compatible services (MinIO, DigitalOcean Spaces)
 
     # Registration
@@ -97,7 +98,7 @@ class Settings(BaseSettings):
         ""  # e.g. https://auth.example.com/application/o/securo/.well-known/openid-configuration
     )
     oidc_client_id: str = ""
-    oidc_client_secret: str = ""
+    oidc_client_secret: SecretStr = SecretStr("")
     oidc_redirect_uri: str = ""  # defaults to {FRONTEND_URL}/api/auth/oidc/callback
     oidc_scopes: str = "openid email profile"
     oidc_auto_register: bool = True

--- a/backend/app/providers/enable_banking.py
+++ b/backend/app/providers/enable_banking.py
@@ -180,7 +180,7 @@ class EnableBankingProvider(BankProvider):
         if key_file:
             cls._cached_private_key = Path(key_file).read_text(encoding="utf-8")
             return cls._cached_private_key
-        raw = settings.enable_banking_private_key or ""
+        raw = settings.enable_banking_private_key.get_secret_value() or ""
         if "\\n" in raw and "\n" not in raw:
             raw = raw.replace("\\n", "\n")
         cls._cached_private_key = raw

--- a/backend/app/providers/pluggy.py
+++ b/backend/app/providers/pluggy.py
@@ -262,7 +262,7 @@ class PluggyProvider(BankProvider):
                 f"{PLUGGY_API_BASE}/auth",
                 json={
                     "clientId": settings.pluggy_client_id,
-                    "clientSecret": settings.pluggy_client_secret,
+                    "clientSecret": settings.pluggy_client_secret.get_secret_value(),
                 },
             )
             resp.raise_for_status()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from pydantic import SecretStr
 import pytest
 
 from app.core.config import Settings
@@ -19,14 +20,14 @@ def test_oidc_secret_reads_from_secrets_dir(secrets: Path):
     write(secrets, "oidc_client_secret", "file-secret")
 
     settings = Settings(_secrets_dir=str(secrets))
-    assert settings.oidc_client_secret == "file-secret"
+    assert settings.oidc_client_secret.get_secret_value() == "file-secret"
 
 
 def test_oidc_secret_strips_whitespace(secrets: Path):
     write(secrets, "oidc_client_secret", "  stripped-value  \n\n")
 
     settings = Settings(_secrets_dir=str(secrets))
-    assert settings.oidc_client_secret == "stripped-value"
+    assert settings.oidc_client_secret.get_secret_value() == "stripped-value"
 
 
 def test_oidc_secret_inline_when_no_file(secrets: Path):
@@ -35,13 +36,13 @@ def test_oidc_secret_inline_when_no_file(secrets: Path):
         _secrets_dir=str(secrets),
     )
 
-    assert settings.oidc_client_secret == "inline-secret"
+    assert settings.oidc_client_secret.get_secret_value() == "inline-secret"
 
 
 def test_oidc_secret_default_when_no_file(secrets: Path):
     settings = Settings(_secrets_dir=str(secrets))
 
-    assert settings.oidc_client_secret == ""
+    assert settings.oidc_client_secret.get_secret_value() == ""
 
 
 def test_multiple_secrets_dirs_merge(tmp_path: Path):
@@ -67,4 +68,8 @@ def test_multiple_secrets_dirs_merge(tmp_path: Path):
     settings = Settings(_secrets_dir=[str(d1), str(d2)])
 
     for key, expectedValue in expectedSecrets.items():
-        assert getattr(settings, key) == expectedValue
+        value = getattr(settings, key)
+        if isinstance(value, SecretStr):
+            value = value.get_secret_value()
+
+        assert value == expectedValue

--- a/backend/tests/test_oidc_auth.py
+++ b/backend/tests/test_oidc_auth.py
@@ -4,6 +4,7 @@ import json
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from pydantic import SecretStr
 from httpx import AsyncClient
 from sqlalchemy import select
 
@@ -35,7 +36,7 @@ def oidc_settings(monkeypatch):
     settings.oidc_provider_name = "Pocket ID"
     settings.oidc_discovery_url = "https://id.example.com/.well-known/openid-configuration"
     settings.oidc_client_id = "securo"
-    settings.oidc_client_secret = "secret"
+    settings.oidc_client_secret = SecretStr("secret")
     settings.frontend_url = "http://test"
     settings.oidc_sync_roles = False
     settings.oidc_roles_claim = "groups"


### PR DESCRIPTION
## What

Migrate all credential-type settings (secret_key, pluggy_client_secret, enable_banking_private_key, storage_s3_access_key, storage_s3_secret_key, oidc_client_secret) from plain str to Pydantic's SecretStr. Update all consumers to call .get_secret_value() where the raw string is needed.

## Why

Plain string settings are accidentally exposed in logs, tracebacks, and serialization output. SecretStr automatically masks values in repr() and JSON responses, preventing credential leaks.

## How to Test

Steps to verify the changes work:

- Run pytest

## Related Issue

Closes #___ (or link the issue this addresses).

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
- [ ] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))
