### PR TITLE
chore(deps): bump pytest to >=9.0 and pytest-asyncio to >=1.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,8 +36,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.4.0",
-    "pytest-asyncio>=0.23.0,<1.0",
+    "pytest>=9.0.0",
+    "pytest-asyncio>=1.0",
     "pytest-cov>=4.1.0",
     "pytest-xdist>=3.6.1",
     "httpx>=0.26.0",


### PR DESCRIPTION
## What

Update dev testing dependencies to their latest major versions. pytest-asyncio 1.0 drops the <1.0 upper bound, and pytest moves to the 9.x line.

## Why

When running ty, there's an issue with pytest < 9 that threw the error "error[invalid-argument-type]: Argument to bound method `skip` is incorrect"

## How to Test

Run `mise backend:test`

## Related Issue

Closes #___ (or link the issue this addresses).

## Checklist

- [x] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
- [ ] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))
