### PR TITLE
fix: setup page layout broken by overflowing language buttons

### DIFF
--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -52,6 +52,23 @@ i18n.on('languageChanged', syncHtmlLang)
 
 export type SupportedLang = 'pt-BR' | 'pt-PT' | 'en' | 'es' | 'pl' | 'it' | 'ru' | 'uk' | 'de' | 'fr'
 
+// Single source of truth for language pickers. When adding a locale, register
+// the bundle above and add one entry here; every picker stays in sync instead
+// of each hand-rolling its own list (the setup screen's button row broke a
+// little more with every translation PR before this existed).
+export const SUPPORTED_LANGS: { code: SupportedLang; label: string }[] = [
+  { code: 'en', label: 'English' },
+  { code: 'pt-BR', label: 'Português (BR)' },
+  { code: 'pt-PT', label: 'Português (PT)' },
+  { code: 'es', label: 'Español' },
+  { code: 'fr', label: 'Français' },
+  { code: 'de', label: 'Deutsch' },
+  { code: 'it', label: 'Italiano' },
+  { code: 'pl', label: 'Polski' },
+  { code: 'ru', label: 'Русский' },
+  { code: 'uk', label: 'Українська' },
+]
+
 // Normalise any browser/i18n language tag to one of our supported keys. The
 // backend and resource bundles key Portuguese as the region-tagged 'pt-BR'
 // while 'en'/'es' are bare, so naively truncating to the primary subtag

--- a/frontend/src/pages/setup.tsx
+++ b/frontend/src/pages/setup.tsx
@@ -10,6 +10,13 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardFooter } from '@/components/ui/card'
 import { CurrencySelect } from '@/components/currency-select'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { AuthBrandPanel } from '@/components/auth-brand-panel'
 import { cn } from '@/lib/utils'
 import { Sun, Moon, Globe } from 'lucide-react'
@@ -101,15 +108,16 @@ export default function SetupPage() {
                   <Globe size={14} />
                   {t('setup.language')}
                 </Label>
-                <select
-                  value={currentLang}
-                  onChange={(e) => i18n.changeLanguage(e.target.value)}
-                  className="w-full border border-border rounded-lg px-2 py-1.5 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                >
-                  {SUPPORTED_LANGS.map(({ code, label }) => (
-                    <option key={code} value={code}>{label}</option>
-                  ))}
-                </select>
+                <Select value={currentLang} onValueChange={(lng) => i18n.changeLanguage(lng)}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SUPPORTED_LANGS.map(({ code, label }) => (
+                      <SelectItem key={code} value={code}>{label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
               <div className="space-y-1.5">
                 <Label className="text-sm">{t('setup.theme')}</Label>

--- a/frontend/src/pages/setup.tsx
+++ b/frontend/src/pages/setup.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from 'next-themes'
 import { setup } from '@/lib/api'
-import { resolveSupportedLang } from '@/lib/i18n'
+import { resolveSupportedLang, SUPPORTED_LANGS } from '@/lib/i18n'
 import { useAuth } from '@/contexts/auth-context'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -96,133 +96,20 @@ export default function SetupPage() {
               </div>
             )}
             <div className="flex items-center justify-between gap-4">
-              <div className="space-y-1.5">
+              <div className="space-y-1.5 min-w-0 flex-1">
                 <Label className="text-sm flex items-center gap-1.5">
                   <Globe size={14} />
                   {t('setup.language')}
                 </Label>
-                <div className="flex items-center gap-1">
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('ru')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'ru'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    RU
-                  </button>
-                   <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('de')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'de'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    DE
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('uk')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'uk'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    UK
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('en')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'en'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    EN
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('es')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'es'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    ES
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('pl')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'pl'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    PL
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('it')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'it'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    IT
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('pt-BR')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'pt-BR'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    PT-BR
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('pt-PT')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'pt-PT'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    PT-PT
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => i18n.changeLanguage('fr')}
-                    className={cn(
-                      'px-2.5 py-1 rounded text-[11px] font-semibold transition-colors',
-                      currentLang === 'fr'
-                        ? 'bg-primary/15 text-primary'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    FR
-                  </button>
-                </div>
+                <select
+                  value={currentLang}
+                  onChange={(e) => i18n.changeLanguage(e.target.value)}
+                  className="w-full border border-border rounded-lg px-2 py-1.5 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                >
+                  {SUPPORTED_LANGS.map(({ code, label }) => (
+                    <option key={code} value={code}>{label}</option>
+                  ))}
+                </select>
               </div>
               <div className="space-y-1.5">
                 <Label className="text-sm">{t('setup.theme')}</Label>


### PR DESCRIPTION
## Summary

Fixes #503. The first-run setup card rendered one pill button per locale in a non-wrapping flex row inside the 400px card. With 10 locales the row overflowed: the theme toggle was pushed **outside the card**, and the PT-BR/PT-PT labels wrapped mid-word. This regressed incrementally, each translation PR (#263, #278, #334, #346, #373, #455, #461) appended one more button.

## Changes

- Replaced the 10 hand-rolled buttons with a compact `<select>` (native language names), removing ~130 lines from `setup.tsx`.
- Added `SUPPORTED_LANGS` to `lib/i18n.ts` as the single source of truth for language pickers: adding a locale is now one entry in the same file that registers the bundle, and the setup layout can no longer regress.

## Validation

Reproduced and verified against a real empty deployment (throwaway database + ephemeral backend, `has_users: false`):

- **Before**: theme block floating outside the card, labels wrapping mid-word.
- **After**: selector and theme toggle side by side inside the card.
- Full flow exercised in the browser: switched the selector to Português (BR) (whole page re-rendered in pt-BR), created the admin account, landed on the dashboard with the chosen language persisted.
- `tsc -b`, `eslint`, `vitest` (56 passed) all clean.

Follow-up candidate (not in this PR): `app-layout.tsx` still hand-rolls its own per-locale dropdown items and could consume `SUPPORTED_LANGS` too.

Closes #503