### PR TITLE
fix: convert enable banking consent validity from seconds to days

### DIFF
--- a/backend/app/providers/enable_banking.py
+++ b/backend/app/providers/enable_banking.py
@@ -299,6 +299,9 @@ class EnableBankingProvider(BankProvider):
             inst_country = (item.get("country") or "").upper()
             if inst_country:
                 countries.add(inst_country)
+            if (maximum_consent_validity := item.get("maximum_consent_validity", None)) is not None:
+                maximum_consent_validity = timedelta(seconds=maximum_consent_validity).days
+
             institutions.append(
                 InstitutionData(
                     name=item.get("name") or "",
@@ -307,7 +310,7 @@ class EnableBankingProvider(BankProvider):
                     logo=item.get("logo"),
                     bic=item.get("bic"),
                     psu_types=list(item.get("psu_types") or []),
-                    max_consent_days=item.get("maximum_consent_validity"),
+                    max_consent_days=maximum_consent_validity,
                 )
             )
         institutions.sort(key=lambda i: (i.country, i.display_name.lower()))

--- a/backend/tests/test_providers_enable_banking.py
+++ b/backend/tests/test_providers_enable_banking.py
@@ -167,7 +167,7 @@ async def test_list_institutions_maps_and_dedupes_countries(eb_keys):
                         "logo": "https://l/revolut.png",
                         "bic": "REVOLT21",
                         "psu_types": ["personal"],
-                        "maximum_consent_validity": 180,
+                        "maximum_consent_validity": 15552000,
                     },
                     {"name": "Sparkasse", "country": "DE"},
                     {"name": "BNP Paribas", "country": "FR"},

--- a/frontend/src/components/oauth-connect-dialog.tsx
+++ b/frontend/src/components/oauth-connect-dialog.tsx
@@ -15,6 +15,7 @@ type Institution = {
   name: string
   display_name: string
   country: string
+  max_consent_days?: number | null
   logo?: string | null
 }
 
@@ -108,6 +109,7 @@ export function OAuthConnectDialog({ open, onClose, provider, supportsAssetSync 
       const url = await connections.getOAuthUrl(provider, {
         country,
         institution_name: institution.name,
+        valid_until_days: institution.max_consent_days,
         ...(supportsAssetSync ? { sync_assets: syncAssets } : {}),
       })
       window.location.assign(url)


### PR DESCRIPTION
## What

Enable Banking returns maximum_consent_validity in seconds (as documented in the ASPs data reference [here](https://enablebanking.com/docs/api/reference/#aspspdata)), but the code was incorrectly treating the raw value as days. This change converts the value using timedelta(seconds=...).days before storing it.

Additionally, this PR ensures that valid_until_days is passed to getOAuthUrl, so the configured consent validity is correctly applied when generating the OAuth URL.

## Why

While attempting to add Trade Republic through Enable Banking, I encountered an error indicating that the consent validity could not exceed 90 days.

After investigating the issue, I found that the validity value was being stored incorrectly. Additionally, we were not passing the configured validity when invoking the Enable Banking API, causing it to fall back to the default value of 180 days. This PR fixes both issues by correctly storing the configured validity and ensuring it is included in the API request.

## How to Test

Steps to verify the changes work:

1. Set up the Enable Banking sandbox application
3. Define Enable Banking environment variables in the .env file
4. Add a bank integration by selecting a mock bank
6. Test the failure by adding one more day, like `max_consent_days=maximum_consent_validity+1,`

## Related Issue

Closes #___ (or link the issue this addresses).

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
- [ ] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))
