### PR TITLE
fix: prevent date field self-shadowing in AssetTransactionUpdate

### DIFF
--- a/backend/app/schemas/asset.py
+++ b/backend/app/schemas/asset.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date, datetime
+from datetime import date as _date, datetime
 from decimal import Decimal
 from typing import Optional
 
@@ -12,15 +12,15 @@ class AssetCreate(BaseModel):
     currency: str = "USD"
     units: Optional[Decimal] = None
     valuation_method: str = "manual"
-    purchase_date: Optional[date] = None
+    purchase_date: Optional[_date] = None
     purchase_price: Optional[Decimal] = None
-    sell_date: Optional[date] = None
+    sell_date: Optional[_date] = None
     sell_price: Optional[Decimal] = None
     current_value: Optional[Decimal] = None  # convenience: creates initial AssetValue
     growth_type: Optional[str] = None
     growth_rate: Optional[Decimal] = None
     growth_frequency: Optional[str] = None
-    growth_start_date: Optional[date] = None
+    growth_start_date: Optional[_date] = None
     is_archived: bool = False
     position: int = 0
     group_id: Optional[uuid.UUID] = None
@@ -28,7 +28,7 @@ class AssetCreate(BaseModel):
     # fetches the live quote on create and seeds the first AssetValue.
     ticker: Optional[str] = None
     ticker_exchange: Optional[str] = None
-    maturity_date: Optional[date] = None
+    maturity_date: Optional[_date] = None
     # Per-unit price for the opening buy of a market-priced holding (preço
     # médio model, consistent with the transaction ledger). When omitted, the
     # service seeds the buy at the live quote ("bought at market now").
@@ -41,14 +41,14 @@ class AssetUpdate(BaseModel):
     currency: Optional[str] = None
     units: Optional[Decimal] = None
     valuation_method: Optional[str] = None
-    purchase_date: Optional[date] = None
+    purchase_date: Optional[_date] = None
     purchase_price: Optional[Decimal] = None
-    sell_date: Optional[date] = None
+    sell_date: Optional[_date] = None
     sell_price: Optional[Decimal] = None
     growth_type: Optional[str] = None
     growth_rate: Optional[Decimal] = None
     growth_frequency: Optional[str] = None
-    growth_start_date: Optional[date] = None
+    growth_start_date: Optional[_date] = None
     is_archived: Optional[bool] = None
     position: Optional[int] = None
     # Use a sentinel to differentiate "don't change group" (field omitted)
@@ -67,14 +67,14 @@ class AssetRead(BaseModel):
     currency: str
     units: Optional[float] = None
     valuation_method: str
-    purchase_date: Optional[date] = None
+    purchase_date: Optional[_date] = None
     purchase_price: Optional[float] = None
-    sell_date: Optional[date] = None
+    sell_date: Optional[_date] = None
     sell_price: Optional[float] = None
     growth_type: Optional[str] = None
     growth_rate: Optional[float] = None
     growth_frequency: Optional[str] = None
-    growth_start_date: Optional[date] = None
+    growth_start_date: Optional[_date] = None
     is_archived: bool
     position: int
     current_value: Optional[float] = None
@@ -85,7 +85,7 @@ class AssetRead(BaseModel):
     source: str = "manual"
     connection_id: Optional[uuid.UUID] = None
     isin: Optional[str] = None
-    maturity_date: Optional[date] = None
+    maturity_date: Optional[_date] = None
     group_id: Optional[uuid.UUID] = None
     ticker: Optional[str] = None
     ticker_exchange: Optional[str] = None
@@ -109,7 +109,7 @@ class AssetTransactionCreate(BaseModel):
     quantity: Decimal
     price: Decimal
     fee: Decimal = Decimal("0")
-    date: date
+    date: _date
     notes: Optional[str] = None
 
 
@@ -118,7 +118,7 @@ class AssetTransactionUpdate(BaseModel):
     quantity: Optional[Decimal] = None
     price: Optional[Decimal] = None
     fee: Optional[Decimal] = None
-    date: Optional[date] = None
+    date: Optional[_date] = None
     notes: Optional[str] = None
 
 
