### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "Europe/Paris",
+  "schedule": ["before 8am on monday"],
+  "prConcurrentLimit": 5,
+  "labels": ["dependencies"],
+  "rangeStrategy": "update-lockfile",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 8am on the first day of the month"]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "GitHub Actions (non-major)"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "frontend (non-major)"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "backend (non-major)"
+    },
+    {
+      "description": "Postgres majors need a deliberate data migration for self-hosters — never auto-PR them",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["pgvector/pgvector"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "uv pinned in the Dockerfile, CI and scripts/lock.sh (marked with a `# renovate:` comment)",
+      "fileMatch": [
+        "^backend/Dockerfile$",
+        "^backend/scripts/lock\\.sh$",
+        "^\\.github/workflows/ci\\.yml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n[^\\n]*?(?:==|@)(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `renovate.json`. Inert until the [Mend Renovate app](https://github.com/apps/renovate) is installed on the repo (maintainer action, GitHub UI).

Design, tuned for a solo maintainer:

- **Weekly, batched**: non-major updates grouped per area (GitHub Actions / frontend npm / backend python) — at most ~3 PRs on a Monday morning, not a daily drip. Majors stay individual. Monthly lock file maintenance refreshes transitive pins.
- **`pgvector/pgvector` majors disabled**: a Postgres major would break every self-hoster's data directory without a manual migration — that must never arrive as an automated PR.
- **The `uv` pin is managed too**: a regex manager bumps the pinned version in the Dockerfile, CI and `scripts/lock.sh` (marked with `# renovate:` comments).
- `rangeStrategy: update-lockfile`: pyproject ranges stay as intent, the lock moves.

## Depends on

#511 — backend updates flow through `uv.lock`, which #511 introduces. Merge that first; without it Renovate can only see the pyproject ranges.

## How to Test

Config validates against the Renovate schema. Real validation happens on install: the app's dependency dashboard issue will list everything it detects.

## Checklist

- [ ] Backend tests pass (`pytest`) — not touched
- [ ] Frontend lints clean / builds — not touched
- [ ] Translations updated — none
- [x] For a large or core change, I discussed it first (issue or Discord) so we could align before the code