### PR TITLE
fix: show recurring badge only for linked transactions

### DIFF
--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -441,6 +441,10 @@ export default function TransactionsPage() {
     queryKey: ['recurring'],
     queryFn: recurring.list,
   })
+  const recurringById = useMemo(
+    () => new Map((recurringList ?? []).map(item => [item.id, item])),
+    [recurringList],
+  )
 
   const { data: accountingModeData } = useQuery({
     queryKey: ['admin', 'accounting-mode'],
@@ -1007,11 +1011,10 @@ export default function TransactionsPage() {
               </span>
                             )
             }
-            {(tx.recurring_transaction_id != null ||
-              recurringList?.some(r => r.description === tx.description && r.type === tx.type)) && (
+            {tx.recurring_transaction_id != null && (
               <span
                 className="text-[10px] font-semibold uppercase tracking-wide text-primary bg-primary/5 border border-primary/10 px-1.5 py-0.5 rounded-full"
-                title={tx.recurring_transaction_id != null ? t('transactions.recurringLinkedTooltip') : undefined}
+                title={t('transactions.recurringLinkedTooltip')}
               >
                 {t('transactions.recurringBadge')}
               </span>
@@ -1782,7 +1785,11 @@ export default function TransactionsPage() {
         categories={categoriesList ?? []}
         categoryGroups={categoryGroupsList ?? []}
         accounts={accountsList ?? []}
-        recurringMatch={editingTx ? recurringList?.find(r => r.description === editingTx.description && r.type === editingTx.type) : undefined}
+        recurringMatch={
+          editingTx?.recurring_transaction_id
+            ? recurringById.get(editingTx.recurring_transaction_id)
+            : undefined
+        }
         onSave={handleTransactionSave}
         onDelete={editingTx ? () => deleteMutation.mutate(editingTx.id) : undefined}
         onUnlinkTransfer={(pairId) => unlinkTransferMutation.mutate(pairId)}


### PR DESCRIPTION
## What

- Show the recurring badge only when a transaction has a stored `recurring_transaction_id`.
- Resolve the recurring definition shown in the transaction dialog by that ID instead of inferring a match from description and type.

## Why

Transactions with the same description and type were all shown as recurring even when only one was actually linked. The frontend fallback ignored the stored relationship and produced false badges and dialog matches.

## How to Test

1. Create or import multiple transactions with the same description and type but different amounts.
2. Link only one transaction to a recurring definition.
3. Confirm only the linked transaction displays the recurring badge.
4. Open both transactions and confirm recurring details appear only for the linked transaction.

Local validation:

- `npm test`: 56 tests passed
- `npm run lint`: 0 errors (41 existing warnings)
- `npm run build`: passed, including `tsc -b`
- Browser smoke test: linked and unlinked transactions with the same description/type behaved according to their stored IDs

## Related Issue

Closes #497

## Checklist

- [ ] Backend tests pass (`pytest`) — not run; this is a frontend-only change and CI skips the backend suite when no backend files changed
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Frontend tests pass (`npm test`)
- [x] Translations updated — not applicable; no user-facing strings changed
- [x] Prior discussion — not required for this small, focused bug fix from an existing issue
