### PR TITLE
feat: show the linked transaction in the transfer dialog

### DIFF
--- a/backend/app/api/transactions.py
+++ b/backend/app/api/transactions.py
@@ -372,6 +372,26 @@ async def get_transfer_candidates(
     ]
 
 
+@router.get("/{transaction_id}/transfer-pair", response_model=Optional[TransactionRead])
+async def get_transfer_pair(
+    transaction_id: uuid.UUID,
+    ctx: WorkspaceContext = Depends(current_workspace),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Return the counterpart leg of a transfer, or null when not linked."""
+    anchor = await transaction_service.get_transaction(session, transaction_id, ctx.workspace.id)
+    if not anchor:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+    pair = await transaction_service.get_transfer_pair(
+        session, ctx.workspace.id, transaction_id
+    )
+    if not pair:
+        return None
+    return _tag_fx_fallback(
+        TransactionRead.model_validate(pair, from_attributes=True), ctx.user.primary_currency
+    )
+
+
 @router.get("/{transaction_id}", response_model=TransactionRead)
 async def get_transaction(
     transaction_id: uuid.UUID,

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -923,6 +923,41 @@ async def get_transfer_candidates(
     return candidates
 
 
+async def get_transfer_pair(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    transaction_id: uuid.UUID,
+) -> Optional[Transaction]:
+    """Return the counterpart leg of a linked transfer, or None.
+
+    Both legs share the same ``transfer_pair_id``, so the counterpart is the
+    other row carrying that id — not a foreign key on the anchor itself.
+    """
+    anchor = await get_transaction(session, transaction_id, workspace_id)
+    if not anchor or anchor.transfer_pair_id is None:
+        return None
+
+    result = await session.execute(
+        select(Transaction)
+        .where(
+            Transaction.workspace_id == workspace_id,
+            Transaction.transfer_pair_id == anchor.transfer_pair_id,
+            Transaction.id != anchor.id,
+        )
+        .options(
+            selectinload(Transaction.category),
+            selectinload(Transaction.account),
+            selectinload(Transaction.payee_entity),
+            selectinload(Transaction.splits),
+        )
+        .limit(1)
+    )
+    pair = result.scalars().first()
+    if pair:
+        pair.payee_name = pair.payee_entity.name if pair.payee_entity else None
+    return pair
+
+
 async def link_existing_as_transfer(
     session: AsyncSession,
     workspace_id: uuid.UUID,

--- a/backend/tests/test_transfer_api.py
+++ b/backend/tests/test_transfer_api.py
@@ -992,3 +992,75 @@ async def test_transfers_appear_in_transaction_list(
     transfer_txns = [tx for tx in items if tx.get("transfer_pair_id") == transfer_pair_id]
     assert len(transfer_txns) == 2
     assert {tx["type"] for tx in transfer_txns} == {"debit", "credit"}
+
+
+@pytest.mark.asyncio
+async def test_get_transfer_pair_returns_counterpart(
+    client: AsyncClient, auth_headers, test_account: Account, second_account: Account
+):
+    """Each leg resolves to the other leg of the pair."""
+    created = await client.post(
+        "/api/transactions/transfer",
+        json={
+            "from_account_id": str(test_account.id),
+            "to_account_id": str(second_account.id),
+            "amount": 500.00,
+            "date": date.today().isoformat(),
+            "description": "Transfer to savings",
+        },
+        headers=auth_headers,
+    )
+    assert created.status_code == 201
+    debit = created.json()["debit"]
+    credit = created.json()["credit"]
+
+    # Debit -> credit
+    response = await client.get(
+        f"/api/transactions/{debit['id']}/transfer-pair", headers=auth_headers
+    )
+    assert response.status_code == 200
+    pair = response.json()
+    assert pair["id"] == credit["id"]
+    assert pair["type"] == "credit"
+    assert pair["account_id"] == str(second_account.id)
+    assert float(pair["amount"]) == 500.00
+
+    # Credit -> debit (symmetric)
+    response = await client.get(
+        f"/api/transactions/{credit['id']}/transfer-pair", headers=auth_headers
+    )
+    assert response.status_code == 200
+    assert response.json()["id"] == debit["id"]
+
+
+@pytest.mark.asyncio
+async def test_get_transfer_pair_null_when_not_a_transfer(
+    client: AsyncClient, auth_headers, test_account: Account
+):
+    """A transaction with no transfer_pair_id resolves to null, not an error."""
+    created = await client.post(
+        "/api/transactions",
+        json={
+            "account_id": str(test_account.id),
+            "description": "Groceries",
+            "amount": 42.00,
+            "date": date.today().isoformat(),
+            "type": "debit",
+        },
+        headers=auth_headers,
+    )
+    assert created.status_code == 201
+
+    response = await client.get(
+        f"/api/transactions/{created.json()['id']}/transfer-pair", headers=auth_headers
+    )
+    assert response.status_code == 200
+    assert response.json() is None
+
+
+@pytest.mark.asyncio
+async def test_get_transfer_pair_404_for_unknown_transaction(client: AsyncClient, auth_headers):
+    response = await client.get(
+        f"/api/transactions/{uuid.uuid4()}/transfer-pair", headers=auth_headers
+    )
+    assert response.status_code == 404

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { getAccountLabel } from '@/lib/account-utils'
+import { getAccountLabel, getAccountName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
-import { useDateLocale } from '@/hooks/use-display-locale'
+import { useDateLocale, useDisplayLocale } from '@/hooks/use-display-locale'
+import { formatCurrency } from '@/lib/format'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '@/contexts/auth-context'
 import { currencies as currenciesApi, transactions as transactionsApi, settings as settingsApi, payees as payeesApi, rules as rulesApi } from '@/lib/api'
@@ -107,7 +108,7 @@ export function TransactionDialog({
   transaction: Transaction | null
   categories: Category[]
   categoryGroups: CategoryGroup[]
-  accounts: { id: string; name: string; type?: string }[]
+  accounts: { id: string; name: string; display_name?: string | null; type?: string }[]
   recurringMatch?: RecurringTransaction
   onSave: (data: Partial<Transaction>, recurringData?: { frequency: string; end_date?: string }, pendingFiles?: File[], action?: SaveAction) => void
   onDelete?: () => void
@@ -323,7 +324,7 @@ function TransactionForm({
   duplicateDraft: Partial<Transaction> | null
   categories: Category[]
   categoryGroups: CategoryGroup[]
-  accounts: { id: string; name: string; type?: string }[]
+  accounts: { id: string; name: string; display_name?: string | null; type?: string }[]
   recurringMatch?: RecurringTransaction
   onSave: (data: Partial<Transaction>, recurringData?: { frequency: string; end_date?: string }, pendingFiles?: File[], action?: SaveAction) => void
   onDelete?: () => void
@@ -344,6 +345,7 @@ function TransactionForm({
   const { privacyMode, MASK } = usePrivacyMode()
   const userCurrency = user?.preferences?.currency_display ?? 'USD'
   const dateLocale = useDateLocale()
+  const displayLocale = useDisplayLocale()
   const { data: supportedCurrencies } = useQuery({
     queryKey: ['currencies'],
     queryFn: currenciesApi.list,
@@ -438,6 +440,14 @@ function TransactionForm({
     queryKey: ['rules'],
     queryFn: rulesApi.list,
     enabled: !!transaction && !!onCreateRule,
+  })
+
+  // Counterpart leg of a transfer. Fetched lazily so only transfer dialogs
+  // pay for it — the list response carries just the shared pair id.
+  const { data: transferPair } = useQuery({
+    queryKey: ['transactions', transaction?.id, 'transfer-pair'],
+    queryFn: () => transactionsApi.transferPair(transaction!.id),
+    enabled: !!transaction?.id && !!transaction?.transfer_pair_id,
   })
   const extendableRules = useMemo(
     () => (rulesList ?? []).filter(canExtendRuleFromTransaction),
@@ -695,6 +705,25 @@ function TransactionForm({
           <div className="flex items-start justify-between gap-3">
             <div className="space-y-1 min-w-0">
               <p>{t('transactions.transferInfo')}</p>
+              {transferPair && (() => {
+                const pairAccount = accounts.find(a => a.id === transferPair.account_id)
+                const sign = transferPair.type === 'debit' ? '−' : '+'
+                return (
+                  <p className="text-xs text-blue-600 dark:text-blue-300 truncate">
+                    <span className="font-medium">{t('transactions.transferLinkedTo')}</span>{' '}
+                    {pairAccount ? getAccountName(pairAccount) : '—'}
+                    {' · '}
+                    {new Date(transferPair.date + 'T00:00:00').toLocaleDateString(dateLocale)}
+                    {' · '}
+                    {sign}
+                    {formatCurrency(
+                      Math.abs(Number(transferPair.amount)),
+                      transferPair.currency ?? undefined,
+                      displayLocale,
+                    )}
+                  </p>
+                )
+              })()}
               <p className="text-xs text-blue-500 dark:text-blue-400">{t('transactions.transferTooltip')}</p>
             </div>
             {onUnlinkTransfer && transaction?.transfer_pair_id && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -558,6 +558,10 @@ export const transactions = {
     const { data } = await api.get(`/transactions/${transactionId}/transfer-candidates`, { params })
     return data
   },
+  transferPair: async (transactionId: string): Promise<Transaction | null> => {
+    const { data } = await api.get(`/transactions/${transactionId}/transfer-pair`)
+    return data
+  },
   unlinkTransfer: async (pairId: string): Promise<void> => {
     await api.delete(`/connections/transfers/${pairId}`)
   },

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -418,6 +418,7 @@
     "transferDescription": "Beschreibung",
     "transferNotes": "Notizen",
     "transferInfo": "Dies ist eine Umbuchung — Änderungen an Beschreibung, Datum und Notizen wirken sich auf beide Seiten aus",
+    "transferLinkedTo": "Verknüpft mit:",
     "transferTooltip": "Umbuchungen sind von den Berichts- und Dashboard-Summen ausgeschlossen",
     "installmentTooltip": "Ratenzahlung — {{count}} Belastungen von insgesamt {{total}}",
     "billOverrideTooltip": "Verschoben auf die Abrechnung fällig am {{date}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -418,6 +418,7 @@
     "transferDescription": "Description",
     "transferNotes": "Notes",
     "transferInfo": "This is a transfer — changes to description, date, and notes will apply to both sides",
+    "transferLinkedTo": "Linked to:",
     "transferTooltip": "Transfers are excluded from report and dashboard totals",
     "installmentTooltip": "Installment plan — {{count}} charges totaling {{total}}",
     "billOverrideTooltip": "Moved to the bill due {{date}}",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -415,6 +415,7 @@
     "transferDescription": "Descripción",
     "transferNotes": "Notas",
     "transferInfo": "Esto es una transferencia — los cambios en descripción, fecha y notas se aplicarán a ambos lados",
+    "transferLinkedTo": "Vinculada a:",
     "transferTooltip": "Las transferencias están excluidas de los informes y totales del panel",
     "installmentTooltip": "Plan de cuotas — {{count}} cargos por un total de {{total}}",
     "billOverrideTooltip": "Movido a la factura con vencimiento {{date}}",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -418,6 +418,7 @@
     "transferDescription": "Description",
     "transferNotes": "Notes",
     "transferInfo": "Il s'agit d'un virement — les modifications de la description, de la date et des notes s'appliqueront aux deux côtés",
+    "transferLinkedTo": "Liée à :",
     "transferTooltip": "Les virements sont exclus des totaux des rapports et du tableau de bord",
     "installmentTooltip": "Paiement échelonné — {{count}} prélèvements pour un total de {{total}}",
     "billOverrideTooltip": "Déplacée vers la facture due le {{date}}",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -415,6 +415,7 @@
     "transferDescription": "Descrizione",
     "transferNotes": "Note",
     "transferInfo": "Questo è un trasferimento — le modifiche a descrizione, data e note si applicheranno a entrambi i lati",
+    "transferLinkedTo": "Collegata a:",
     "transferTooltip": "I trasferimenti sono esclusi dai totali dei report e della dashboard",
     "installmentTooltip": "Piano rateale — {{count}} addebiti per un totale di {{total}}",
     "billOverrideTooltip": "Spostato all'estratto conto in scadenza il {{date}}",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -436,6 +436,7 @@
     "transferDescription": "Opis",
     "transferNotes": "Notatki",
     "transferInfo": "To transfer — zmiany opisu, daty i notatek obejmą obie strony",
+    "transferLinkedTo": "Powiązana z:",
     "transferTooltip": "Transfery są wyłączone z sum w raportach i na pulpicie",
     "installmentTooltip_one": "Plan ratalny — {{count}} obciążenie na łączną kwotę {{total}}",
     "installmentTooltip_few": "Plan ratalny — {{count}} obciążenia na łączną kwotę {{total}}",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -415,6 +415,7 @@
     "transferDescription": "Descrição",
     "transferNotes": "Notas",
     "transferInfo": "Esta é uma transferência — alterações na descrição, data e notas serão aplicadas em ambos os lados",
+    "transferLinkedTo": "Vinculada a:",
     "transferTooltip": "Transferências são excluídas dos totais de relatórios e dashboard",
     "installmentTooltip": "Compra parcelada — {{count}} parcelas totalizando {{total}}",
     "billOverrideTooltip": "Movida para a fatura com vencimento em {{date}}",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -415,6 +415,7 @@
     "transferDescription": "Descrição",
     "transferNotes": "Notas",
     "transferInfo": "Esta é uma transferência — alterações na descrição, data e notas serão aplicadas em ambos os lados",
+    "transferLinkedTo": "Associada a:",
     "transferTooltip": "Transferências são excluídas dos totais de relatórios e do painel",
     "installmentTooltip": "Compra a prestações — {{count}} prestações totalizando {{total}}",
     "billOverrideTooltip": "Movida para a fatura com vencimento em {{date}}",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -418,6 +418,7 @@
     "transferDescription": "Описание",
     "transferNotes": "Примечания",
     "transferInfo": "Это перевод — изменения в описании, дате и примечаниях будут применены к обеим сторонам",
+    "transferLinkedTo": "Связана с:",
     "transferTooltip": "Переводы исключаются из отчётов и итогов панели",
     "installmentTooltip": "План рассрочки — {{count}} платежей на сумму {{total}}",
     "billOverrideTooltip": "Перенесено на оплату {{date}}",

--- a/frontend/src/locales/uk.json
+++ b/frontend/src/locales/uk.json
@@ -418,6 +418,7 @@
     "transferDescription": "Опис",
     "transferNotes": "Примітки",
     "transferInfo": "Це переказ — зміни в описі, даті та примітках буде застосовано до обох сторін",
+    "transferLinkedTo": "Пов'язана з:",
     "transferTooltip": "Перекази виключаються зі звітів та підсумків панелі",
     "installmentTooltip": "План розстрочки — {{count}} платежів на суму {{total}}",
     "billOverrideTooltip": "Перенесено на оплату {{date}}",


### PR DESCRIPTION
Closes #453

The transfer banner said *that* a transaction was a transfer but never *which* one it was linked to, so there was no way to tell whether an automatic link was correct. Adds one line under the existing message:

`Linked to: Revolut · 26/07/2026 · +€ 300,00`

**Backend** — both legs share the same `transfer_pair_id`, so the counterpart is the other row carrying that id; `TransactionRead` only exposed the bare UUID. Adds `transaction_service.get_transfer_pair()` and `GET /transactions/{id}/transfer-pair`, a sibling of the existing `transfer-candidates` endpoint. Returns null when the transaction isn't a transfer.

**Frontend** — the dialog fetches it lazily (`enabled` on `transfer_pair_id`), so only transfer dialogs pay for the request and list responses stay unchanged. Account name, date and signed amount reuse `getAccountName` / `formatCurrency`, matching the list row and the link-transfer dialog.

Also widens the dialog's `accounts` prop with `display_name` — without it the banner rendered the raw bank name (often the account holder's name) where the rest of the app shows the display name.

Tests: 3 cases in `test_transfer_api.py` covering both directions, the non-transfer null case, and an unknown id. New string added to all 10 locales.

Verified in Chrome against a real synced pair: both legs resolve to each other with matching account, date and amount, in light and dark mode.