### PR TITLE
feat: sort account pickers by display name

### DIFF
--- a/frontend/src/components/link-transfer-dialog.tsx
+++ b/frontend/src/components/link-transfer-dialog.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { getAccountName } from '@/lib/account-utils'
+import { getAccountName, sortAccountsByDisplayName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
 import { useQuery } from '@tanstack/react-query'
@@ -158,8 +158,8 @@ export function LinkTransferDialog({
     // Manual accounts (no bank connection) where we can auto-create the
     // counterpart, since a synced account would already have a real
     // transaction showing in the candidates list above.
-    const manualCounterpartAccounts = accounts.filter(
-      (a) => a.connection_id == null && a.id !== anchor!.account_id,
+    const manualCounterpartAccounts = sortAccountsByDisplayName(
+      accounts.filter((a) => a.connection_id == null && a.id !== anchor!.account_id),
     )
 
     return (

--- a/frontend/src/components/rule-dialog.tsx
+++ b/frontend/src/components/rule-dialog.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { getAccountName } from '@/lib/account-utils'
+import { getAccountName, sortAccountsByDisplayName } from '@/lib/account-utils'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
@@ -72,13 +72,14 @@ export function RuleDialog({
   rule: Rule | null
   categories: Category[]
   categoryGroups: CategoryGroup[]
-  accounts: { id: string; name: string }[]
+  accounts: { id: string; name: string; display_name?: string | null }[]
   payees: Payee[]
   onSave: (data: Partial<Rule>) => void
   loading: boolean
   initialData?: RuleDialogInitialData
 }) {
   const { t } = useTranslation()
+  const sortedAccounts = useMemo(() => sortAccountsByDisplayName(accounts), [accounts])
 
   const defaultConditions: RuleCondition[] = initialData?.conditions ?? rule?.conditions as RuleCondition[] ?? [{ field: 'description', op: 'contains', value: '' }]
   const defaultActions: RuleAction[] = initialData?.actions ?? rule?.actions as RuleAction[] ?? [{ op: 'set_category', value: '' }]
@@ -234,7 +235,7 @@ export function RuleDialog({
                       onChange={(e) => updateCondition(i, 'value', e.target.value)}
                     >
                       <option value="">{t('rules.selectAccount')}</option>
-                      {accounts.map(acc => (
+                      {sortedAccounts.map(acc => (
                         <option key={acc.id} value={acc.id}>{getAccountName(acc)}</option>
                       ))}
                     </select>

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { getAccountLabel, getAccountName } from '@/lib/account-utils'
+import { getAccountLabel, getAccountName, sortAccountsByDisplayName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useDateLocale, useDisplayLocale } from '@/hooks/use-display-locale'
 import { formatCurrency } from '@/lib/format'
@@ -435,6 +435,7 @@ function TransactionForm({
   const userCurrency = user?.preferences?.currency_display ?? 'USD'
   const dateLocale = useDateLocale()
   const displayLocale = useDisplayLocale()
+  const sortedAccounts = useMemo(() => sortAccountsByDisplayName(accounts), [accounts])
   const { data: supportedCurrencies } = useQuery({
     queryKey: ['currencies'],
     queryFn: currenciesApi.list,
@@ -453,7 +454,7 @@ function TransactionForm({
   const [currency, setCurrency] = useState(seed?.currency ?? userCurrency)
   const [categoryId, setCategoryId] = useState(seed?.category_id ?? '')
   const [payeeId, setPayeeId] = useState(seed?.payee_id ?? '')
-  const [accountId, setAccountId] = useState(seed?.account_id ?? accounts[0]?.id ?? '')
+  const [accountId, setAccountId] = useState(seed?.account_id ?? sortedAccounts[0]?.id ?? '')
   const [notes, setNotes] = useState(seed?.notes ?? '')
   // Manual CC bucketing override (issue #92). Empty = auto. Visible only
   // when the selected account is a credit card.
@@ -1081,7 +1082,7 @@ function TransactionForm({
               onChange={(e) => setAccountId(e.target.value)}
               required
             >
-              {accounts.map((acc) => (
+              {sortedAccounts.map((acc) => (
                 <option key={acc.id} value={acc.id}>{getAccountLabel(acc)}</option>
               ))}
             </select>

--- a/frontend/src/components/transactions-filter-bar.tsx
+++ b/frontend/src/components/transactions-filter-bar.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from 'react'
-import { getAccountName } from '@/lib/account-utils'
+import { getAccountName, sortAccountsByDisplayName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
 import { startOfMonth, startOfYear, subDays } from 'date-fns'
@@ -135,6 +135,7 @@ export function TransactionsFilterBar({
   const [draftMaxAmount, setDraftMaxAmount] = useState<string>(filterMaxAmount)
   const [mobileFilterView, setMobileFilterView] = useState<MobileFilterView>('root')
   const searchRef = useRef<HTMLInputElement>(null)
+  const sortedAccounts = useMemo(() => sortAccountsByDisplayName(accounts), [accounts])
 
   // When a CheckRow is clicked inside a submenu, Radix tries to close the submenu
   // even if we preventDefault in onSelect. We intercept the close request so the
@@ -399,7 +400,7 @@ export function TransactionsFilterBar({
                 view={mobileFilterView}
                 setView={setMobileFilterView}
                 setMenuOpen={setMenuOpen}
-                accounts={accounts}
+                accounts={sortedAccounts}
                 categories={categories}
                 categoryGroups={categoryGroups}
                 payees={payees}
@@ -488,12 +489,12 @@ export function TransactionsFilterBar({
                           <div className="my-1 h-px bg-border/60" />
                         </>
                       )}
-                      {accounts.length === 0 ? (
+                      {sortedAccounts.length === 0 ? (
                         <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
                           {t('transactions.filtersBar.noOptions')}
                         </div>
                       ) : accountSelectionMode === 'single' ? (
-                        accounts.map((a) => {
+                        sortedAccounts.map((a) => {
                           const checked = filterAccountIds[0] === a.id
                           return (
                             <DropdownMenuItem
@@ -519,7 +520,7 @@ export function TransactionsFilterBar({
                           )
                         })
                       ) : (
-                        accounts.map((a) => (
+                        sortedAccounts.map((a) => (
                           <DropdownMenuCheckboxItem
                             key={a.id}
                             checked={filterAccountIds.includes(a.id)}

--- a/frontend/src/components/transfer-dialog.tsx
+++ b/frontend/src/components/transfer-dialog.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react'
-import { getAccountLabel } from '@/lib/account-utils'
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { getAccountLabel, sortAccountsByDisplayName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { localDateString } from '@/lib/date-utils'
 import { Button } from '@/components/ui/button'
@@ -40,7 +40,9 @@ export function TransferDialog({
   defaultFromAccountId?: string
 }) {
   const { t } = useTranslation()
-  const [fromAccountId, setFromAccountId] = useState(defaultFromAccountId || (accounts[0]?.id ?? ''))
+  const sortedAccounts = useMemo(() => sortAccountsByDisplayName(accounts), [accounts])
+  const firstAccountId = sortedAccounts[0]?.id ?? ''
+  const [fromAccountId, setFromAccountId] = useState(defaultFromAccountId || firstAccountId)
   const [toAccountId, setToAccountId] = useState('')
   const [amount, setAmount] = useState('')
   const [date, setDate] = useState(localDateString)
@@ -50,14 +52,14 @@ export function TransferDialog({
 
   // Reset form when dialog opens
   const resetForm = useCallback(() => {
-    setFromAccountId(defaultFromAccountId || (accounts[0]?.id ?? ''))
+    setFromAccountId(defaultFromAccountId || firstAccountId)
     setToAccountId('')
     setAmount('')
     setDate(localDateString())
     setDescription('')
     setNotes('')
     setDestinationAmount('')
-  }, [defaultFromAccountId, accounts])
+  }, [defaultFromAccountId, firstAccountId])
 
   useEffect(() => {
     if (open) resetForm()
@@ -68,7 +70,7 @@ export function TransferDialog({
   const isCrossCurrency = fromAccount && toAccount && fromAccount.currency !== toAccount.currency
   const isSameAccount = fromAccountId && toAccountId && fromAccountId === toAccountId
 
-  const availableToAccounts = accounts.filter((a) => a.id !== fromAccountId)
+  const availableToAccounts = sortedAccounts.filter((a) => a.id !== fromAccountId)
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
@@ -107,7 +109,7 @@ export function TransferDialog({
                 required
               >
                 <option value="" disabled>{t('transactions.account')}</option>
-                {accounts.map((acc) => (
+                {sortedAccounts.map((acc) => (
                   <option key={acc.id} value={acc.id}>
                     {getAccountLabel(acc)} ({acc.currency})
                   </option>

--- a/frontend/src/lib/account-utils.test.ts
+++ b/frontend/src/lib/account-utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { sortAccountsByDisplayName } from './account-utils'
+
+describe('sortAccountsByDisplayName', () => {
+  it('orders accounts by display name when present and falls back to name', () => {
+    const accounts = [
+      { id: '1', name: 'Alpha', display_name: 'Vacation' },
+      { id: '2', name: 'Zulu', display_name: null },
+      { id: '3', name: 'Checking', display_name: 'Bills' },
+    ]
+
+    expect(sortAccountsByDisplayName(accounts).map((account) => account.id)).toEqual([
+      '3',
+      '1',
+      '2',
+    ])
+  })
+
+  it('does not mutate the API account list', () => {
+    const accounts = [{ name: 'Zulu' }, { name: 'Alpha' }]
+
+    sortAccountsByDisplayName(accounts)
+
+    expect(accounts.map((account) => account.name)).toEqual(['Zulu', 'Alpha'])
+  })
+})

--- a/frontend/src/lib/account-utils.ts
+++ b/frontend/src/lib/account-utils.ts
@@ -3,6 +3,21 @@ export function getAccountName(account: { name: string; display_name?: string | 
 }
 
 /**
+ * Return a presentation-only copy ordered by the name users see.
+ * The input is never mutated, which keeps React Query's cached account list intact.
+ */
+export function sortAccountsByDisplayName<
+  T extends { name: string; display_name?: string | null },
+>(accounts: readonly T[]): T[] {
+  return [...accounts].sort((left, right) =>
+    getAccountName(left).localeCompare(getAccountName(right), undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    }),
+  )
+}
+
+/**
  * The bank's identifier for an account, masked to its last 4 chars, e.g. "•••• 1234".
  *
  * Banks commonly report every account under the same label (often the holder's

--- a/frontend/src/pages/collections.tsx
+++ b/frontend/src/pages/collections.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { collections as collectionsApi, accounts as accountsApi, assetGroups as assetGroupsApi } from '@/lib/api'
-import { getAccountName } from '@/lib/account-utils'
+import { getAccountName, sortAccountsByDisplayName } from '@/lib/account-utils'
 import { PageHeader } from '@/components/page-header'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -124,7 +124,7 @@ export default function CollectionsPage() {
         open={dialogOpen}
         onClose={() => { setDialogOpen(false); setEditing(null) }}
         collection={editing}
-        accounts={(accounts ?? []).map((a) => ({ id: a.id, label: accountName.get(a.id) ?? a.name, currency: a.currency }))}
+        accounts={sortAccountsByDisplayName(accounts ?? []).map((a) => ({ id: a.id, label: accountName.get(a.id) ?? a.name, currency: a.currency }))}
         wallets={(wallets ?? []).map((w) => ({ id: w.id, label: w.name }))}
         loading={createMutation.isPending || updateMutation.isPending}
         onSave={(payload) => {

--- a/frontend/src/pages/goals.tsx
+++ b/frontend/src/pages/goals.tsx
@@ -1,5 +1,5 @@
 import { createElement, useState } from 'react'
-import { getAccountName } from '@/lib/account-utils'
+import { getAccountName, sortAccountsByDisplayName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useDisplayLocale } from '@/hooks/use-display-locale'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -540,7 +540,7 @@ export default function GoalsPage() {
                 label={t('goals.account')}
                 placeholder={t('goals.selectAccount')}
                 defaultValue={editing?.account_id}
-                items={accountsList}
+                items={sortAccountsByDisplayName(accountsList ?? [])}
                 renderOption={(acc) => `${getAccountName(acc)} (${acc.currency})`}
               />
             )}

--- a/frontend/src/pages/group-detail.tsx
+++ b/frontend/src/pages/group-detail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
+import { getAccountName, sortAccountsByDisplayName } from '@/lib/account-utils'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
@@ -1070,9 +1071,9 @@ export default function GroupDetailPage() {
                         onChange={(e) => setSettleAccountId(e.target.value)}
                       >
                         <option value="">{t('splitGroups.selectAccount')}</option>
-                        {(accountsList ?? []).map((a) => (
+                        {sortAccountsByDisplayName(accountsList ?? []).map((a) => (
                           <option key={a.id} value={a.id}>
-                            {a.display_name || a.name}
+                            {getAccountName(a)}
                           </option>
                         ))}
                       </select>

--- a/frontend/src/pages/import.tsx
+++ b/frontend/src/pages/import.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback } from 'react'
-import { getAccountName } from '@/lib/account-utils'
+import { getAccountName, sortAccountsByDisplayName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -393,7 +393,7 @@ export default function ImportPage() {
                 onChange={(e) => setSelectedAccount(e.target.value)}
               >
                 <option value="">{t('import.selectAccount')}</option>
-                {accountsList?.map((acc) => (
+                {sortAccountsByDisplayName(accountsList ?? []).map((acc) => (
                   <option key={acc.id} value={acc.id}>{getAccountName(acc)} ({t(TYPE_LABELS[acc.type] || acc.type)})</option>
                 ))}
               </select>

--- a/frontend/src/pages/recurring.tsx
+++ b/frontend/src/pages/recurring.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { getAccountName } from '@/lib/account-utils'
+import React, { useMemo, useState } from 'react'
+import { getAccountName, sortAccountsByDisplayName } from '@/lib/account-utils'
 import { useTranslation } from 'react-i18next'
 import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -279,7 +279,7 @@ function RecurringForm({
   recurring: RecurringTransaction | null
   categories: Category[]
   categoryGroups: CategoryGroup[]
-  accounts: { id: string; name: string }[]
+  accounts: { id: string; name: string; display_name?: string | null }[]
   onSave: (data: Partial<RecurringTransaction>) => void
   onCancel: () => void
   loading: boolean
@@ -287,6 +287,7 @@ function RecurringForm({
   const { t } = useTranslation()
   const { user } = useAuth()
   const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const sortedAccounts = useMemo(() => sortAccountsByDisplayName(accounts), [accounts])
   const { data: supportedCurrencies } = useQuery({
     queryKey: ['currencies'],
     queryFn: currenciesApi.list,
@@ -304,7 +305,7 @@ function RecurringForm({
   const [startDate, setStartDate] = useState(recurring?.start_date ?? localDateString())
   const [endDate, setEndDate] = useState(recurring?.end_date ?? '')
   const [categoryId, setCategoryId] = useState(recurring?.category_id ?? '')
-  const [accountId, setAccountId] = useState(recurring?.account_id ?? accounts[0]?.id ?? '')
+  const [accountId, setAccountId] = useState(recurring?.account_id ?? sortedAccounts[0]?.id ?? '')
   const [isActive, setIsActive] = useState(recurring?.is_active ?? true)
   const [autoGenerate, setAutoGenerate] = useState(recurring?.auto_generate ?? true)
 
@@ -417,7 +418,7 @@ function RecurringForm({
             required
           >
             {!accountId && <option value="" disabled>{t('recurring.noAccount')}</option>}
-            {accounts.map((acc) => (
+            {sortedAccounts.map((acc) => (
               <option key={acc.id} value={acc.id}>{getAccountName(acc)}</option>
             ))}
           </select>


### PR DESCRIPTION
## What

- Add a shared, non-mutating helper that orders accounts by `display_name` when present and falls back to `name`.
- Apply the ordering consistently to account pickers in:
  - transaction and recurring transaction dialogs
  - transfer and linked-transfer dialogs
  - transaction filters on desktop and mobile
  - rules
  - imports
  - goals
  - collections
  - group settlements
- Update recurring and rule dialog account types to include the optional `display_name` field.
- Add unit coverage for display-name fallback ordering and input immutability.
- Keep the accounts API contract and backend ordering unchanged.

## Why

Account pickers display a user-defined account name when available, but previously inherited API ordering based on the canonical provider name. As a result, the visible options could appear out of alphabetical order.

Keeping this as presentation-only sorting avoids changing API consumers, account-listing behavior, or the canonical account name.

## How to Test

1. Create or sync several accounts with canonical names that sort differently from their display names.
2. Set display names on some, but not all, accounts.
3. Verify account options are ordered by the visible name in transaction, recurring transaction, transfer, linked-transfer, filter, rule, import, goal, collection, and group-settlement pickers.
4. Verify accounts without a display name are ordered using their canonical name.
5. Verify new transaction, recurring transaction, and transfer forms select the first visible account option.
6. Verify editing existing records and explicit transfer defaults preserve their selected account.
7. Verify the accounts API still returns canonical `name` and a separate `display_name`.

Automated verification performed:

- `npm test -- src/lib/account-utils.test.ts`
- `npm run build`
- `npm run lint` (passes with existing repository warnings)
- `git diff --check`

## Related Issue

Closes #589

## Checklist

- [x] Backend behavior is unchanged; backend tests are not required for this frontend-only change
- [x] Frontend lints complete without errors (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] No translations required (no user-facing strings changed)
- [x] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))
