### PR TITLE
fix: preserve regex pattern case in rule engine matching

### DIFF
--- a/backend/app/services/rule_engine.py
+++ b/backend/app/services/rule_engine.py
@@ -10,11 +10,15 @@ if TYPE_CHECKING:
     from app.models.transaction import Transaction
 
 
+def _strip_accents(text: str) -> str:
+    """Remove diacritics (accents), preserving case."""
+    nfkd = unicodedata.normalize("NFKD", text)
+    return "".join(c for c in nfkd if not unicodedata.combining(c))
+
+
 def _normalize(text: str) -> str:
     """Normalize text: uppercase and remove diacritics (accents)."""
-    upper = text.upper()
-    nfkd = unicodedata.normalize("NFKD", upper)
-    return "".join(c for c in nfkd if not unicodedata.combining(c))
+    return _strip_accents(text.upper())
 
 
 def _to_decimal(val) -> Decimal:
@@ -63,8 +67,11 @@ def _match_condition(condition: dict, tx: "Transaction") -> bool:
             return tx_str != val_str
         if op == "regex":
             try:
-                # Normalize both sides so accents don't break matches
-                pattern = _normalize(str(value or ""))
+                # Strip accents from the pattern so it lines up with the
+                # normalized text, but keep its case: uppercasing a regex
+                # inverts escape classes (\s -> \S, \b -> \B, \d -> \D) and
+                # breaks inline flags. Case is already handled by IGNORECASE.
+                pattern = _strip_accents(str(value or ""))
                 return bool(re.search(pattern, tx_str, re.IGNORECASE))
             except re.error:
                 return False

--- a/backend/tests/test_rule_engine.py
+++ b/backend/tests/test_rule_engine.py
@@ -77,6 +77,56 @@ def test_regex():
     assert evaluate_conditions("and", conditions, tx) is True
 
 
+def test_regex_whitespace_class():
+    conditions = [{"field": "description", "op": "regex", "value": r"PIX\s+RECEBIDO"}]
+    tx = make_tx(description="PIX RECEBIDO JOAO")
+    assert evaluate_conditions("and", conditions, tx) is True
+
+
+def test_regex_digit_class():
+    conditions = [{"field": "description", "op": "regex", "value": r"NOTA \d+"}]
+    tx = make_tx(description="OPERACOES EM BOLSA NOTA 123884393")
+    assert evaluate_conditions("and", conditions, tx) is True
+
+
+def test_regex_word_boundary():
+    conditions = [{"field": "description", "op": "regex", "value": r"\bCDB\b"}]
+    tx = make_tx(description="VENCIMENTO CDB BANCO MASTER")
+    assert evaluate_conditions("and", conditions, tx) is True
+
+
+def test_regex_word_boundary_no_match():
+    conditions = [{"field": "description", "op": "regex", "value": r"\bCDB\b"}]
+    tx = make_tx(description="COMPRA CDB321LQ8I6 RESGATE")
+    assert evaluate_conditions("and", conditions, tx) is False
+
+
+def test_regex_negative_lookahead_with_whitespace():
+    conditions = [
+        {"field": "description", "op": "regex", "value": r"RESGATE(?!\s+PONTOS)"}
+    ]
+    assert evaluate_conditions("and", conditions, make_tx(description="RESGATE RDB")) is True
+    assert evaluate_conditions("and", conditions, make_tx(description="RESGATE PONTOS")) is False
+
+
+def test_regex_inline_flag_is_valid():
+    conditions = [{"field": "description", "op": "regex", "value": "(?i)uber"}]
+    tx = make_tx(description="UBER TRIP")
+    assert evaluate_conditions("and", conditions, tx) is True
+
+
+def test_regex_lowercase_pattern_still_matches():
+    conditions = [{"field": "description", "op": "regex", "value": "pix.*recebido"}]
+    tx = make_tx(description="PIX RECEBIDO JOAO")
+    assert evaluate_conditions("and", conditions, tx) is True
+
+
+def test_regex_accented_pattern_still_matches():
+    conditions = [{"field": "description", "op": "regex", "value": "APLICAÇÃO"}]
+    tx = make_tx(description="APLICACAO EM CDB")
+    assert evaluate_conditions("and", conditions, tx) is True
+
+
 def test_amount_lt():
     conditions = [{"field": "amount", "op": "lt", "value": 50}]
     tx = make_tx(amount=Decimal("25.50"))


### PR DESCRIPTION
## What

The `regex` operator in the rule engine ran `_normalize()` on the user's pattern as well as on the transaction text. `_normalize()` uppercases, which silently inverts every lowercase escape class in the pattern:

```
\s -> \S      \d -> \D      \w -> \W      \b -> \B
```

so the pattern ends up meaning the opposite of what was written. Inline flags are corrupted too (`(?i)` -> `(?I)`), raising a `re.error` that is swallowed into a silent non-match. `\s` cannot be expressed at all, because `\S` uppercases to itself.

This PR strips accents from the pattern **without** changing its case. Case-insensitive matching is already provided by the `re.IGNORECASE` flag passed to `re.search()`, so the uppercase step was redundant for literals and destructive for metacharacters. Text normalization is unchanged.

## Why it matters

The built-in **Investimentos (Aplicação / Resgate)** rule ships with `\bCDB\b`, `\bLCA\b` and `\bLCI\b`, which execute as non-word-boundary assertions. That breaks in both directions.

False negatives, left uncategorized:

```
Vencimento CDB1258I64U | CDB BANCO XP S.A. - JAN/2026
Vencimento CDB321LQ8I6 | CDB BANCO MASTER S/A - SET/2025
IR - Vencimento CDB4183KHGS | CDB FIBRA - OUT/2025
```

False positives, wrongly categorized as investments because the token is embedded in a longer word:

```
"BRASILCAP CAPITALIZACAO SA"     \BLCA\B matches brasi(LCA)p
"ALCIDES JOSE CANDIDO NETO"      \BLCI\B matches a(LCI)des
```

Measured across 577 distinct descriptions from a real account: 10 transactions wrongly excluded, 2 wrongly included.

## Scope

`Investimentos` is the only built-in rule using escape classes, so no other default rule changes behaviour. User-defined rules that relied on plain literals are unaffected; ones using `\s`, `\d`, `\w` or `\b` start behaving as written.

## Tests

Adds regression coverage to `backend/tests/test_rule_engine.py` for `\s`, `\d`, `\b` (matching and non-matching), negative lookahead containing `\s`, inline flags, lowercase patterns and accented patterns.

Against `main` these fail 5/10; with the fix the file passes 58/58.

Closes #463