### PR TITLE
fix(frontend): use local dates for form defaults

### DIFF
--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -5,6 +5,7 @@ import { useDateLocale } from '@/hooks/use-display-locale'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '@/contexts/auth-context'
 import { currencies as currenciesApi, transactions as transactionsApi, settings as settingsApi, payees as payeesApi, rules as rulesApi } from '@/lib/api'
+import { localDateString } from '@/lib/date-utils'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { normalizeRuleMatchValue } from '@/lib/rule-match-utils'
 import { cn, normalizeText } from '@/lib/utils'
@@ -355,7 +356,7 @@ function TransactionForm({
   const seed = transaction ?? duplicateDraft
   const [description, setDescription] = useState(seed?.description ?? '')
   const [amount, setAmount] = useState(seed?.amount?.toString() ?? '')
-  const [date, setDate] = useState(seed?.date ?? new Date().toISOString().split('T')[0])
+  const [date, setDate] = useState(seed?.date ?? localDateString())
   const [type, setType] = useState<'debit' | 'credit'>(seed?.type ?? 'debit')
   const [currency, setCurrency] = useState(seed?.currency ?? userCurrency)
   const [categoryId, setCategoryId] = useState(seed?.category_id ?? '')

--- a/frontend/src/components/transactions-filter-bar.tsx
+++ b/frontend/src/components/transactions-filter-bar.tsx
@@ -2,7 +2,7 @@ import { useMemo, useRef, useState } from 'react'
 import { getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
-import { format, startOfMonth, startOfYear, subDays } from 'date-fns'
+import { startOfMonth, startOfYear, subDays } from 'date-fns'
 import {
   ArrowUpDown,
   Calendar as CalendarIcon,
@@ -39,6 +39,7 @@ import {
 import { Calendar } from '@/components/ui/calendar'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { localDateString } from '@/lib/date-utils'
 import { resolveDateFnsLocale } from '@/lib/date-fns-locale'
 import { CategoryFilterContent } from '@/components/category-filter-content'
 import type { Account, Category, CategoryGroup, Group, Payee } from '@/types'
@@ -71,10 +72,6 @@ interface TransactionsFilterBarProps {
   categoryGroups: CategoryGroup[]
   payees: Payee[]
   groups: Group[]
-}
-
-function toISODate(d: Date): string {
-  return format(d, 'yyyy-MM-dd')
 }
 
 function toggleInArray(arr: string[], id: string): string[] {
@@ -259,38 +256,38 @@ export function TransactionsFilterBar({
       {
         key: 'today',
         label: t('transactions.filtersBar.datePresets.today'),
-        from: toISODate(today),
-        to: toISODate(today),
+        from: localDateString(today),
+        to: localDateString(today),
       },
       {
         key: 'last7',
         label: t('transactions.filtersBar.datePresets.last7'),
-        from: toISODate(subDays(today, 6)),
-        to: toISODate(today),
+        from: localDateString(subDays(today, 6)),
+        to: localDateString(today),
       },
       {
         key: 'last30',
         label: t('transactions.filtersBar.datePresets.last30'),
-        from: toISODate(subDays(today, 29)),
-        to: toISODate(today),
+        from: localDateString(subDays(today, 29)),
+        to: localDateString(today),
       },
       {
         key: 'thisMonth',
         label: t('transactions.filtersBar.datePresets.thisMonth'),
-        from: toISODate(startOfMonth(today)),
-        to: toISODate(today),
+        from: localDateString(startOfMonth(today)),
+        to: localDateString(today),
       },
       {
         key: 'last90',
         label: t('transactions.filtersBar.datePresets.last90'),
-        from: toISODate(subDays(today, 89)),
-        to: toISODate(today),
+        from: localDateString(subDays(today, 89)),
+        to: localDateString(today),
       },
       {
         key: 'thisYear',
         label: t('transactions.filtersBar.datePresets.thisYear'),
-        from: toISODate(startOfYear(today)),
-        to: toISODate(today),
+        from: localDateString(startOfYear(today)),
+        to: localDateString(today),
       },
     ]
   }, [t])
@@ -942,7 +939,7 @@ export function TransactionsFilterBar({
                   draftFrom ? new Date(draftFrom + 'T00:00:00') : new Date()
                 }
                 locale={dateFnsLocale}
-                onSelect={(d) => setDraftFrom(d ? toISODate(d) : '')}
+                onSelect={(d) => setDraftFrom(d ? localDateString(d) : '')}
               />
             </div>
             <div className="sm:pl-2">
@@ -959,7 +956,7 @@ export function TransactionsFilterBar({
                       : new Date()
                 }
                 locale={dateFnsLocale}
-                onSelect={(d) => setDraftTo(d ? toISODate(d) : '')}
+                onSelect={(d) => setDraftTo(d ? localDateString(d) : '')}
               />
             </div>
           </div>

--- a/frontend/src/components/transfer-dialog.tsx
+++ b/frontend/src/components/transfer-dialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { getAccountLabel } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
+import { localDateString } from '@/lib/date-utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -42,7 +43,7 @@ export function TransferDialog({
   const [fromAccountId, setFromAccountId] = useState(defaultFromAccountId || (accounts[0]?.id ?? ''))
   const [toAccountId, setToAccountId] = useState('')
   const [amount, setAmount] = useState('')
-  const [date, setDate] = useState(new Date().toISOString().split('T')[0])
+  const [date, setDate] = useState(localDateString)
   const [description, setDescription] = useState('')
   const [notes, setNotes] = useState('')
   const [fxRate, setFxRate] = useState('')
@@ -53,7 +54,7 @@ export function TransferDialog({
     setFromAccountId(defaultFromAccountId || (accounts[0]?.id ?? ''))
     setToAccountId('')
     setAmount('')
-    setDate(new Date().toISOString().split('T')[0])
+    setDate(localDateString())
     setDescription('')
     setNotes('')
     setFxRate('')

--- a/frontend/src/lib/date-utils.test.ts
+++ b/frontend/src/lib/date-utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { localDateString } from './date-utils'
+
+describe('localDateString', () => {
+  it('formats the browser-local calendar day', () => {
+    const originalTimezone = process.env.TZ
+
+    try {
+      process.env.TZ = 'America/Los_Angeles'
+      expect(localDateString(new Date('2026-07-01T06:30:00Z'))).toBe('2026-06-30')
+    } finally {
+      if (originalTimezone === undefined) delete process.env.TZ
+      else process.env.TZ = originalTimezone
+    }
+  })
+})

--- a/frontend/src/lib/date-utils.ts
+++ b/frontend/src/lib/date-utils.ts
@@ -1,0 +1,5 @@
+import { format } from 'date-fns'
+
+export function localDateString(date = new Date()) {
+  return format(date, 'yyyy-MM-dd')
+}

--- a/frontend/src/pages/account-detail.tsx
+++ b/frontend/src/pages/account-detail.tsx
@@ -6,6 +6,7 @@ import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
 import { format, addDays, addMonths, parseISO } from 'date-fns'
 import { accounts, transactions, categories as categoriesApi, categoryGroups as categoryGroupsApi } from '@/lib/api'
+import { localDateString } from '@/lib/date-utils'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import type { CreditCardBill, Transaction } from '@/types'
@@ -35,11 +36,11 @@ import {
 
 function defaultFrom() {
   const now = new Date()
-  return format(new Date(now.getFullYear(), now.getMonth(), 1), 'yyyy-MM-dd')
+  return localDateString(new Date(now.getFullYear(), now.getMonth(), 1))
 }
 
 function defaultTo() {
-  return format(new Date(), 'yyyy-MM-dd')
+  return localDateString()
 }
 
 function daysInMonth(year: number, month: number): number {

--- a/frontend/src/pages/accounts.tsx
+++ b/frontend/src/pages/accounts.tsx
@@ -7,6 +7,7 @@ import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { accounts, connections, currencies } from '@/lib/api'
+import { localDateString } from '@/lib/date-utils'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -733,7 +734,7 @@ function AccountDialog({
   const [type, setType] = useState(account?.type ?? 'checking')
   const [balance, setBalance] = useState(account?.balance?.toString() ?? '0')
   const [currency, setCurrency] = useState(account?.currency ?? userCurrency)
-  const [balanceDate, setBalanceDate] = useState(new Date().toISOString().slice(0, 10))
+  const [balanceDate, setBalanceDate] = useState(localDateString)
   const [creditLimit, setCreditLimit] = useState(account?.credit_limit?.toString() ?? '')
   const [statementCloseDay, setStatementCloseDay] = useState(account?.statement_close_day?.toString() ?? '')
   const [paymentDueDay, setPaymentDueDay] = useState(account?.payment_due_day?.toString() ?? '')
@@ -744,7 +745,7 @@ function AccountDialog({
     setType(account?.type ?? 'checking')
     setBalance(account?.balance?.toString() ?? '0')
     setCurrency(account?.currency ?? userCurrency)
-    setBalanceDate(new Date().toISOString().slice(0, 10))
+    setBalanceDate(localDateString())
     setCreditLimit(account?.credit_limit?.toString() ?? '')
     setStatementCloseDay(account?.statement_close_day?.toString() ?? '')
     setPaymentDueDay(account?.payment_due_day?.toString() ?? '')

--- a/frontend/src/pages/assets.tsx
+++ b/frontend/src/pages/assets.tsx
@@ -4,6 +4,7 @@ import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useRegisterPageChatContext } from '@/lib/page-chat-context'
 import { assets, assetGroups, currencies as currenciesApi } from '@/lib/api'
+import { localDateString } from '@/lib/date-utils'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -1973,7 +1974,7 @@ function AssetDetail({ assetId, currency, locale: loc, dateLocale: dateLoc, purc
   const queryClient = useQueryClient()
 
   const [valueAmount, setValueAmount] = useState('')
-  const [valueDate, setValueDate] = useState(new Date().toISOString().slice(0, 10))
+  const [valueDate, setValueDate] = useState(localDateString)
 
   const { data: values, isLoading: valuesLoading } = useQuery({
     queryKey: ['asset-values', assetId],
@@ -2296,7 +2297,7 @@ function AssetTransactionsTab({
   const [formQuantity, setFormQuantity] = useState('')
   const [formPrice, setFormPrice] = useState('')
   const [formFee, setFormFee] = useState('')
-  const [formDate, setFormDate] = useState<string>(new Date().toISOString().slice(0, 10))
+  const [formDate, setFormDate] = useState<string>(localDateString)
 
   function afterChange() {
     queryClient.refetchQueries({ queryKey: ['asset-transactions'] })
@@ -2357,7 +2358,7 @@ function AssetTransactionsTab({
     setFormQuantity('')
     setFormPrice('')
     setFormFee('')
-    setFormDate(new Date().toISOString().slice(0, 10))
+    setFormDate(localDateString())
     setDialogOpen(true)
   }
 
@@ -2381,7 +2382,7 @@ function AssetTransactionsTab({
     setFormQuantity('')
     setFormPrice('')
     setFormFee('')
-    setFormDate(new Date().toISOString().slice(0, 10))
+    setFormDate(localDateString())
     setDialogOpen(true)
   }
 
@@ -2763,7 +2764,7 @@ function AddHoldingTransactionDialog({
   const [quantity, setQuantity] = useState('')
   const [price, setPrice] = useState('')
   const [fee, setFee] = useState('')
-  const [date, setDate] = useState(new Date().toISOString().slice(0, 10))
+  const [date, setDate] = useState(localDateString)
 
   useEffect(() => {
     if (assetId) {
@@ -2771,7 +2772,7 @@ function AddHoldingTransactionDialog({
       setQuantity('')
       setPrice('')
       setFee('')
-      setDate(new Date().toISOString().slice(0, 10))
+      setDate(localDateString())
     }
   }, [assetId])
 

--- a/frontend/src/pages/group-detail.tsx
+++ b/frontend/src/pages/group-detail.tsx
@@ -31,6 +31,7 @@ import {
   type GroupMemberPayload,
   type GroupSettlementPayload,
 } from '@/lib/api'
+import { localDateString } from '@/lib/date-utils'
 import { MemberForm } from '@/components/member-form'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
@@ -287,7 +288,7 @@ export default function GroupDetailPage() {
   const [settleFrom, setSettleFrom] = useState('')
   const [settleTo, setSettleTo] = useState('')
   const [settleAmount, setSettleAmount] = useState('')
-  const [settleDate, setSettleDate] = useState(new Date().toISOString().split('T')[0])
+  const [settleDate, setSettleDate] = useState(localDateString)
   const [settleNotes, setSettleNotes] = useState('')
   const [settleCurrency, setSettleCurrency] = useState('USD')
   // Optional ledger integration for the payer: 'none' records the
@@ -368,7 +369,7 @@ export default function GroupDetailPage() {
     setSettleFrom(from ?? '')
     setSettleTo(to ?? '')
     setSettleAmount(amount != null ? amount.toFixed(2) : '')
-    setSettleDate(new Date().toISOString().split('T')[0])
+    setSettleDate(localDateString())
     setSettleNotes('')
     // Use the line's currency when settling a specific debt, falling
     // back to the group's default for free-form settlements. This

--- a/frontend/src/pages/recurring.tsx
+++ b/frontend/src/pages/recurring.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { categories as categoriesApi, categoryGroups as categoryGroupsApi, recurring as recurringApi, accounts as accountsApi, currencies as currenciesApi } from '@/lib/api'
+import { localDateString } from '@/lib/date-utils'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -298,7 +299,7 @@ function RecurringForm({
   const [type, setType] = useState<'debit' | 'credit'>(recurring?.type ?? 'debit')
   const [frequency, setFrequency] = useState(recurring?.frequency ?? 'monthly')
   const [dayOfMonth, setDayOfMonth] = useState(recurring?.day_of_month?.toString() ?? '')
-  const [startDate, setStartDate] = useState(recurring?.start_date ?? new Date().toISOString().split('T')[0])
+  const [startDate, setStartDate] = useState(recurring?.start_date ?? localDateString())
   const [endDate, setEndDate] = useState(recurring?.end_date ?? '')
   const [categoryId, setCategoryId] = useState(recurring?.category_id ?? '')
   const [accountId, setAccountId] = useState(recurring?.account_id ?? accounts[0]?.id ?? '')


### PR DESCRIPTION
## Summary

- format user-facing form defaults using the browser local calendar day
- share one date helper across transaction, transfer, account, asset, settlement, and recurring forms
- leave UTC download filename timestamps unchanged

## Why

`new Date().toISOString()` produces a UTC day, so users near midnight outside UTC can get yesterday or tomorrow in date inputs.

## Checks

- 37 frontend tests passed
- focused regression passed with outer UTC and Tokyo timezones
- frontend lint passed with existing warnings
- frontend production build passed
- independently reviewed and approved