### PR TITLE
refactor(frontend): share currency formatter

### DIFF
--- a/frontend/src/components/app-layout.tsx
+++ b/frontend/src/components/app-layout.tsx
@@ -70,6 +70,7 @@ import { GlobalChatPanel } from '@/components/global-chat-panel'
 import { useFeatureFlags } from '@/hooks/use-feature-flags'
 import { Bot, Search, Sparkles } from 'lucide-react'
 import { setThemeBasedOnSystem } from '@/lib/theme-utils'
+import { formatCurrency } from '@/lib/format'
 
 type NavItem =
   | { type: 'link'; key: string; path: string; icon: React.ElementType }
@@ -96,12 +97,6 @@ const navItems: NavItem[] = [
   { type: 'link', key: 'splitGroups', path: '/groups', icon: Split },
   { type: 'link', key: 'rules', path: '/rules', icon: SlidersHorizontal },
 ]
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(
-    value,
-  )
-}
 
 export function AppLayout() {
   const { t } = useTranslation()

--- a/frontend/src/components/link-transfer-dialog.tsx
+++ b/frontend/src/components/link-transfer-dialog.tsx
@@ -16,10 +16,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { ArrowRight, AlertTriangle, Info, ArrowLeft, Search, Sparkles } from 'lucide-react'
 import { transactions as transactionsApi } from '@/lib/api'
 import type { Account, Transaction } from '@/types'
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
-}
+import { formatCurrency } from '@/lib/format'
 
 type CounterpartCardProps = {
   label: string

--- a/frontend/src/components/mobile-transaction-row.tsx
+++ b/frontend/src/components/mobile-transaction-row.tsx
@@ -5,10 +5,7 @@ import type { Transaction, Account } from '@/types'
 import { AlertTriangle, ArrowLeftRight, Clock, EyeClosed, Paperclip } from 'lucide-react'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useTranslation } from 'react-i18next'
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
-}
+import { formatCurrency } from '@/lib/format'
 
 interface MobileTransactionRowProps {
   tx: Transaction

--- a/frontend/src/components/transaction-calendar-view.tsx
+++ b/frontend/src/components/transaction-calendar-view.tsx
@@ -10,13 +10,10 @@ import { getAccountName } from '@/lib/account-utils'
 import { activityChartData, dayActivity } from '@/lib/calendar-activity'
 import { weekdayShortLabels } from '@/lib/date-utils'
 import { cn } from '@/lib/utils'
+import { formatCurrency } from '@/lib/format'
 
 function parseLocalDate(value: string) {
   return new Date(`${value}T00:00:00`)
-}
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
 }
 
 function compactCurrency(value: number, currency = 'USD', locale = 'en-US') {

--- a/frontend/src/components/transaction-drill-down.tsx
+++ b/frontend/src/components/transaction-drill-down.tsx
@@ -8,6 +8,7 @@ import { CategoryIcon } from '@/components/category-icon'
 import { useAuth } from '@/contexts/auth-context'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import type { Transaction } from '@/types'
+import { formatCurrency } from '@/lib/format'
 
 export type DrillDownFilter = {
   title: string
@@ -35,10 +36,6 @@ type DisplayItem = {
   isProjected: boolean
   attachmentCount: number
   transaction: Transaction | null
-}
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
 }
 
 export function TransactionDrillDown({

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -139,7 +139,27 @@ export function resolveDateLocale(
 }
 
 /**
+ * Build a currency formatter, falling back to a known-good locale *and*
+ * currency. A malformed locale throws just like a malformed currency code
+ * does, and `useDisplayLocale` can surface one (i18next reads `?lng=` from
+ * the querystring), so the fallback has to replace both.
+ */
+function currencyFormatter(currency: string, locale: string): Intl.NumberFormat {
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: currency || 'USD',
+    })
+  } catch {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+  }
+}
+
+/**
  * Format a numeric value as currency using Intl.NumberFormat.
+ *
+ * Fraction digits are left to Intl so each currency keeps its own precision:
+ * pinning two would render JPY as "￥1,000.00" and CLP as "$1.000,00".
  */
 export function formatCurrency(
   value: number | null | undefined,
@@ -147,21 +167,10 @@ export function formatCurrency(
   locale = 'en-US',
 ): string {
   if (value == null) return '—'
-  // Normalize -0 to 0 so we never render "-R$ 0,00" / "-$0.00"
-  const v = Object.is(value, -0) ? 0 : value
-  try {
-    return new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency: currency || 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(v)
-  } catch {
-    return new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(v)
-  }
+  const formatter = currencyFormatter(currency, locale)
+  // Anything that rounds to zero at the currency's own precision would render
+  // with a stray minus ("-R$ 0,00"), which covers -0 as well as the sub-cent
+  // residue that summed balances and FX conversions leave behind.
+  const factor = 10 ** (formatter.resolvedOptions().maximumFractionDigits ?? 2)
+  return formatter.format(Math.round(value * factor) === 0 ? 0 : value)
 }

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -147,10 +147,21 @@ export function formatCurrency(
   locale = 'en-US',
 ): string {
   if (value == null) return '—'
-  return new Intl.NumberFormat(locale, {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value)
+  // Normalize -0 to 0 so we never render "-R$ 0,00" / "-$0.00"
+  const v = Object.is(value, -0) ? 0 : value
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: currency || 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(v)
+  } catch {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(v)
+  }
 }

--- a/frontend/src/pages/account-detail.tsx
+++ b/frontend/src/pages/account-detail.tsx
@@ -25,6 +25,7 @@ import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
 import { resolveDateFnsLocale } from '@/lib/date-fns-locale'
+import { formatCurrency } from '@/lib/format'
 import {
   AreaChart,
   Area,
@@ -228,10 +229,6 @@ function creditCardCycleBoundaries(
     start: format(start, 'yyyy-MM-dd'),
     end: format(end, 'yyyy-MM-dd'),
   }
-}
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
 }
 
 function formatDateStr(dateStr: string, locale = 'pt-BR') {

--- a/frontend/src/pages/accounts.tsx
+++ b/frontend/src/pages/accounts.tsx
@@ -37,6 +37,7 @@ import { ConnectionSettingsDialog } from '@/components/connection-settings-dialo
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
+import { formatCurrency } from '@/lib/format'
 
 // Account types offered in the create/edit dialog. Shared between the manual
 // type selector and the connected-account override selector so the list stays
@@ -48,10 +49,6 @@ const ACCOUNT_TYPE_OPTIONS = [
   { value: 'investment', labelKey: 'accounts.typeInvestment' },
   { value: 'wallet', labelKey: 'accounts.typeWallet' },
 ] as const
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
-}
 
 function daysUntil(dateStr: string | null): number | null {
   if (!dateStr) return null

--- a/frontend/src/pages/assets.tsx
+++ b/frontend/src/pages/assets.tsx
@@ -55,14 +55,7 @@ import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
 import { useCollectionFilter } from '@/contexts/collection-filter-context'
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  try {
-    return new Intl.NumberFormat(locale, { style: 'currency', currency: currency || 'USD' }).format(value)
-  } catch {
-    return new Intl.NumberFormat(locale, { style: 'currency', currency: 'USD' }).format(value)
-  }
-}
+import { formatCurrency } from '@/lib/format'
 
 // Renders a logo image when one is available, falling back to the asset's
 // type-based Lucide icon on missing URL or broken image. Uses the type's

