### PR TITLE
fix: make category picker scrollable inside dialogs on touch/wheel input

### DIFF
--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -4,6 +4,55 @@ import { SearchIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+// When this list is nested inside a modal Dialog (e.g. category picker
+// inside the transaction dialog), Radix's body scroll lock (react-remove-scroll)
+// registers a bubble-phase `wheel`/`touchmove` listener on `document` that
+// preventDefault()s events whose target isn't inside the dialog's own DOM
+// subtree — which is exactly this list's situation, since its Popover portals
+// to document.body. That listener only fires once the event has bubbled all
+// the way up, so React's own (passive, non-preventable) onWheel/onTouchMove
+// props can't detect or work around it in time. The only reliable fix is to
+// attach our own non-passive native listener directly on the list and drive
+// scrollTop ourselves, unconditionally — this works the same whether or not
+// a Dialog's scroll lock is active.
+function useManualScroll<T extends HTMLElement>() {
+  const ref = React.useRef<T>(null)
+
+  React.useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      const multiplier = e.deltaMode === 1 ? 20 : e.deltaMode === 2 ? el.clientHeight : 1
+      el.scrollTop += e.deltaY * multiplier
+    }
+
+    let touchStart: { y: number; scrollTop: number } | null = null
+    const onTouchStart = (e: TouchEvent) => {
+      const touch = e.touches[0]
+      touchStart = { y: touch.clientY, scrollTop: el.scrollTop }
+    }
+    const onTouchMove = (e: TouchEvent) => {
+      if (!touchStart) return
+      e.preventDefault()
+      const touch = e.touches[0]
+      el.scrollTop = touchStart.scrollTop + (touchStart.y - touch.clientY)
+    }
+
+    el.addEventListener("wheel", onWheel, { passive: false })
+    el.addEventListener("touchstart", onTouchStart, { passive: true })
+    el.addEventListener("touchmove", onTouchMove, { passive: false })
+    return () => {
+      el.removeEventListener("wheel", onWheel)
+      el.removeEventListener("touchstart", onTouchStart)
+      el.removeEventListener("touchmove", onTouchMove)
+    }
+  }, [])
+
+  return ref
+}
+
 function Command({
   className,
   ...props
@@ -43,10 +92,12 @@ function CommandList({
   className,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.List>) {
+  const ref = useManualScroll<HTMLDivElement>()
   return (
     <CommandPrimitive.List
+      ref={ref}
       data-slot="command-list"
-      className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+      className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden overscroll-contain", className)}
       {...props}
     />
   )


### PR DESCRIPTION
Fixes #428

## Why

Radix's body scroll lock (`react-remove-scroll`) registers a bubble-phase `wheel`/`touchmove` listener on `document` that calls `preventDefault()` on events whose target isn't inside the Dialog's own DOM subtree. The `Command` list used by combobox pickers (e.g. selecting a category on a rule's action) portals to `document.body`, so it falls outside that subtree, and its wheel/touch events get suppressed before the list itself can scroll — this leaves the picker frozen on touch devices (and non-scrollable via mouse wheel) when opened from within a Dialog.

React also attaches `onWheel`/`onTouchMove` as passive listeners, so calling `preventDefault()` from them isn't an option.

## How

`CommandList` now attaches its own non-passive native `wheel`/`touchstart`/`touchmove` listeners directly to the list's DOM node (via a ref) and drives `scrollTop` manually, unconditionally. This works the same whether or not a Dialog's scroll lock is currently active.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Open the rule dialog's category picker on a touch device/emulator and confirm the list scrolls with a finger drag
- [x] Confirm mouse-wheel scrolling also works in the same picker
- [x] Repeat for the transaction dialog's category picker