### PR TITLE
fix(dashboard): keep excluded rows out of category drill-down total

### DIFF
--- a/frontend/src/components/transaction-drill-down.tsx
+++ b/frontend/src/components/transaction-drill-down.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
 import { useQuery } from '@tanstack/react-query'
 import { transactions as transactionsApi, dashboard, admin } from '@/lib/api'
-import { AlertTriangle, Info, Paperclip, X } from 'lucide-react'
+import { AlertTriangle, EyeClosed, Info, Paperclip, X } from 'lucide-react'
 import { CategoryIcon } from '@/components/category-icon'
 import { useAuth } from '@/contexts/auth-context'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
@@ -33,6 +33,11 @@ type DisplayItem = {
   categoryName: string | null
   categoryColor: string | null
   isProjected: boolean
+  // Row is shown for transparency but kept out of the total — ignored
+  // split-originals and settlement legs, i.e. what the dashboard category
+  // figure excludes. Keeps the panel's total matching the number that
+  // opened it while still surfacing the excluded rows.
+  isExcluded: boolean
   attachmentCount: number
   transaction: Transaction | null
 }
@@ -108,6 +113,7 @@ export function TransactionDrillDown({
         categoryName: tx.category?.name ?? null,
         categoryColor: tx.category?.color ?? null,
         isProjected: false,
+        isExcluded: tx.is_ignored === true || tx.source === 'settlement',
         attachmentCount: tx.attachment_count ?? 0,
         transaction: tx,
       })
@@ -133,6 +139,7 @@ export function TransactionDrillDown({
         categoryName: pt.category_name,
         categoryColor: pt.category_color ?? null,
         isProjected: true,
+        isExcluded: false,
         attachmentCount: 0,
         transaction: null,
       })
