### PR TITLE
fix: stop badging non-recurring transactions as RECURRING

### DIFF
--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -25,7 +25,7 @@ celery_app.conf.beat_schedule = {
     },
     "generate-recurring-daily": {
         "task": "app.tasks.recurring_tasks.generate_all_recurring",
-        "schedule": 60 * 60,  # every hour; generate_pending is idempotent (advances next_occurrence)
+        "schedule": 60,  # every minute (base2 local testing); generate_pending is idempotent (advances next_occurrence)
     },
     "apply-asset-growth-daily": {
         "task": "app.tasks.asset_tasks.apply_asset_growth_rules",

--- a/frontend/src/pages/account-detail.tsx
+++ b/frontend/src/pages/account-detail.tsx
@@ -716,8 +716,13 @@ export default function AccountDetailPage() {
     let running = endBalance
     return sorted.map((tx) => {
       const balanceAtPoint = running
-      const amt = usePrimary && tx.amount_primary != null ? Number(tx.amount_primary) : Number(tx.amount)
-      running -= tx.type === 'credit' ? amt : -amt
+      // Mirror the backend's balance exclusion (account_service.py: tx.is_ignored
+      // or tx.category.is_ignored) — those rows never counted toward endBalance,
+      // so walking past them must not shift it either.
+      if (!tx.is_ignored && !tx.category?.is_ignored) {
+        const amt = usePrimary && tx.amount_primary != null ? Number(tx.amount_primary) : Number(tx.amount)
+        running -= tx.type === 'credit' ? amt : -amt
+      }
       return { ...tx, runningBalance: balanceAtPoint }
     })
   }, [txData, summary, isCreditCard, balanceHistory, usePrimary])

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -966,11 +966,10 @@ export default function TransactionsPage() {
               </span>
                             )
             }
-            {(tx.recurring_transaction_id != null ||
-              recurringList?.some(r => r.description === tx.description && r.type === tx.type)) && (
+            {tx.recurring_transaction_id != null && (
               <span
                 className="text-[10px] font-semibold uppercase tracking-wide text-primary bg-primary/5 border border-primary/10 px-1.5 py-0.5 rounded-full"
-                title={tx.recurring_transaction_id != null ? t('transactions.recurringLinkedTooltip') : undefined}
+                title={t('transactions.recurringLinkedTooltip')}
               >
                 {t('transactions.recurringBadge')}
               </span>


### PR DESCRIPTION
## Summary
- Stop the frontend from marking non-recurring transactions with a RECURRING badge (false positive).
- Run the recurring-transaction generation job every minute for local testing.
- Exclude ignored transactions/categories from the account-detail running balance calculation, matching the backend's endBalance exclusion.

## Test plan
- [ ] Verify RECURRING badge only shows on transactions the backend actually flags as recurring.
- [ ] Verify account detail running balance matches endBalance when ignored transactions/categories are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)