### PR TITLE
fix(frontend): keep category actions visible in short viewports

### DIFF
--- a/frontend/src/pages/categories.tsx
+++ b/frontend/src/pages/categories.tsx
@@ -264,7 +264,7 @@ export default function CategoriesPage() {
 
       {/* Category Dialog */}
       <Dialog open={catDialogOpen} onOpenChange={() => { setCatDialogOpen(false); setEditingCat(null) }}>
-        <DialogContent>
+        <DialogContent className="flex max-h-[calc(100dvh-2rem)] flex-col overflow-hidden">
           <DialogHeader>
             <DialogTitle>{editingCat ? t('categories.editCategory') : t('categories.newCategory')}</DialogTitle>
           </DialogHeader>
@@ -287,61 +287,63 @@ export default function CategoriesPage() {
                 createCatMutation.mutate(data)
               }
             }}
-            className="space-y-4"
+            className="flex min-h-0 flex-1 flex-col"
           >
-            <div className="space-y-2">
-              <Label>{t('groups.name')}</Label>
-              <Input name="name" defaultValue={editingCat?.name ?? ''} required />
+            <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-3">
+              <div className="space-y-2">
+                <Label>{t('groups.name')}</Label>
+                <Input name="name" defaultValue={editingCat?.name ?? ''} required />
+              </div>
+              <div className="space-y-2">
+                <Label>{t('categories.group')}</Label>
+                <select
+                  name="group_id"
+                  defaultValue={editingCat?.group_id ?? ''}
+                  className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                >
+                  <option value="">{t('categories.noGroup')}</option>
+                  {groups?.map((g) => (
+                    <option key={g.id} value={g.id}>{g.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label>{t('groups.color')}</Label>
+                <Input name="color" type="color" value={formColor} onChange={(e) => setFormColor(e.target.value)} required className="h-9 px-2 py-1" />
+              </div>
+              <div className="space-y-2">
+                <Label>{t('groups.icon')}</Label>
+                <IconPicker value={formIcon} color={formColor} onChange={setFormIcon} />
+                <input type="hidden" name="icon" value={formIcon} />
+              </div>
+              <div className="pt-2 border-t border-border">
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={formTreatAsTransfer}
+                    onChange={(e) => setFormTreatAsTransfer(e.target.checked)}
+                    className="h-4 w-4 mt-0.5 rounded border-border shrink-0"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <span className="text-sm font-medium text-foreground">{t('categories.treatAsTransfer')}</span>
+                    <p className="text-xs text-muted-foreground mt-0.5">{t('categories.treatAsTransferDesc')}</p>
+                  </div>
+                </label>
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={formIgnoreTransfer}
+                    onChange={(e) => setFormIgnoreTransfer(e.target.checked)}
+                    className="h-4 w-4 mt-0.5 rounded border-border shrink-0"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <span className="text-sm font-medium text-foreground">{t('categories.ignoreTransfer')}</span>
+                    <p className="text-xs text-muted-foreground mt-0.5">{t('categories.ignoreTransferDesc')}</p>
+                  </div>
+                </label>
+              </div>
             </div>
-            <div className="space-y-2">
-              <Label>{t('categories.group')}</Label>
-              <select
-                name="group_id"
-                defaultValue={editingCat?.group_id ?? ''}
-                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-              >
-                <option value="">{t('categories.noGroup')}</option>
-                {groups?.map((g) => (
-                  <option key={g.id} value={g.id}>{g.name}</option>
-                ))}
-              </select>
-            </div>
-            <div className="space-y-2">
-              <Label>{t('groups.color')}</Label>
-              <Input name="color" type="color" value={formColor} onChange={(e) => setFormColor(e.target.value)} required className="h-9 px-2 py-1" />
-            </div>
-            <div className="space-y-2">
-              <Label>{t('groups.icon')}</Label>
-              <IconPicker value={formIcon} color={formColor} onChange={setFormIcon} />
-              <input type="hidden" name="icon" value={formIcon} />
-            </div>
-            <div className="pt-2 border-t border-border">
-              <label className="flex items-start gap-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={formTreatAsTransfer}
-                  onChange={(e) => setFormTreatAsTransfer(e.target.checked)}
-                  className="h-4 w-4 mt-0.5 rounded border-border shrink-0"
-                />
-                <div className="flex-1 min-w-0">
-                  <span className="text-sm font-medium text-foreground">{t('categories.treatAsTransfer')}</span>
-                  <p className="text-xs text-muted-foreground mt-0.5">{t('categories.treatAsTransferDesc')}</p>
-                </div>
-              </label>
-              <label className="flex items-start gap-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={formIgnoreTransfer}
-                  onChange={(e) => setFormIgnoreTransfer(e.target.checked)}
-                  className="h-4 w-4 mt-0.5 rounded border-border shrink-0"
-                />
-                <div className="flex-1 min-w-0">
-                  <span className="text-sm font-medium text-foreground">{t('categories.ignoreTransfer')}</span>
-                  <p className="text-xs text-muted-foreground mt-0.5">{t('categories.ignoreTransferDesc')}</p>
-                </div>
-              </label>
-            </div>
-            <DialogFooter>
+            <DialogFooter className="mt-2 shrink-0 border-t pt-4">
               <Button type="button" variant="outline" onClick={() => { setCatDialogOpen(false); setEditingCat(null) }}>
                 {t('common.cancel')}
               </Button>


### PR DESCRIPTION
## What

- constrain the category dialog to the available viewport height
- keep the dialog footer and save action visible while the form body scrolls

### Before

At the affected `1264x629` effective viewport, the 757 px dialog started at
`-64 px`, while the save button started at `632 px`, outside the visible area.

<img width="640" alt="Category dialog clipped before the fix at 1264x629" src="https://github.com/user-attachments/assets/92a257e7-5ef8-4bc4-b1cd-13ea5f0dbbcd" />

### After

The dialog is capped at `100dvh - 2rem`. The form body scrolls independently,
while the title and footer remain visible. In every viewport below, the dialog,
title, Cancel, and Save actions stay within the viewport, the footer remains
stationary while the form body scrolls, and no horizontal page overflow occurs.

| Profile | Resolution | Evidence |
| --- | --- | --- |
| Wide desktop | `1920x1080` | <img width="320" alt="Category dialog at 1920x1080" src="https://github.com/user-attachments/assets/9fd87a48-ccbf-4d5d-85e4-1bcf1a68cc9c" /> |
| Desktop | `1440x900` | <img width="320" alt="Category dialog at 1440x900" src="https://github.com/user-attachments/assets/3860781a-44a4-4598-b045-a43470e85b28" /> |
| Laptop | `1366x768` | <img width="320" alt="Category dialog at 1366x768" src="https://github.com/user-attachments/assets/3780b5c3-12b4-4513-aeb9-1930922ea5ab" /> |
| Original failure condition | `1264x629` | <img width="320" alt="Category dialog at 1264x629" src="https://github.com/user-attachments/assets/3f5be856-26dd-46c5-abe7-2ba571275e63" /> |
| Tablet landscape | `1024x768` | <img width="320" alt="Category dialog at 1024x768" src="https://github.com/user-attachments/assets/a1188b25-bb8a-4a08-bba4-a39281ae31e2" /> |
| Tablet portrait | `820x1180` | <img width="220" alt="Category dialog at 820x1180" src="https://github.com/user-attachments/assets/f2b3ebab-f964-4af0-87f5-47f8b2d9a48f" /> |
| Tablet portrait compact | `768x1024` | <img width="220" alt="Category dialog at 768x1024" src="https://github.com/user-attachments/assets/194ae557-aa4f-43e8-91a4-2d16ebbdb03d" /> |
| Mobile landscape | `844x390` | <img width="320" alt="Category dialog at 844x390" src="https://github.com/user-attachments/assets/2ddb9046-f1bc-45d7-b8d2-a9982e805639" /> |
| Large mobile | `430x932` | <img width="200" alt="Category dialog at 430x932" src="https://github.com/user-attachments/assets/ee92c5ee-bb1d-4e79-a2ec-b1015cfc1388" /> |
| Mobile | `390x844` | <img width="200" alt="Category dialog at 390x844" src="https://github.com/user-attachments/assets/dd0f4f5f-7eb3-4ad6-828b-7d503ce97bb8" /> |
| Small mobile | `360x800` | <img width="190" alt="Category dialog at 360x800" src="https://github.com/user-attachments/assets/81f4266a-dc1e-4d68-9f06-0387afd4752f" /> |
| Minimum mobile | `320x568` | <img width="180" alt="Category dialog at 320x568" src="https://github.com/user-attachments/assets/baf062b7-4e66-463d-9cf8-31d5d1651ba4" /> |

## Why

Short effective viewports — including desktop windows with browser zoom — could
make the category dialog taller than the screen. The centered dialog was clipped
at both ends, so users could not reach the save action without changing their
display or zoom settings.

## How to Test

1. Open **Categories**.
2. Open **Add Category** without submitting the form.
3. Resize or emulate one of the viewports in the table above.
4. Verify the dialog title and footer stay inside the viewport.
5. Scroll the form body and verify the Save action remains visible and stationary.
6. Verify the page does not gain horizontal overflow.

Checks:

- `npm run lint` (passes with existing repository warnings)
- `npm run build`
- `npm test` (40 tests)

## Related Issue

Closes #467

## Checklist

- [ ] Backend tests pass (`pytest`) — not run; frontend-only change
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (not applicable; no user-facing strings changed)
- [x] For a large or core change, I discussed it first (not applicable; focused UI bug fix)
