### PR TITLE
fix(frontend): show loading feedback during login

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { Toaster } from '@/components/ui/sonner'
 import { ThemeProvider } from '@/components/theme-provider'
 import { AuthProvider } from '@/contexts/auth-context'
@@ -48,9 +49,12 @@ const queryClient = new QueryClient({
 })
 
 function LoadingFallback() {
+  const { t } = useTranslation()
+
   return (
-    <div className="flex items-center justify-center min-h-[50vh]">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+    <div className="flex flex-col items-center justify-center gap-3 min-h-[50vh]" role="status">
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" aria-hidden="true" />
+      <span className="text-sm text-muted-foreground">{t('common.loading')}</span>
     </div>
   )
 }

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -154,6 +154,15 @@ export default function LoginPage() {
     setError('')
   }
 
+  if (token) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 min-h-screen" role="status">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" aria-hidden="true" />
+        <span className="text-sm text-muted-foreground">{t('common.loading')}</span>
+      </div>
+    )
+  }
+
   const handlePasskeySecondFactor = async () => {
     setError('')
     setIsPasskeyLoading(true)


### PR DESCRIPTION
## Intent

The developer wanted to diagnose an email/password login experience where navigation appeared delayed, verify it in browser automation, and improve feedback after successful authentication. The identified requirement was to keep the immediate redirect to the homepage while showing an accessible localized loading message during the slow lazy-loaded dashboard transition. They then asked to preserve only that login loading-feedback change, create a branch and commit it without pushing, and configure no-mistakes globally to use OpenCode.

## What Changed
- Add an accessible, localized loading message to lazy route transition fallbacks.
- Show the same loading state on the login page immediately after authentication while the dashboard route loads.

## Risk Assessment

✅ Low: The six-line fallback enhancement reuses an existing translated key and adds appropriate status semantics without altering authentication or routing behavior.

## Testing

The focused browser flow authenticated through the login form, held the lazy dashboard module for five seconds, and captured the full-screen localized loading status after the URL redirected to `/`; the targeted locale test also passed. Temporary frontend dependencies and test servers were removed, leaving the worktree clean.

- Evidence: Post-login loading feedback during delayed dashboard transition (local file: <code>/var/folders/lj/7tbhd0yj3312vf38b7x7x_800000gp/T/no-mistakes-evidence/01KY5MDD39HZK5DZC30877PET0/login-loading-feedback.png</code>)
<details>
<summary>Evidence: Captured route and accessible loading status</summary>

```text
{
  "url": "http://127.0.0.1:5173/",
  "status": "Loading..."
}
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (14m14s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `frontend/src/App.tsx:55` - The new Suspense fallback is not shown during an email/password login transition. Chromium automation delayed the dashboard module after successful authentication; the URL changed immediately to `/`, but the rendered page remained the login form, with no `role=&#34;status&#34;` or &#34;Loading...&#34; text. The user receives no loading feedback during the intended slow transition.
- `cd frontend && npm test -- --run src/locales/i18n.test.ts`
- <code>`cd frontend &amp;&amp; npm run dev -- --host 127.0.0.1 --port 5173` with Chromium automation that mocked successful email/password authentication and delayed `src/pages/dashboard.tsx` by 2.5 seconds</code>
- <code>`cd frontend &amp;&amp; node login-loading-feedback.e2e.mjs` (temporary verification script; removed after execution)</code>

🔧 Fix: Show loading feedback after login authentication
✅ Re-checked - no issues remain.
- `git diff 4c3b8cc92342e40971049510d9c6bbe73b74a9e5 7695ae157b5ad977372c33f65c32d19624761b58`
- <code>`node /var/folders/lj/7tbhd0yj3312vf38b7x7x_800000gp/T/no-mistakes-evidence/01KY5MDD39HZK5DZC30877PET0/login-loading-evidence.mjs` - mocked successful email/password login, delayed `dashboard.tsx`, confirmed the browser navigated to `/` and exposed `role=status` with `Loading...`</code>
- `npm test -- src/locales/i18n.test.ts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