@@ -129,7 +129,7 @@ class AssetBuyCreate(BaseModel):
     quantity: Decimal
     price: Decimal
     fee: Decimal = Decimal("0")
-    date: date
+    date: _date
     name: Optional[str] = None
     group_id: Optional[uuid.UUID] = None
     notes: Optional[str] = None
@@ -142,7 +142,7 @@ class AssetTransactionRead(BaseModel):
     quantity: float
     price: float
     fee: float
-    date: date
+    date: _date
     source: str
     notes: Optional[str] = None
     # Denormalized holding context so the global transactions tab can render
@@ -180,14 +180,14 @@ class MarketSymbolMatch(BaseModel):
 
 class AssetValueCreate(BaseModel):
     amount: Decimal
-    date: date
+    date: _date
 
 
 class AssetValueRead(BaseModel):
     id: uuid.UUID
     asset_id: uuid.UUID
     amount: float
-    date: date
+    date: _date
     source: str
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/test_asset_transactions_api.py
+++ b/backend/tests/test_asset_transactions_api.py
@@ -104,6 +104,39 @@ async def test_update_and_delete_transaction_via_api(
 
 
 @pytest.mark.asyncio
+async def test_update_transaction_all_fields_via_api(
+    client: AsyncClient, auth_headers: dict, market_asset_api: Asset
+):
+    r = await client.post(
+        f"/api/assets/{market_asset_api.id}/transactions",
+        headers=auth_headers,
+        json={"kind": "buy", "quantity": 10, "price": 20, "date": "2026-01-01"},
+    )
+    assert r.status_code == 201
+    tx_id = (
+        await client.get(f"/api/assets/{market_asset_api.id}/transactions", headers=auth_headers)
+    ).json()[0]["id"]
+
+    r = await client.patch(
+        f"/api/assets/transactions/{tx_id}",
+        headers=auth_headers,
+        json={"kind": "buy", "quantity": 119, "price": 43.47, "fee": 0, "date": "2025-04-15"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["units"] == 119
+    assert round(body["average_price"], 2) == 43.47
+
+    r = await client.get(f"/api/assets/{market_asset_api.id}/transactions", headers=auth_headers)
+    tx = r.json()[0]
+    assert tx["kind"] == "buy"
+    assert tx["quantity"] == 119
+    assert round(tx["price"], 2) == 43.47
+    assert tx["fee"] == 0
+    assert tx["date"] == "2025-04-15"
+
+
+@pytest.mark.asyncio
 async def test_buy_consolidates_existing_ticker_via_api(
     client: AsyncClient, auth_headers: dict, session: AsyncSession, market_asset_api: Asset
 ):


### PR DESCRIPTION
## What

Fixes `AssetTransactionUpdate` (`backend/app/schemas/asset.py`) so `PATCH /api/assets/transactions/{tx_id}` can actually accept a `date` value, and adds a regression test covering a full-field transaction update.

## Why

The field `date: Optional[date] = None` shadowed itself: Python binds the default `None` to the class attribute `date` before evaluating the `Optional[date]` annotation, so the annotation resolved to `None` instead of `datetime.date`. Pydantic then required the field to always be `None`, meaning any PATCH request that included a `date` was rejected with a 422 — transaction dates could never be updated through this endpoint. Aliasing the import (`from datetime import date as _date`) and using `_date` throughout the schema file avoids the name collision.

## How to Test

1. Run the backend test suite: `pytest backend/tests/test_asset_transactions_api.py -v`
2. Manually:
   - `POST /api/assets/{asset_id}/transactions` with `{"kind": "buy", "quantity": 10, "price": 20, "date": "2026-01-01"}`
   - `PATCH /api/assets/transactions/{tx_id}` with `{"kind": "buy", "quantity": 119, "price": 43.47, "fee": 0, "date": "2025-04-15"}`
   - Confirm the response is `200` and the transaction's date is updated to `2025-04-15` (previously returned `422`).

## Related Issue

Closes #481

## Checklist

- [x] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`) - N/A, backend-only change
- [ ] Frontend builds (`npm run build`) - N/A, backend-only change
- [ ] Translations updated (if user-facing strings changed) - N/A, no user-facing strings changed
- [x] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes)) - filed #481 first with root-cause analysis before opening this PR
