### PR TITLE
fix: truncate transaction notes description

### DIFF
--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -1081,7 +1081,7 @@ export default function TransactionsPage() {
           {(showInlineNotes || showInlineTags) && tx.notes && (
             <div className="mt-1 space-y-0.5">
               {showInlineNotes && noteText && (
-                <p className="text-xs text-muted-foreground italic leading-snug">{noteText}</p>
+                <p className="text-xs text-muted-foreground italic leading-snug truncate">{noteText}</p>
               )}
               {showInlineTags && noteTags.length > 0 && (
                 <div className="flex flex-wrap gap-1">


### PR DESCRIPTION
## What

Updated the transaction card to truncate the notes description when the text exceeds the available space.

## Why
The transaction title was already truncated correctly, but the notes description could overflow when it contained long text. 
This happens in Transactions Screen.

**Screenshots**

Before:
<img width="1259" height="150" alt="before" src="https://github.com/user-attachments/assets/719edc5e-1599-42e0-ae08-e954e2e54d22" />



After:

<img width="1253" height="158" alt="after" src="https://github.com/user-attachments/assets/f9944ab3-2ab0-43d4-a6c3-0d2614b3c918" />
