### PR TITLE
feat(currency): add Ukrainian Hryvnia (UAH) support

### DIFF
--- a/backend/app/api/currencies.py
+++ b/backend/app/api/currencies.py
@@ -34,6 +34,7 @@ CURRENCY_META = {
     "RUB": {"symbol": "₽", "name": "Russian Ruble", "flag": "\U0001F1F7\U0001F1FA"},
     "GTQ": {"symbol": "Q", "name": "Guatemalan Quetzal", "flag": "\U0001F1EC\U0001F1F9"},
     "PHP": {"symbol": "₱", "name": "Philippine Peso", "flag": "\U0001F1F5\U0001F1ED"},
+    "UAH": {"symbol": "₴", "name": "Ukrainian Hryvnia", "flag": "\U0001F1FA\U0001F1E6"},
 }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ,PHP"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ,PHP,UAH"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/backend/tests/test_currencies_api.py
+++ b/backend/tests/test_currencies_api.py
@@ -46,3 +46,15 @@ async def test_currencies_include_dop_with_metadata(client: AsyncClient):
     assert dop["symbol"] == "RD$"
     assert dop["name"] == "Peso Dominicano"
     assert dop["flag"] == "🇩🇴"
+
+
+@pytest.mark.asyncio
+async def test_currencies_include_uah_with_metadata(client: AsyncClient):
+    response = await client.get("/api/currencies")
+    data = response.json()
+    uah = next((currency for currency in data if currency["code"] == "UAH"), None)
+
+    assert uah is not None
+    assert uah["symbol"] == "₴"
+    assert uah["name"] == "Ukrainian Hryvnia"
+    assert uah["flag"] == "🇺🇦"

--- a/frontend/src/components/currency-select.tsx
+++ b/frontend/src/components/currency-select.tsx
@@ -32,6 +32,7 @@ export const CURRENCIES = [
   { code: 'RUB', flag: '\u{1F1F7}\u{1F1FA}', symbol: '₽' },
   { code: 'GTQ', flag: '\u{1F1EC}\u{1F1F9}', symbol: 'Q' },
   { code: 'PHP', flag: '\u{1F1F5}\u{1F1ED}', symbol: '₱' },
+  { code: 'UAH', flag: '\u{1F1FA}\u{1F1E6}', symbol: '₴' },
 ] as const
 
 interface CurrencySelectProps {

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -59,6 +59,7 @@ const CURRENCY_LOCALE: Record<string, string> = {
   RUB: 'ru-RU',
   GTQ: 'es-GT',
   PHP: 'en-PH',
+  UAH: 'uk-UA',
 }
 
 /**


### PR DESCRIPTION
Closes #457

Adds the Ukrainian Hryvnia (UAH) as a supported currency.

- **Name:** Ukrainian Hryvnia
- **Code:** UAH (ISO 4217)
- **Symbol:** ₴
- **Flag:** 🇺🇦 · **Locale:** `uk-UA`

Same four-file footprint as previous currency additions (e.g. PHP #366, GTQ #365):
- `backend/app/api/currencies.py` — `CURRENCY_META` entry
- `backend/app/core/config.py` — added to `supported_currencies`
- `frontend/src/components/currency-select.tsx` — `CURRENCIES` list
- `frontend/src/lib/format.ts` — `CURRENCY_LOCALE` mapping

Plus a `CURRENCY_META` test in `backend/tests/test_currencies_api.py`, following the existing CLP/DOP pattern.

Verified: UAH appears in the setup/register currency selector (and the workspace Default-currency picker, same component) rendering the 🇺🇦 flag and ₴ symbol; `/api/currencies` returns the new entry; `uk-UA` formats as `1 234 567,89 ₴`. Open Exchange Rates covers UAH — a live `latest.json` call with the new symbol list returns a UAH rate, with no supported code missing from the response. Backend `ruff` + `pytest`, frontend `lint`, `tsc -b` and `vitest` all pass.