@@ -174,15 +181,18 @@ export function TransactionDrillDown({
   // amount_primary; if it's missing we can't convert, so skip the row
   // instead of adding a raw foreign amount as if it were primary. This
   // matches how get_summary computes monthly_*_primary on the backend.
-  const absTotal = displayItems.reduce((sum, item) => {
-    if (item.currency === userCurrency) {
-      return sum + Math.abs(item.amount)
-    }
-    if (item.amountPrimary != null) {
-      return sum + Math.abs(item.amountPrimary)
-    }
-    return sum
-  }, 0)
+  const primaryAbs = (item: DisplayItem): number => {
+    if (item.currency === userCurrency) return Math.abs(item.amount)
+    if (item.amountPrimary != null) return Math.abs(item.amountPrimary)
+    return 0
+  }
+  // Excluded rows are listed for transparency but kept out of the total, so
+  // it matches the dashboard category figure that opened this panel.
+  const countedItems = displayItems.filter((i) => !i.isExcluded)
+  const absTotal = countedItems.reduce((sum, item) => sum + primaryAbs(item), 0)
+  const excludedTotal = displayItems
+    .filter((i) => i.isExcluded)
+    .reduce((sum, item) => sum + primaryAbs(item), 0)
 
   return (
     <>
@@ -252,10 +262,19 @@ export function TransactionDrillDown({
                   />
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2">
-                      <p className="text-sm font-medium text-foreground truncate">{item.description}</p>
+                      <p className={`text-sm font-medium truncate ${item.isExcluded ? 'text-muted-foreground' : 'text-foreground'}`}>{item.description}</p>
                       {item.isProjected && (
                         <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-violet-100 text-violet-600 shrink-0">
                           {t('transactions.recurringBadge')}
+                        </span>
+                      )}
+                      {item.isExcluded && (
+                        <span
+                          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold bg-gray-100 text-gray-500 border border-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700 shrink-0"
+                          title={t('transactions.drillDownExcludedTooltip')}
+                        >
+                          <EyeClosed className="h-3 w-3" />
+                          {t('transactions.ignored')}
                         </span>
                       )}
                       {item.attachmentCount > 0 && (
@@ -270,7 +289,9 @@ export function TransactionDrillDown({
                   <div className="text-right shrink-0">
                     <span
                       className={`text-sm font-semibold tabular-nums ${
-                        item.type === 'credit' ? 'text-emerald-600' : 'text-rose-500'
+                        item.isExcluded
+                          ? 'text-muted-foreground line-through'
+                          : item.type === 'credit' ? 'text-emerald-600' : 'text-rose-500'
                       }`}
                     >
                       {item.type === 'credit' ? '+' : '-'}
@@ -295,11 +316,19 @@ export function TransactionDrillDown({
 
         {/* Footer */}
         {displayItems.length > 0 && (
-          <div className="px-5 py-3 border-t border-border bg-muted/50 shrink-0">
+          <div className="px-5 py-3 border-t border-border bg-muted/50 shrink-0 space-y-1">
+            {excludedTotal > 0 && (
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>{t('transactions.summaryExcluded')}</span>
+                <span className="tabular-nums line-through">
+                  {mask(formatCurrency(excludedTotal, userCurrency, locale))}
+                </span>
+              </div>
+            )}
             <div className="flex items-center justify-between">
               <span className="text-xs text-muted-foreground">
                 {t('dashboard.drillDownTotal', {
-                  count: displayItems.length,
+                  count: countedItems.length,
                   total: mask(formatCurrency(absTotal, userCurrency, locale)),
                 })}
               </span>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -259,6 +259,7 @@
     "drillDownDay": "Transaktionen — {{date}}",
     "drillDownTotal": "{{count}} Transaktionen · {{total}}",
     "drillDownEmpty": "Keine Transaktionen gefunden",
+    "drillDownExcludedTooltip": "Nicht in dieser Summe enthalten",
     "drillDownClose": "Schließen",
     "accrualNote": "Kreditkartentransaktionen werden nach dem Fälligkeitsdatum der Abrechnung gruppiert (Soll-Modus).",
     "savingsRate": "Sparquote",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -259,6 +259,7 @@
     "drillDownDay": "Transactions — {{date}}",
     "drillDownTotal": "{{count}} transactions · {{total}}",
     "drillDownEmpty": "No transactions found",
+    "drillDownExcludedTooltip": "Not counted in this total",
     "drillDownClose": "Close",
     "accrualNote": "Credit-card transactions are grouped by bill due date (accrual mode).",
     "savingsRate": "Savings Rate",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -259,6 +259,7 @@
     "drillDownDay": "Transacciones — {{date}}",
     "drillDownTotal": "{{count}} transacciones · {{total}}",
     "drillDownEmpty": "No se encontraron transacciones",
+    "drillDownExcludedTooltip": "No se incluye en este total",
     "drillDownClose": "Cerrar",
     "accrualNote": "Las transacciones con tarjeta de crédito se agrupan por la fecha de vencimiento de la factura (modo acumulado).",
     "savingsRate": "Tasa de ahorro",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -259,6 +259,7 @@
     "drillDownDay": "Transazioni — {{date}}",
     "drillDownTotal": "{{count}} transazioni · {{total}}",
     "drillDownEmpty": "Nessuna transazione trovata",
+    "drillDownExcludedTooltip": "Non conteggiato in questo totale",
     "drillDownClose": "Chiudi",
     "accrualNote": "Le transazioni con carta di credito sono raggruppate per scadenza dell'estratto conto (modalità per competenza).",
     "savingsRate": "Tasso di risparmio",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -262,6 +262,7 @@
     "drillDownTotal_many": "{{count}} transakcji · {{total}}",
     "drillDownTotal_other": "{{count}} transakcji · {{total}}",
     "drillDownEmpty": "Nie znaleziono transakcji",
+    "drillDownExcludedTooltip": "Nie wliczone do tej sumy",
     "drillDownClose": "Zamknij",
     "accrualNote": "Transakcje kartą kredytową są grupowane wg terminu płatności rachunku (tryb memoriałowy).",
     "savingsRate": "Stopa oszczędności",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -259,6 +259,7 @@
     "drillDownDay": "Transações — {{date}}",
     "drillDownTotal": "{{count}} transações · {{total}}",
     "drillDownEmpty": "Nenhuma transação encontrada",
+    "drillDownExcludedTooltip": "Não entra neste total",
     "drillDownClose": "Fechar",
     "accrualNote": "Transações de cartão de crédito são agrupadas pela data de vencimento da fatura (modo competência).",
     "savingsRate": "Taxa de Economia",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -259,6 +259,7 @@
     "drillDownDay": "Транзакции — {{date}}",
     "drillDownTotal": "{{count}} транзакций · {{total}}",
     "drillDownEmpty": "Транзакции не найдены",
+    "drillDownExcludedTooltip": "Не учитывается в этой сумме",
     "drillDownClose": "Закрыть",
     "accrualNote": "Кредитные карты: транзакции группируются по дате платежа (метод начисления).",
     "savingsRate": "Норма сбережений",

--- a/frontend/src/locales/uk.json
+++ b/frontend/src/locales/uk.json
@@ -259,6 +259,7 @@
     "drillDownDay": "Транзакції — {{date}}",
     "drillDownTotal": "{{count}} транзакцій · {{total}}",
     "drillDownEmpty": "Транзакції не знайдено",
+    "drillDownExcludedTooltip": "Не враховується в цій сумі",
     "drillDownClose": "Закрити",
     "accrualNote": "Кредитні картки: транзакції групуються за датою платежу (метод нарахування).",
     "savingsRate": "Норма заощаджень",


### PR DESCRIPTION
## What

The dashboard category drill-down side panel summed **every** returned transaction into its subtotal, including rows that don't count toward P&L (ignored transactions and settlement legs). As a result the panel's total didn't match the category total that opened it.

This shows those rows for transparency — greyed, struck-through, with an "ignored" badge — but keeps them **out of the total**, and adds an "Excluded" line reporting their sum. It mirrors the treatment the main Transactions list already uses (`summaryExcluded`).

## Why

The dashboard category figure uses `counts_as_user_pnl()` (excludes ignored / settlement / transfer-category rows), but the drill-down called the generic transactions list — which intentionally returns ignored rows — and summed them client-side. So clicking a category that contained any ignored transaction opened a panel whose total contradicted the number just clicked.

## How to Test

1. In a given month, mark one transaction of a spending category as ignored (row menu → ignore).
2. On the dashboard, note that category's total (it excludes the ignored one).
3. Click the category to open the drill-down side panel.
   - **Before:** the ignored transaction was listed and added into the panel total, so it diverged from the category figure.
   - **After:** it's listed but greyed / struck-through with an "ignored" badge, an "Excluded" line reports its sum, and the panel total matches the category figure.

## Related Issue

None — small self-contained bug fix.

## Checklist

- [x] Backend tests pass (`pytest`) — no backend changes
- [x] Frontend lints clean (`npm run lint`) — no new warnings vs. baseline
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (all 8 locales)
- [ ] For a large or core change, I discussed it first — N/A (small bug fix)