--- a/frontend/src/pages/budgets.tsx
+++ b/frontend/src/pages/budgets.tsx
@@ -26,10 +26,7 @@ import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
 import { resolveDateFnsLocale } from '@/lib/date-fns-locale'
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
-}
+import { formatCurrency } from '@/lib/format'
 
 function currentMonth() {
   const now = new Date()

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -51,11 +51,7 @@ import { useAuth } from '@/contexts/auth-context'
 import { useCollectionFilter } from '@/contexts/collection-filter-context'
 import { resolveDateFnsLocale } from '@/lib/date-fns-locale'
 import type { Rule, Transaction } from '@/types'
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
-}
-
+import { formatCurrency } from '@/lib/format'
 
 function formatDate(dateStr: string, locale = 'pt-BR') {
   return new Date(dateStr + 'T00:00:00').toLocaleDateString(locale)

--- a/frontend/src/pages/goals.tsx
+++ b/frontend/src/pages/goals.tsx
@@ -32,10 +32,7 @@ import { PageHeader } from '@/components/page-header'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
-}
+import { formatCurrency } from '@/lib/format'
 
 function getGoalIcon(iconKey: string | null) {
   return (iconKey && ICON_MAP[iconKey]) || Target

--- a/frontend/src/pages/group-detail.tsx
+++ b/frontend/src/pages/group-detail.tsx
@@ -50,10 +50,7 @@ import { CategoryIcon } from '@/components/category-icon'
 import { DatePickerInput } from '@/components/ui/date-picker-input'
 import { PageHeader } from '@/components/page-header'
 import type { GroupMember, GroupSettlement, Transaction } from '@/types'
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
-}
+import { formatCurrency } from '@/lib/format'
 
 function SectionCard({ children }: { children: React.ReactNode }) {
   return (

--- a/frontend/src/pages/payees.tsx
+++ b/frontend/src/pages/payees.tsx
@@ -46,10 +46,7 @@ import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
 import type { Payee } from '@/types'
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
-}
+import { formatCurrency } from '@/lib/format'
 
 export default function PayeesPage() {
   const { t } = useTranslation()

--- a/frontend/src/pages/recurring.tsx
+++ b/frontend/src/pages/recurring.tsx
@@ -26,10 +26,7 @@ import { DatePickerInput } from '@/components/ui/date-picker-input'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
-}
+import { formatCurrency } from '@/lib/format'
 
 const TH = 'text-xs font-medium text-muted-foreground py-3'
 

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -28,6 +28,7 @@ import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
 import { useCollectionFilter } from '@/contexts/collection-filter-context'
 import type { ReportResponse, CategoryTrendItem } from '@/types'
+import { formatCurrency } from '@/lib/format'
 
 // A small qualitative palette of well-separated hues for the composition
 // detail ring. Capped to a handful of slices, distinct colours make each
@@ -48,10 +49,6 @@ const SLICE_COLORS = [
   '#06B6D4', // cyan
 ]
 const OTHER_SLICE_COLOR = '#9CA3AF'
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
-}
 
 function formatCompact(value: number, currency = 'USD', locale = 'en-US') {
   return new Intl.NumberFormat(locale, {

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -58,6 +58,7 @@ import { MobileTransactionRow } from '@/components/mobile-transaction-row'
 import { useAuth } from '@/contexts/auth-context'
 import { useWorkspace } from '@/contexts/workspace-context'
 import { useCollectionFilter } from '@/contexts/collection-filter-context'
+import { formatCurrency } from '@/lib/format'
 
 type TransactionUpdatePayload = Partial<Transaction> & {
   apply_to_transfer_pair?: boolean
@@ -66,10 +67,6 @@ type TransactionUpdatePayload = Partial<Transaction> & {
 type PendingTransferCategoryUpdate = {
   id: string
   data: TransactionUpdatePayload
-}
-
-function formatCurrency(value: number, currency = 'USD', locale = 'en-US') {
-  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value)
 }
 
 function parseHashtags(notes: string | null): string[] {


### PR DESCRIPTION
## What

- Centralize currency formatting in the shared frontend formatter.
- Replace duplicated page and component helpers with the shared utility.
- Normalize negative zero and fall back safely when a currency code is invalid.

## Why

The account-detail work exposed several copies of the same formatter. Keeping the cleanup separate makes the functional and layout reviews smaller and prevents formatting behavior from drifting between screens.

## How to Test

1. Run `cd frontend && ./node_modules/.bin/tsc --noEmit -p tsconfig.app.json`.
2. Run `cd frontend && ./node_modules/.bin/vitest run`.
3. Open screens that display monetary values and verify currencies render as before, including zero values.

## Related Issue

Extracted from [securo-finance/securo#526](https://github.com/securo-finance/securo/pull/526).

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
- [x] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))
