### PR TITLE
fix: align calendar weekday headers with the dates below them

### DIFF
--- a/frontend/src/components/transaction-calendar-view.tsx
+++ b/frontend/src/components/transaction-calendar-view.tsx
@@ -6,6 +6,7 @@ import type { TransactionCalendarDay, TransactionCalendarItem, TransactionCalend
 import { Skeleton } from '@/components/ui/skeleton'
 import { CategoryIcon } from '@/components/category-icon'
 import { activityChartData, dayActivity } from '@/lib/calendar-activity'
+import { weekdayShortLabels } from '@/lib/date-utils'
 import { cn } from '@/lib/utils'
 
 function parseLocalDate(value: string) {
@@ -103,13 +104,7 @@ export function TransactionCalendarView({
   }, [calendar, onSelectedDateChange, selectedDate])
 
   const selectedDay = calendar?.days.find((day) => day.date === selectedDate)
-  const weekDays = useMemo(
-    () => Array.from({ length: 7 }, (_, index) => {
-      const date = new Date(Date.UTC(2024, 0, 7 + index)) // Sunday-start reference week
-      return date.toLocaleDateString(dateLocale, { weekday: 'short' })
-    }),
-    [dateLocale],
-  )
+  const weekDays = useMemo(() => weekdayShortLabels(dateLocale), [dateLocale])
 
   if (isLoading) {
     return (

--- a/frontend/src/lib/date-utils.test.ts
+++ b/frontend/src/lib/date-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { localDateString } from './date-utils'
+import { localDateString, weekdayShortLabels } from './date-utils'
 
 describe('localDateString', () => {
   it('formats the browser-local calendar day', () => {
@@ -13,5 +13,26 @@ describe('localDateString', () => {
       if (originalTimezone === undefined) delete process.env.TZ
       else process.env.TZ = originalTimezone
     }
+  })
+})
+
+describe('weekdayShortLabels', () => {
+  it('starts the week on Sunday regardless of the viewer timezone', () => {
+    const originalTimezone = process.env.TZ
+
+    try {
+      process.env.TZ = 'America/Santo_Domingo'
+      expect(weekdayShortLabels('en-US')).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'])
+
+      process.env.TZ = 'Pacific/Kiritimati'
+      expect(weekdayShortLabels('en-US')).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'])
+    } finally {
+      if (originalTimezone === undefined) delete process.env.TZ
+      else process.env.TZ = originalTimezone
+    }
+  })
+
+  it('translates the labels for the requested locale', () => {
+    expect(weekdayShortLabels('es-ES')[0]).toMatch(/^dom/i)
   })
 })

--- a/frontend/src/lib/date-utils.ts
+++ b/frontend/src/lib/date-utils.ts
@@ -3,3 +3,14 @@ import { format } from 'date-fns'
 export function localDateString(date = new Date()) {
   return format(date, 'yyyy-MM-dd')
 }
+
+// Short weekday names for a Sunday-start calendar header. The reference week is
+// anchored in UTC, so it has to be formatted in UTC as well — otherwise a viewer
+// behind UTC reads each instant as the previous day and every label shifts one
+// column, leaving the headers out of step with the dates underneath them.
+export function weekdayShortLabels(locale: string) {
+  return Array.from({ length: 7 }, (_, index) => {
+    const date = new Date(Date.UTC(2024, 0, 7 + index)) // 2024-01-07 is a Sunday
+    return date.toLocaleDateString(locale, { weekday: 'short', timeZone: 'UTC' })
+  })
+}


### PR DESCRIPTION
## What

Fixes the weekday header row in the transaction calendar so the labels line up with the dates underneath them.

The header labels were built from a UTC-anchored reference week (`Date.UTC(2024, 0, 7)`, a Sunday) but formatted with `toLocaleDateString` in the viewer's own timezone. For anyone behind UTC that instant reads as the previous day, so the entire row shifted one column: at UTC−4 it rendered `SAT SUN MON TUE WED THU FRI` instead of `SUN MON TUE WED THU FRI SAT`.

The builder now formats in UTC as well, and moved to `weekdayShortLabels()` in `frontend/src/lib/date-utils.ts` so a timezone regression test can cover it.

## Why

With the labels off by one, every date in the month appeared to fall on the wrong weekday, August 2026 showed the 1st under `FRI` even though it was a Saturday. The day cells themselves were never wrong: the backend grid in `transaction_calendar_service.py` builds a correct Sunday-start month grid, so this was purely a display bug in the header, but it made the whole calendar untrustworthy at a glance.

The impact scales with distance from UTC, invisible in UTC and ahead of it, wrong for every user in the Americas.

## How to Test

1. Set your machine timezone to one behind UTC (e.g. `America/Santo_Domingo`, UTC−4)
2. Run the frontend and open **Transactions → Calendar**
3. The header row reads `SUN → SAT`, and August 2026 shows the 1st in the Saturday column
4. Switch the app language and confirm the labels are still localized and still Sunday-first
5. `cd frontend && npm test`, `weekdayShortLabels` is asserted under both a west-of-UTC (`America/Santo_Domingo`) and an ahead-of-UTC (`Pacific/Kiritimati`) timezone

## Related Issue

Closes #492

## Checklist

- [ ] Backend tests pass (`pytest`) - not run; no backend files are touched by this change
- [x] Frontend lints clean (`npm run lint`) - 0 errors (41 pre-existing warnings elsewhere in the repo, none from these files)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed) - n/a, the labels come from `toLocaleDateString` and stay localized
- [x] For a large or core change, I discussed it first (issue or Discord) - filed as #492
