### PR TITLE
fix: SimpleFIN pending transactions no longer date to the Unix epoch

### DIFF
--- a/backend/app/providers/simplefin.py
+++ b/backend/app/providers/simplefin.py
@@ -380,7 +380,11 @@ class SimpleFinProvider(BankProvider):
             return None
         txn_type = "debit" if amount_raw < 0 else "credit"
         amount = amount_raw.copy_abs()
-        posted = _epoch_to_date(raw.get("posted"))
+        # SimpleFIN sends "posted": 0 (not null) for transactions that haven't
+        # posted yet — a falsy epoch, not a real one, so treat it as unset
+        # rather than letting it resolve to 1970-01-01 and shadow the correct
+        # transacted_at date below.
+        posted = _epoch_to_date(raw.get("posted")) if raw.get("posted") else None
         transacted = _epoch_to_date(raw.get("transacted_at"))
         txn_date = posted or transacted
         if not txn_date:

--- a/backend/tests/test_providers_simplefin.py
+++ b/backend/tests/test_providers_simplefin.py
@@ -79,6 +79,13 @@ def test_epoch_to_date_parses_seconds():
     assert _epoch_to_date(1672531200) == date(2023, 1, 1)
 
 
+def test_epoch_to_date_zero_is_technically_the_epoch():
+    # _epoch_to_date(0) legitimately returns 1970-01-01 — it's callers that
+    # must decide whether 0 means "no value" for their field. See
+    # test_get_transactions_pending_tx_uses_transacted_at_not_epoch below.
+    assert _epoch_to_date(0) == date(1970, 1, 1)
+
+
 # ----- claim flow -------------------------------------------------------------
 
 
@@ -282,6 +289,52 @@ async def test_get_transactions_filters_by_account_and_parses_signs():
     assert by_id["t1"].status == "posted"
     assert by_id["t2"].status == "pending"
     assert by_id["t2"].type == "credit"
+
+
+@pytest.mark.asyncio
+async def test_get_transactions_pending_tx_uses_transacted_at_not_epoch():
+    """A pending tx's "posted": 0 must not shadow the real transacted_at date.
+
+    Regression test for the bug where pending transactions were stored dated
+    1970-01-01 (the Unix epoch), making them invisible in any date-filtered
+    view even though the sync itself succeeded.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "accounts": [
+                    {
+                        "id": "acc-1",
+                        "currency": "USD",
+                        "balance": "0",
+                        "transactions": [
+                            {
+                                "id": "pending-1",
+                                "amount": "-56.28",
+                                "posted": 0,
+                                "transacted_at": 1752624000,  # 2025-07-16 UTC
+                                "pending": True,
+                                "description": "Gas Station",
+                            },
+                        ],
+                    },
+                ]
+            },
+        )
+
+    creds = {"access_url": "https://u:p@bridge.example/simplefin"}
+    provider = SimpleFinProvider()
+    with _patched_client(handler):
+        txns = await provider.get_transactions(
+            creds, "acc-1", since=date(2025, 7, 1)
+        )
+    assert len(txns) == 1
+    txn = txns[0]
+    assert txn.status == "pending"
+    assert txn.date == date(2025, 7, 16)
+    assert txn.date != date(1970, 1, 1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `_epoch_to_date(0)` legitimately returns `1970-01-01` (it's a valid conversion of a real epoch timestamp), but SimpleFIN sends `"posted": 0` — not `null` — specifically to mean *not posted yet*, not "posted at the Unix epoch."
- `posted = _epoch_to_date(raw.get("posted"))` was therefore resolving to a truthy `date(1970, 1, 1)` for every pending transaction, so `posted or transacted` picked that wrong date and never fell through to the correct `transacted_at` value sitting right next to it.
- Net effect: pending transactions synced from SimpleFIN silently get dated to 1970-01-01, making them invisible in any date-filtered view even though the sync completes without error.

## Fix
Treat a falsy `posted` (covers `0`, `None`, missing) as "no posted date yet" before converting, so the fallback to `transacted_at` actually kicks in:

```python
posted = _epoch_to_date(raw.get("posted")) if raw.get("posted") else None
```

## Test plan
- [x] Added `test_get_transactions_pending_tx_uses_transacted_at_not_epoch`, reproducing the exact bug: a pending transaction with `"posted": 0` and a real `transacted_at`, asserting the parsed date matches `transacted_at` and is not `1970-01-01`.
- [x] Added `test_epoch_to_date_zero_is_technically_the_epoch` documenting that `_epoch_to_date(0)` itself is correct — the bug is in the caller treating that as meaningful rather than in the helper.
- [x] Full `backend/tests/test_providers_simplefin.py` suite passes (20/20) locally.
- [x] `ruff check` clean on both changed files.

Fixes #447