### PR TITLE
fix: Order categories by name in CategoryGroup model

### DIFF
--- a/backend/app/models/category_group.py
+++ b/backend/app/models/category_group.py
@@ -27,4 +27,7 @@ class CategoryGroup(Base):
     is_system: Mapped[bool] = mapped_column(Boolean, default=False)
 
     user: Mapped["User"] = relationship(back_populates="category_groups")
-    categories: Mapped[list["Category"]] = relationship(back_populates="group")
+    categories: Mapped[list["Category"]] = relationship(
+        back_populates="group",
+        order_by="Category.name",
+    )

--- a/backend/tests/test_category_service.py
+++ b/backend/tests/test_category_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.category import Category
 from app.models.category_group import CategoryGroup
 from app.schemas.category import CategoryCreate, CategoryUpdate
+from app.services.category_group_service import get_groups
 from app.services.category_service import (
     DEFAULT_CATEGORIES_I18N,
     create_category,
@@ -140,6 +141,17 @@ async def test_get_categories_ordered(session: AsyncSession, test_user, test_wor
         system_idx = categories.index(system_cats[0])
         custom_idx = categories.index(custom_cats[0])
         assert system_idx < custom_idx
+
+
+@pytest.mark.asyncio
+async def test_get_categories_group_ordered_by_name(session: AsyncSession, test_user, test_workspace):
+    await create_default_categories(session, test_user.id, lang="pt-BR")
+
+    groups = await get_groups(session, test_workspace.id)
+    food_group = [g for g in groups if g.name == "Alimentação"][0]
+
+    names = [c.name for c in food_group.categories]
+    assert names == sorted(names)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Added ordering to categories relationship by Category.name.

## What

Adds `order_by="Category.name"` to the `CategoryGroup.categories` relationship (`backend/app/models/category_group.py`), so child categories come back alphabetically sorted by name whenever the relationship is loaded — including the `selectinload` used in `category_group_service.get_groups`.

## Why

Better interface organization(Actually, I have OCD).

## How to Test

Steps to verify the changes work:

1. Run the local stack (`docker compose up --build`).
2. Create a new workspace (or use an existing one) with default categories, and optionally add a few custom categories out of alphabetical order.
3. Go to Settings → Categories in the frontend.
4. Confirm categories within each group appear in alphabetical order by name.

## Checklist

- [X] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
- [X] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))
