### PR TITLE
fix: QIF import misdating DD/MM statements as MM/DD

### DIFF
--- a/backend/app/api/import_transactions.py
+++ b/backend/app/api/import_transactions.py
@@ -60,7 +60,7 @@ async def preview_import(
             transactions = import_service.parse_ofx(content)
             detected_format = "ofx"
         elif filename.lower().endswith('.qif'):
-            transactions = import_service.parse_qif(content)
+            transactions = import_service.parse_qif(content, date_format=date_format)
             detected_format = "qif"
         elif filename.lower().endswith('.xml') or filename.lower().endswith('.camt'):
             transactions = import_service.parse_camt(content)
@@ -91,7 +91,7 @@ async def preview_import(
                 detected_format = "ofx"
             except Exception:
                 try:
-                    transactions = import_service.parse_qif(content)
+                    transactions = import_service.parse_qif(content, date_format=date_format)
                     detected_format = "qif"
                 except Exception:
                     try:

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -165,8 +165,50 @@ def parse_ofx(content: bytes) -> list[TransactionImport]:
     return transactions
 
 
-def parse_qif(content: bytes) -> list[TransactionImport]:
-    """Parse QIF file content and return transactions."""
+# QIF "D" lines carry no format metadata; US-first order is the historical
+# default. The Quicken apostrophe variants are always month-first.
+_QIF_FALLBACK_DATE_FORMATS = [
+    '%m/%d/%Y', '%d/%m/%Y', '%Y-%m-%d',
+    "%m/%d'%Y", "%m/%d'%y",
+    '%m/%d/%y', '%d/%m/%y',
+]
+
+
+def _qif_date_formats(date_format: str | None, raw_dates: list[str]) -> list[str]:
+    """Decide the strptime formats for a QIF file's dates, once per file.
+
+    An explicit user choice is strict (like parse_csv): only that format and
+    its 2-digit-year variant are accepted. Otherwise the order is inferred
+    from the whole file — a first component > 12 can only be a day, so the
+    file is DD/MM; per-line first-match parsing would silently mix MM/DD and
+    DD/MM within a single import for the ambiguous days 1-12.
+    """
+    if date_format and date_format in DATE_FORMAT_MAP:
+        fmt = DATE_FORMAT_MAP[date_format]
+        return [fmt, fmt.replace('%Y', '%y')]
+
+    saw_day_first = saw_month_first = False
+    for value in raw_dates:
+        match = re.match(r"^(\d{1,2})/(\d{1,2})/\d{2,4}$", value)
+        if not match:
+            continue
+        first, second = int(match.group(1)), int(match.group(2))
+        if first > 12 >= second:
+            saw_day_first = True
+        if second > 12 >= first:
+            saw_month_first = True
+
+    if saw_day_first and not saw_month_first:
+        return ['%d/%m/%Y', '%d/%m/%y'] + _QIF_FALLBACK_DATE_FORMATS
+    return list(_QIF_FALLBACK_DATE_FORMATS)
+
+
+def parse_qif(content: bytes, date_format: str | None = None) -> list[TransactionImport]:
+    """Parse QIF file content and return transactions.
+
+    date_format: optional explicit format (see DATE_FORMAT_MAP keys); when
+    omitted, the day/month order is inferred from the whole file.
+    """
     # Try UTF-8 first, fall back to Latin-1 for legacy software (e.g. Microsoft Money)
     try:
         text = content.decode('utf-8-sig')
@@ -176,6 +218,15 @@ def parse_qif(content: bytes) -> list[TransactionImport]:
 
     # Split into transaction blocks by "^"
     blocks = text.split('^')
+
+    raw_dates = [
+        stripped[1:].strip()
+        for block in blocks
+        for stripped in (line.strip() for line in block.strip().splitlines())
+        if stripped.startswith('D')
+    ]
+    date_formats = _qif_date_formats(date_format, raw_dates)
+
     for block in blocks:
         lines = block.strip().splitlines()
         if not lines:
@@ -192,12 +243,7 @@ def parse_qif(content: bytes) -> list[TransactionImport]:
                 continue
             tag, value = line[0], line[1:]
             if tag == 'D':
-                # Try common date formats (including 2-digit year variants)
-                for fmt in [
-                    '%m/%d/%Y', '%d/%m/%Y', '%Y-%m-%d',
-                    "%m/%d'%Y", "%m/%d'%y",
-                    '%m/%d/%y', '%d/%m/%y',
-                ]:
+                for fmt in date_formats:
                     try:
                         txn_date = datetime.strptime(value.strip(), fmt).date()
                         break

--- a/backend/tests/test_import_service.py
+++ b/backend/tests/test_import_service.py
@@ -530,6 +530,61 @@ class TestParseQif:
         assert transactions[1].date == date(2026, 1, 20)
         assert transactions[1].type == "credit"
 
+    def test_parse_qif_explicit_day_first_format(self):
+        """An explicit DD/MM/YYYY choice must win over the US-first default."""
+        qif_content = (
+            "D07/03/2026\n"
+            "T-100.00\n"
+            "PLandlord\n"
+            "^\n"
+        )
+        transactions = parse_qif(qif_content.encode("utf-8"), date_format="DD/MM/YYYY")
+        assert len(transactions) == 1
+        assert transactions[0].date == date(2026, 3, 7)
+
+    def test_parse_qif_explicit_month_first_format(self):
+        qif_content = (
+            "D07/03/2026\n"
+            "T-100.00\n"
+            "^\n"
+        )
+        transactions = parse_qif(qif_content.encode("utf-8"), date_format="MM/DD/YYYY")
+        assert transactions[0].date == date(2026, 7, 3)
+
+    def test_parse_qif_infers_day_first_from_whole_file(self):
+        """One unambiguous date (day > 12) pins the whole file to DD/MM, so
+        ambiguous dates in the same file stop being parsed as MM/DD."""
+        qif_content = (
+            "D25/03/2026\n"
+            "T-10.00\n"
+            "^\n"
+            "D07/03/2026\n"
+            "T-20.00\n"
+            "^\n"
+        )
+        transactions = parse_qif(qif_content.encode("utf-8"))
+        assert transactions[0].date == date(2026, 3, 25)
+        assert transactions[1].date == date(2026, 3, 7)
+
+    def test_parse_qif_ambiguous_file_keeps_us_default(self):
+        """A fully ambiguous file keeps the historical MM/DD-first order."""
+        qif_content = (
+            "D07/03/2026\n"
+            "T-20.00\n"
+            "^\n"
+        )
+        transactions = parse_qif(qif_content.encode("utf-8"))
+        assert transactions[0].date == date(2026, 7, 3)
+
+    def test_parse_qif_explicit_format_two_digit_year(self):
+        qif_content = (
+            "D07/03/26\n"
+            "T-100.00\n"
+            "^\n"
+        )
+        transactions = parse_qif(qif_content.encode("utf-8"), date_format="DD/MM/YYYY")
+        assert transactions[0].date == date(2026, 3, 7)
+
     def test_parse_qif_memo_as_description(self):
         """When no payee, memo should be used as description."""
         qif_content = (

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -924,6 +924,7 @@
     "transactionsImported": "Transaktionen importiert",
     "importedWithSkipped": "{{imported}} importiert, {{skipped}} Duplikate übersprungen",
     "csvOptions": "CSV-Optionen",
+    "importOptions": "Importoptionen",
     "dateFormat": "Datumsformat",
     "dateFormatAuto": "Automatisch (erkennen)",
     "flipAmounts": "Beträge umkehren (Einnahmen/Ausgaben tauschen)",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -924,6 +924,7 @@
     "transactionsImported": "transactions imported",
     "importedWithSkipped": "{{imported}} imported, {{skipped}} duplicates skipped",
     "csvOptions": "CSV Options",
+    "importOptions": "Import options",
     "dateFormat": "Date format",
     "dateFormatAuto": "Auto (detect)",
     "flipAmounts": "Negate amounts (swap income/expense)",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -924,6 +924,7 @@
     "transactionsImported": "transacciones importadas",
     "importedWithSkipped": "{{imported}} importadas, {{skipped}} duplicadas omitidas",
     "csvOptions": "Opciones CSV",
+    "importOptions": "Opciones de importación",
     "dateFormat": "Formato de fecha",
     "dateFormatAuto": "Automático (detectar)",
     "flipAmounts": "Invertir importes (intercambiar ingreso/gasto)",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -924,6 +924,7 @@
     "transactionsImported": "transactions importées",
     "importedWithSkipped": "{{imported}} importées, {{skipped}} doublons ignorés",
     "csvOptions": "Options CSV",
+    "importOptions": "Options d'importation",
     "dateFormat": "Format de date",
     "dateFormatAuto": "Auto (détection)",
     "flipAmounts": "Inverser les montants (échanger revenus/dépenses)",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -924,6 +924,7 @@
     "transactionsImported": "transazioni importate",
     "importedWithSkipped": "{{imported}} importate, {{skipped}} duplicati saltati",
     "csvOptions": "Opzioni CSV",
+    "importOptions": "Opzioni di importazione",
     "dateFormat": "Formato data",
     "dateFormatAuto": "Auto (rileva)",
     "flipAmounts": "Inverti importi (scambia entrate/spese)",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -978,6 +978,7 @@
     "transactionsImported": "zaimportowanych transakcji",
     "importedWithSkipped": "Zaimportowano: {{imported}}, pominięto duplikatów: {{skipped}}",
     "csvOptions": "Opcje CSV",
+    "importOptions": "Opcje importu",
     "dateFormat": "Format daty",
     "dateFormatAuto": "Auto (wykryj)",
     "flipAmounts": "Odwróć kwoty (zamień przychód/wydatek)",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -924,6 +924,7 @@
     "transactionsImported": "transações importadas",
     "importedWithSkipped": "{{imported}} importadas, {{skipped}} duplicatas ignoradas",
     "csvOptions": "Opções do CSV",
+    "importOptions": "Opções de importação",
     "dateFormat": "Formato da data",
     "dateFormatAuto": "Automático (detectar)",
     "flipAmounts": "Inverter valores (trocar entrada/saída)",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -924,6 +924,7 @@
     "transactionsImported": "transações importadas",
     "importedWithSkipped": "{{imported}} importadas, {{skipped}} duplicatas ignoradas",
     "csvOptions": "Opções do CSV",
+    "importOptions": "Opções de importação",
     "dateFormat": "Formato da data",
     "dateFormatAuto": "Automático (detectar)",
     "flipAmounts": "Inverter valores (trocar entrada/saída)",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -924,6 +924,7 @@
     "transactionsImported": "импортировано транзакций",
     "importedWithSkipped": "{{imported}} импортировано, {{skipped}} дубликатов пропущено",
     "csvOptions": "Настройки CSV",
+    "importOptions": "Параметры импорта",
     "dateFormat": "Формат даты",
     "dateFormatAuto": "Авто (определить)",
     "flipAmounts": "Инвертировать суммы (поменять доход/расход)",

--- a/frontend/src/locales/uk.json
+++ b/frontend/src/locales/uk.json
@@ -924,6 +924,7 @@
     "transactionsImported": "імпортовано транзакцій",
     "importedWithSkipped": "{{imported}} імпортовано, {{skipped}} дублікатів пропущено",
     "csvOptions": "Налаштування CSV",
+    "importOptions": "Параметри імпорту",
     "dateFormat": "Формат дати",
     "dateFormatAuto": "Авто (визначити)",
     "flipAmounts": "Інвертувати суми (поміняти дохід/витрату)",

--- a/frontend/src/pages/import.tsx
+++ b/frontend/src/pages/import.tsx
@@ -274,6 +274,9 @@ export default function ImportPage() {
   }, [])
 
   const isCsvFile = fileName?.toLowerCase().endsWith('.csv') ?? false
+  // QIF dates are ambiguous for days 1-12 (DD/MM vs MM/DD), so the file
+  // options panel is shown for QIF too, limited to the date-format selector.
+  const isQifFile = fileName?.toLowerCase().endsWith('.qif') ?? false
 
   const incomeCount = previewData?.transactions.filter(t => t.type === 'credit').length ?? 0
   const expenseCount = previewData?.transactions.filter(t => t.type === 'debit').length ?? 0
@@ -403,12 +406,14 @@ export default function ImportPage() {
             </div>
           </div>
 
-          {/* CSV Options */}
-          {isCsvFile && previewData && (
+          {/* CSV/QIF Options */}
+          {(isCsvFile || isQifFile) && previewData && (
             <div className="px-5 py-4 border-b border-border bg-muted/30">
               <div className="flex items-center gap-2 mb-3">
                 <Settings2 size={14} className="text-muted-foreground" />
-                <p className="text-xs font-medium text-muted-foreground">{t('import.csvOptions')}</p>
+                <p className="text-xs font-medium text-muted-foreground">
+                  {isCsvFile ? t('import.csvOptions') : t('import.importOptions')}
+                </p>
               </div>
 
               {previewData.parse_error && (
@@ -431,7 +436,7 @@ export default function ImportPage() {
                     <option value="YYYY-MM-DD">YYYY-MM-DD</option>
                   </select>
                 </div>
-                <div className="flex items-center gap-2 pt-4">
+                {isCsvFile && <div className="flex items-center gap-2 pt-4">
                   <input
                     type="checkbox"
                     id="flip-amount"
@@ -442,8 +447,8 @@ export default function ImportPage() {
                   <Label htmlFor="flip-amount" className="text-sm text-muted-foreground cursor-pointer">
                     {t('import.flipAmounts')}
                   </Label>
-                </div>
-                <div className="flex items-center gap-2 pt-4">
+                </div>}
+                {isCsvFile && <div className="flex items-center gap-2 pt-4">
                   <input
                     type="checkbox"
                     id="split-columns"
@@ -454,8 +459,8 @@ export default function ImportPage() {
                   <Label htmlFor="split-columns" className="text-sm text-muted-foreground cursor-pointer">
                     {t('import.splitColumns')}
                   </Label>
-                </div>
-                <div className="flex items-center gap-2 pt-4">
+                </div>}
+                {isCsvFile && <div className="flex items-center gap-2 pt-4">
                   <input
                     type="checkbox"
                     id="detect-duplicates"
@@ -466,7 +471,7 @@ export default function ImportPage() {
                   <Label htmlFor="detect-duplicates" className="text-sm text-muted-foreground cursor-pointer">
                     {t('import.detectDuplicates')}
                   </Label>
-                </div>
+                </div>}
               </div>
 
               {csvSplitColumns && csvHeaders.length > 0 && (


### PR DESCRIPTION
## Summary

Fixes #518. `parse_qif` tried `%m/%d/%Y` before `%d/%m/%Y` independently per transaction, so importing a DD/MM statement silently misdated every transaction on days 1-12 (~39% of a typical file) while the rest parsed correctly — corrupting monthly reports and budgets in a way that looks random.

## Changes

- **File-level format resolution**: the date format is decided once per file instead of first-match per line. Without an explicit choice, the order is inferred from the whole file: any date with a first component > 12 can only be DD/MM, so a single unambiguous date pins the entire import (a file can no longer mix MM/DD and DD/MM). Fully ambiguous files keep the historical US-first default.
- **Explicit format is strict**: the `date_format` form field the API already accepted is now threaded through to `parse_qif` (same semantics as CSV: only the chosen format plus its 2-digit-year variant).
- **Frontend**: the import options panel now appears for QIF files with the date-format selector; CSV-only controls (negate amounts, split columns, duplicate detection, column mapping) stay hidden. New `import.importOptions` label added to all 10 locales.

## Validation

- New parser tests: explicit DD/MM and MM/DD, file-level inference, ambiguous-file default, 2-digit years (`pytest tests/test_import_service.py`: 106 passed).
- `ruff`/`ty` clean; frontend `tsc -b`, `vitest` (56 passed), lint with no errors.
- Verified end-to-end in the browser: a DD/MM QIF previews with correct March dates via inference, and switching the selector to MM/DD/YYYY re-previews with month-first parsing.

Closes #518