### PR TITLE
fix(frontend): calendar month localization

### DIFF
--- a/frontend/src/pages/budgets.tsx
+++ b/frontend/src/pages/budgets.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
+import { useDisplayLocale } from '@/hooks/use-display-locale'
+import { monthLabel } from '@/lib/month-utils'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { categories as categoriesApi, categoryGroups as groupsApi, budgets as budgetsApi } from '@/lib/api'
 import { toast } from 'sonner'
@@ -60,7 +61,6 @@ export default function BudgetsPage() {
   const { canWrite } = useWorkspace()
   const userCurrency = user?.preferences?.currency_display ?? 'USD'
   const locale = useDisplayLocale()
-  const dateLocale = useDateLocale()
   const queryClient = useQueryClient()
   const [selectedMonth, setSelectedMonth] = useState(currentMonth)
   const [monthCalOpen, setMonthCalOpen] = useState(false)
@@ -126,7 +126,8 @@ export default function BudgetsPage() {
     )
   }
 
-  const monthTitle = new Date(selectedMonth + '-02').toLocaleDateString(dateLocale, { month: 'long', year: 'numeric' }).replace(/^\w/, c => c.toUpperCase())
+  const uiLocale = i18n.resolvedLanguage ?? i18n.language
+  const monthTitle = monthLabel(selectedMonth, uiLocale).replace(/^\w/, c => c.toUpperCase())
 
   return (
     <div>

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -149,7 +149,8 @@ export default function DashboardPage() {
   const dateFnsLocale = resolveDateFnsLocale(i18n.resolvedLanguage ?? i18n.language)
   const { from: monthStart, to: monthEnd } = monthRange(selectedMonth)
   const monthParam = monthStart
-  const monthLabelStr = monthLabel(selectedMonth, dateLocale)
+  const uiLocale = i18n.resolvedLanguage ?? i18n.language
+  const monthLabelStr = monthLabel(selectedMonth, uiLocale)
 
   const handleMonthChange = (newMonth: string) => {
     setSelectedMonth(newMonth)
@@ -518,7 +519,7 @@ export default function DashboardPage() {
       {/* Header */}
       <PageHeader
         section={greeting}
-        title={new Date(selectedMonth + '-02').toLocaleDateString(dateLocale, { month: 'long', year: 'numeric' }).replace(/^\w/, c => c.toUpperCase())}
+        title={monthLabel(selectedMonth, uiLocale).replace(/^\w/, c => c.toUpperCase())}
         action={
           <div className="flex items-center gap-1">
             <button
@@ -532,7 +533,7 @@ export default function DashboardPage() {
                   className="inline-flex items-center justify-center gap-2 border border-border rounded-lg px-3 py-1.5 text-sm bg-card text-foreground hover:bg-muted/50 transition-all cursor-pointer min-w-[180px]"
                 >
                   <CalendarIcon className="size-3.5 text-muted-foreground" />
-                  {new Date(selectedMonth + '-02').toLocaleDateString(dateLocale, { month: 'long', year: 'numeric' }).replace(/^\w/, c => c.toUpperCase())}
+                  {monthLabel(selectedMonth, uiLocale).replace(/^\w/, c => c.toUpperCase())}
                 </button>
               </PopoverTrigger>
               <PopoverContent align="center" className="w-auto p-0">
@@ -891,7 +892,7 @@ export default function DashboardPage() {
                   <Tooltip
                     formatter={(value, name) => [
                       value !== null ? (privacyMode ? MASK : formatCurrency(Number(value), userCurrency, locale)) : '\u2014',
-                      name === 'current' ? monthLabel(selectedMonth, dateLocale).split(' ')[0] : monthLabel(prevMonth, dateLocale).split(' ')[0],
+                      name === 'current' ? monthLabel(selectedMonth, uiLocale).split(' ')[0] : monthLabel(prevMonth, uiLocale).split(' ')[0],
                     ]}
                     labelFormatter={(day) => t('dashboard.day', { day })}
                     contentStyle={{
@@ -938,7 +939,7 @@ export default function DashboardPage() {
               <div className="px-5 pb-4 pt-0 shrink-0">
                 <p className="text-xs text-muted-foreground">
                   {t('dashboard.balanceFlowVsPrev', {
-                    month: monthLabel(prevMonth, dateLocale).split(' ')[0],
+                    month: monthLabel(prevMonth, uiLocale).split(' ')[0],
                     day: footerDay,
                     amount: mask(formatCurrency(footerPrev, userCurrency, locale)),
                     delta: `${footerPct >= 0 ? '+' : ''}${footerPct.toFixed(1)}%`,

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -80,7 +80,7 @@ function parseHashtags(notes: string | null): string[] {
 }
 
 export default function TransactionsPage() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
   const locale = useDisplayLocale()
@@ -1138,7 +1138,7 @@ export default function TransactionsPage() {
             <MonthStepper
               value={steppedMonth}
               onChange={handleMonthChange}
-              locale={dateLocale}
+              locale={i18n.resolvedLanguage ?? i18n.language}
               prevLabel={t('transactions.monthPrevious')}
               nextLabel={t('transactions.monthNext')}
             />


### PR DESCRIPTION
## What

Fixes the locale used for calendar month selections in the frontend (Transactions, Dashboard, and Budgets pages).

## Why

Month names were falling back to English when a user's date formatting settings triggered a non-native date order (e.g., configuring US-style date format in a German UI context). By passing the UI language (`i18n.resolvedLanguage`) explicitly to the month label formatters instead of dateLocale, month names are now consistently translated according to the user's interface language.

## How to Test

Steps to verify the changes work:

1. Change your UI language to German (or a different non english language).
2. Go to Admin Settings -> User Preferences and change the Date Format to something US-based (e.g., MM/DD/YYYY).
3. Navigate to the Dashboard, Transactions, and Budgets pages.
4. Verify that the calendar month selector and the month titles still show localized names (e.g., "März") instead of falling back to "March".

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
