### PR TITLE
fix: passkey login with synced credentials and remove implicit passkey 2FA

### DIFF
--- a/backend/app/api/custom_auth.py
+++ b/backend/app/api/custom_auth.py
@@ -26,14 +26,18 @@ async def login(
     if user is None or not user.is_active:
         raise HTTPException(status_code=400, detail="LOGIN_BAD_CREDENTIALS")
 
-    passkey_count = await session.scalar(
-        select(func.count()).select_from(UserPasskey).where(UserPasskey.user_id == user.id)
-    )
     available_methods = []
     if user.is_2fa_enabled and user.totp_secret:
         available_methods.append("totp")
-    if passkey_count and passkey_count > 0:
-        available_methods.append("passkey")
+        # A passkey doubles as a second factor only when the user explicitly
+        # enabled 2FA. On its own it is a passwordless login alternative —
+        # requiring it on top of the password would permanently lock the
+        # account if the passkey is lost (there are no recovery codes).
+        passkey_count = await session.scalar(
+            select(func.count()).select_from(UserPasskey).where(UserPasskey.user_id == user.id)
+        )
+        if passkey_count and passkey_count > 0:
+            available_methods.append("passkey")
 
     if available_methods:
         # Store temp token in Redis, return 2FA challenge

--- a/backend/app/api/passkeys.py
+++ b/backend/app/api/passkeys.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import secrets
 import uuid
 from datetime import datetime, timezone
@@ -43,6 +44,8 @@ from app.schemas.passkey import (
     PasskeySecondFactorOptionsRequest,
     PasskeySecondFactorVerifyRequest,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -155,10 +158,17 @@ async def _verify_passkey_credential(
             expected_origin=challenge["origin"],
             expected_rp_id=challenge["rp_id"],
             credential_public_key=base64url_to_bytes(passkey.public_key),
-            credential_current_sign_count=passkey.sign_count,
+            # Synced passkeys (1Password, iCloud Keychain, Google Password
+            # Manager) legitimately report a stale counter when used from
+            # another device, so the anti-clone regression check only applies
+            # to device-bound credentials.
+            credential_current_sign_count=0 if passkey.backed_up else passkey.sign_count,
             require_user_verification=True,
         )
     except Exception as exc:
+        logger.warning(
+            "Passkey verification failed for credential %s: %s", passkey.credential_id, exc
+        )
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid passkey") from exc
 
     verified_credential_id = _as_base64url(verification.credential_id)
@@ -304,16 +314,32 @@ async def passkey_authentication_options(
     context = resolve_webauthn_context(request)
     email = body.email.strip().lower() if body.email else None
     expected_user_id: str | None = None
+    allow_credentials: list[PublicKeyCredentialDescriptor] | None = None
 
     if email:
         user_result = await session.execute(select(User).where(func.lower(User.email) == email))
         login_user = user_result.scalar_one_or_none()
         if login_user is not None:
             expected_user_id = str(login_user.id)
+            # Listing the user's credentials lets password managers surface
+            # the matching passkey even when they can't take part in a pure
+            # discoverable-credential ceremony (e.g. 1Password with a locked
+            # vault shows an empty picker otherwise). The endpoint is
+            # rate-limited, which bounds credential enumeration.
+            passkeys_result = await session.execute(
+                select(UserPasskey)
+                .where(UserPasskey.user_id == login_user.id)
+                .order_by(UserPasskey.created_at.asc())
+            )
+            allow_credentials = [
+                PublicKeyCredentialDescriptor(id=base64url_to_bytes(pk.credential_id))
+                for pk in passkeys_result.scalars().all()
+            ] or None
 
     options = generate_authentication_options(
         rp_id=context.rp_id,
         user_verification=UserVerificationRequirement.REQUIRED,
+        allow_credentials=allow_credentials,
     )
     challenge_id = await _store_challenge(
         AUTHENTICATE_CHALLENGE_PREFIX,

--- a/backend/tests/test_passkeys.py
+++ b/backend/tests/test_passkeys.py
@@ -6,6 +6,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from webauthn.helpers import base64url_to_bytes
 
 from app.models.passkey import UserPasskey
 
@@ -154,7 +155,7 @@ async def test_authenticate_passkey_returns_jwt_and_bypasses_2fa(
     )
     assert email_options_response.status_code == 200
     email_options = email_options_response.json()["options"]
-    assert email_options.get("allowCredentials") in (None, [])
+    assert [c["id"] for c in email_options["allowCredentials"]] == [passkey.credential_id]
     challenge_id = email_options_response.json()["challenge_id"]
 
     verification = SimpleNamespace(
@@ -192,11 +193,89 @@ async def test_authenticate_passkey_returns_jwt_and_bypasses_2fa(
     assert isinstance(passkey.last_used_at, datetime)
 
 
-async def test_password_login_with_passkey_requires_second_factor(
+async def _authenticate_with_stored_passkey(client: AsyncClient, passkey: UserPasskey):
+    options_response = await client.post("/api/auth/passkeys/authenticate/options", json={})
+    challenge_id = options_response.json()["challenge_id"]
+    verification = SimpleNamespace(
+        credential_id=base64url_to_bytes(passkey.credential_id),
+        new_sign_count=1,
+    )
+    with patch(
+        "app.api.passkeys.verify_authentication_response", return_value=verification
+    ) as verify_mock:
+        verify_response = await client.post(
+            "/api/auth/passkeys/authenticate/verify",
+            json={
+                "challenge_id": challenge_id,
+                "credential": {
+                    "id": passkey.credential_id,
+                    "rawId": passkey.credential_id,
+                    "response": {
+                        "authenticatorData": "YXV0aC1kYXRh",
+                        "clientDataJSON": "Y2xpZW50LWRhdGE",
+                        "signature": "c2lnbmF0dXJl",
+                        "userHandle": None,
+                    },
+                    "type": "public-key",
+                    "clientExtensionResults": {},
+                },
+            },
+        )
+    assert verify_response.status_code == 200
+    return verify_mock
+
+
+async def test_backed_up_passkey_skips_sign_count_check(
     client: AsyncClient,
     session: AsyncSession,
     test_user,
 ):
+    # Synced passkeys (1Password, iCloud Keychain) report a stale counter when
+    # used from another device; the stored counter must not be enforced.
+    passkey = UserPasskey(
+        user_id=test_user.id,
+        credential_id="YmFja2VkLXVwLWtleQ",
+        public_key="YmFja2VkLXVwLXB1YmxpYw",
+        sign_count=42,
+        name="1Password passkey",
+        backed_up=True,
+    )
+    session.add(passkey)
+    await session.commit()
+    await session.refresh(passkey)
+
+    verify_mock = await _authenticate_with_stored_passkey(client, passkey)
+    assert verify_mock.call_args.kwargs["credential_current_sign_count"] == 0
+
+
+async def test_device_bound_passkey_enforces_sign_count(
+    client: AsyncClient,
+    session: AsyncSession,
+    test_user,
+):
+    passkey = UserPasskey(
+        user_id=test_user.id,
+        credential_id="ZGV2aWNlLWJvdW5kLWtleQ",
+        public_key="ZGV2aWNlLWJvdW5kLXB1YmxpYw",
+        sign_count=42,
+        name="Security key",
+        backed_up=False,
+    )
+    session.add(passkey)
+    await session.commit()
+    await session.refresh(passkey)
+
+    verify_mock = await _authenticate_with_stored_passkey(client, passkey)
+    assert verify_mock.call_args.kwargs["credential_current_sign_count"] == 42
+
+
+async def test_password_login_with_passkey_but_no_2fa_returns_token(
+    client: AsyncClient,
+    session: AsyncSession,
+    test_user,
+):
+    # A registered passkey is a passwordless alternative, not an implicit
+    # second factor: without 2FA enabled, email + password must sign in.
     session.add(
         UserPasskey(
             user_id=test_user.id,
@@ -216,19 +295,48 @@ async def test_password_login_with_passkey_requires_second_factor(
 
     assert response.status_code == 200
     data = response.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+    assert "requires_2fa" not in data
+
+
+async def test_password_login_with_2fa_and_passkey_offers_both_methods(
+    client: AsyncClient,
+    session: AsyncSession,
+    test_user_with_2fa,
+):
+    session.add(
+        UserPasskey(
+            user_id=test_user_with_2fa.id,
+            credential_id="MmZhLXBhc3NrZXk",
+            public_key="cHVibGljLWtleQ",
+            sign_count=1,
+            name="Security key",
+        )
+    )
+    await session.commit()
+
+    response = await client.post(
+        "/api/auth/login",
+        data={"username": test_user_with_2fa.email, "password": "testpass123"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
     assert data["requires_2fa"] is True
     assert data["temp_token"]
-    assert data["available_methods"] == ["passkey"]
+    assert data["available_methods"] == ["totp", "passkey"]
     assert "access_token" not in data
 
 
 async def test_passkey_second_factor_returns_jwt_for_same_user_passkey(
     client: AsyncClient,
     session: AsyncSession,
-    test_user,
+    test_user_with_2fa,
 ):
     passkey = UserPasskey(
-        user_id=test_user.id,
+        user_id=test_user_with_2fa.id,
         credential_id="c2FtZS11c2VyLWtleQ",
         public_key="c2FtZS11c2VyLXB1YmxpYw",
         sign_count=2,
@@ -240,7 +348,7 @@ async def test_passkey_second_factor_returns_jwt_for_same_user_passkey(
 
     login_response = await client.post(
         "/api/auth/login",
-        data={"username": test_user.email, "password": "testpass123"},
+        data={"username": test_user_with_2fa.email, "password": "testpass123"},
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     temp_token = login_response.json()["temp_token"]
@@ -289,14 +397,14 @@ async def test_passkey_second_factor_rejects_other_users_passkey(
     test_user_with_2fa,
 ):
     own_passkey = UserPasskey(
-        user_id=test_user.id,
+        user_id=test_user_with_2fa.id,
         credential_id="b3duZXItbWZhLWtleQ",
         public_key="b3duZXItcHVibGlj",
         sign_count=1,
         name="Own key",
     )
     other_passkey = UserPasskey(
-        user_id=test_user_with_2fa.id,
+        user_id=test_user.id,
         credential_id="b3RoZXItbWZhLWtleQ",
         public_key="b3RoZXItcHVibGlj",
         sign_count=1,
@@ -307,7 +415,7 @@ async def test_passkey_second_factor_rejects_other_users_passkey(
 
     login_response = await client.post(
         "/api/auth/login",
-        data={"username": test_user.email, "password": "testpass123"},
+        data={"username": test_user_with_2fa.email, "password": "testpass123"},
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     temp_token = login_response.json()["temp_token"]


### PR DESCRIPTION
## Summary

Fixes the two auth defects from #534:

- **Synced passkeys (1Password, iCloud Keychain) no longer fail with 401.** `verify_authentication_response` enforced the sign counter, but backed-up passkeys legitimately report a stale counter on cross-device use. The stored `backed_up` flag now disables the regression check for synced credentials; device-bound keys keep it.
- **Password login no longer hard-requires a passkey.** Any registered passkey was added to `available_methods`, turning it into a mandatory second factor even with 2FA disabled, with no recovery path (a lost passkey meant permanent lockout). Passkeys now act as a second factor only when the user explicitly enabled 2FA; otherwise email + password signs in directly.
- **Email-bound passkey ceremonies now send `allowCredentials`**, so password managers can surface the matching passkey instead of showing an empty picker (e.g. 1Password with a locked vault). The endpoint is already rate-limited, bounding enumeration.
- The real verification error is now logged server-side instead of being swallowed into a bare `401 Invalid passkey`.

## Tests

- New: backed-up passkey skips the counter check, device-bound passkey enforces it, password + passkey without 2FA returns a token, 2FA + passkey offers both methods.
- Updated the second-factor tests to use a 2FA-enabled user (the old ones asserted the buggy implicit-2FA behavior).
- `pytest tests/test_passkeys.py tests/test_two_factor.py tests/test_auth_api.py`: 41 passed. `ruff` and `ty` clean.

Closes #534