### PR TITLE
feat(agents): add OrcaRouter as a named LLM provider connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Rates are fetched on-demand when foreign-currency transactions are created. With
 
 ## AI Agents (Optional)
 
-Self-hosted AI assistants over your Securo data — multi-provider (OpenAI, Anthropic, Ollama, OpenAI-compatible), tool-use via MCP, per-agent RAG knowledge base, ⌘J global chat panel.
+Self-hosted AI assistants over your Securo data — multi-provider (OpenAI, Anthropic, Ollama, OpenAI-compatible, OrcaRouter), tool-use via MCP, per-agent RAG knowledge base, ⌘J global chat panel.
 
 Add to `.env`:
 

--- a/backend/app/agents/models/connection.py
+++ b/backend/app/agents/models/connection.py
@@ -24,7 +24,7 @@ class LlmConnection(Base):
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), index=True)
 
     name: Mapped[str] = mapped_column(String(120))
-    # kind ∈ {"ollama","openai","anthropic","openai_compatible"}
+    # kind ∈ {"ollama","openai","anthropic","openai_compatible","orcarouter"}
     kind: Mapped[str] = mapped_column(String(40))
 
     # Endpoint base URL. Optional for openai/anthropic (they have defaults).

--- a/backend/app/agents/providers/orcarouter.py
+++ b/backend/app/agents/providers/orcarouter.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from app.agents.providers.openai_compatible import OpenAICompatibleProvider
+
+
+class OrcaRouterProvider(OpenAICompatibleProvider):
+    """OrcaRouter (https://www.orcarouter.ai) — an OpenAI-compatible router
+    exposing 200+ models (OpenAI, Anthropic, Google, DeepSeek, ...) behind a
+    single API key.
+
+    Same ``/v1/chat/completions`` wire format as OpenAI, so we inherit the
+    OpenAI-compatible client and just preset the public endpoint. The base
+    URL stays configurable for self-hosted or regional deployments; a
+    connection without one uses the public ``https://api.orcarouter.ai/v1``.
+    """
+
+    name = "orcarouter"
+
+    def __init__(self, *, api_key: str = "", base_url: str = "https://api.orcarouter.ai/v1", model: Optional[str] = None):
+        super().__init__(api_key=api_key, base_url=base_url, model=model)

--- a/backend/app/agents/providers/registry.py
+++ b/backend/app/agents/providers/registry.py
@@ -7,6 +7,7 @@ from app.agents.providers.base import LLMProvider
 from app.agents.providers.ollama import OllamaProvider
 from app.agents.providers.openai import OpenAIProvider
 from app.agents.providers.openai_compatible import OpenAICompatibleProvider
+from app.agents.providers.orcarouter import OrcaRouterProvider
 
 
 _PROVIDERS: dict[str, type[LLMProvider]] = {
@@ -14,6 +15,7 @@ _PROVIDERS: dict[str, type[LLMProvider]] = {
     "openai": OpenAIProvider,
     "anthropic": AnthropicProvider,
     "openai_compatible": OpenAICompatibleProvider,
+    "orcarouter": OrcaRouterProvider,
 }
 
 

--- a/backend/app/agents/runtime/executor.py
+++ b/backend/app/agents/runtime/executor.py
@@ -85,6 +85,8 @@ def _provider_for(agent: Agent):
     elif name == "openai_compatible":
         api_key = os.getenv("AGENTS_OPENAI_COMPAT_API_KEY", "")
         base_url = os.getenv("AGENTS_OPENAI_COMPAT_BASE_URL")
+    elif name == "orcarouter":
+        api_key = os.getenv("AGENTS_ORCAROUTER_API_KEY", "")
     return build_provider(name, api_key=api_key, base_url=base_url, model=agent.model)
 
 

--- a/backend/app/agents/schemas/connection.py
+++ b/backend/app/agents/schemas/connection.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class ConnectionCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=120)
-    kind: str = Field(..., description="ollama|openai|anthropic|openai_compatible")
+    kind: str = Field(..., description="ollama|openai|anthropic|openai_compatible|orcarouter")
     base_url: Optional[str] = None
     api_key: Optional[str] = None
     default_model: Optional[str] = None

--- a/backend/app/agents/services/connection_service.py
+++ b/backend/app/agents/services/connection_service.py
@@ -203,13 +203,16 @@ async def test_connection(conn: LlmConnection) -> dict[str, Any]:
                 models = [m.get("name") for m in (r.json().get("models") or [])]
             return {"ok": True, "detail": f"reachable ({len(models)} models)", "models": models}
 
-        if conn.kind in ("openai", "openai_compatible"):
+        if conn.kind in ("openai", "openai_compatible", "orcarouter"):
             # Use the same normalization the runtime provider applies, so
             # "test" hits the same URL "chat" will use. Detects bare-host
             # URLs (e.g. http://lmstudio:1234) and auto-appends /v1.
             from app.agents.providers.openai import normalize_openai_base_url
 
-            base = normalize_openai_base_url(conn.base_url or "https://api.openai.com/v1")
+            # Named providers fall back to their preset endpoint when the
+            # connection stores no base_url (mirrors the OpenAI default).
+            default_base = "https://api.orcarouter.ai/v1" if conn.kind == "orcarouter" else "https://api.openai.com/v1"
+            base = normalize_openai_base_url(conn.base_url or default_base)
             attempted = base
             headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
             async with httpx.AsyncClient(timeout=timeout) as client:

--- a/backend/tests/test_agents_connection_service.py
+++ b/backend/tests/test_agents_connection_service.py
@@ -29,6 +29,22 @@ async def test_create_connection_requires_base_url_for_openai_compatible(session
 
 
 @pytest.mark.asyncio
+async def test_create_connection_orcarouter_works_without_base_url(session, test_user):
+    """OrcaRouter is a named provider with a preset public endpoint, so a
+    connection needs no base_url (mirrors openai/anthropic)."""
+    conn = await cs.create_connection(
+        session, test_user.id, name="My OrcaRouter", kind="orcarouter",
+        api_key="sk-orca-test", default_model="openai/gpt-4o-mini",
+    )
+    assert conn.base_url is None
+    assert conn.default_model == "openai/gpt-4o-mini"
+    # The provider resolves the preset endpoint at build time.
+    provider = cs.build_provider_for_connection(conn)
+    assert provider.name == "orcarouter"
+    assert provider.base_url == "https://api.orcarouter.ai/v1"
+
+
+@pytest.mark.asyncio
 async def test_create_and_get_and_list(session, test_user):
     conn = await cs.create_connection(
         session, test_user.id,
@@ -149,6 +165,21 @@ def test_build_provider_for_connection(session):
     assert provider.name == "openai"
 
 
+def test_build_provider_for_orcarouter_connection(session):
+    """A connection with no base_url resolves to the OrcaRouter preset."""
+    from app.agents.models.connection import LlmConnection
+
+    conn = LlmConnection(
+        id=uuid.uuid4(), user_id=uuid.uuid4(),
+        name="x", kind="orcarouter",
+        base_url=None, api_key_encrypted=None,
+        default_model="openai/gpt-4o-mini", extra={},
+    )
+    provider = cs.build_provider_for_connection(conn)
+    assert provider.name == "orcarouter"
+    assert provider.base_url == "https://api.orcarouter.ai/v1"
+
+
 # --------------------------------------------------------------------- test_connection (probe)
 
 class _FakeResp:
@@ -262,6 +293,27 @@ async def test_probe_openai_compatible_warns_when_bad_json(fake_httpx):
     ))
     assert out["ok"] is False
     assert "did not return JSON" in out["detail"]
+
+
+@pytest.mark.asyncio
+async def test_probe_orcarouter_returns_models_on_success(fake_httpx):
+    fake_httpx.queue.append(_FakeResp(json_body={
+        "data": [{"id": "openai/gpt-4o-mini"}, {"id": "anthropic/claude-sonnet-4.6"}],
+    }))
+    out = await cs.test_connection(_conn(kind="orcarouter"))
+    assert out["ok"] is True
+    assert "2 models" in out["detail"]
+    assert out["models"] == ["openai/gpt-4o-mini", "anthropic/claude-sonnet-4.6"]
+    # A connection with no base_url probes the provider's preset endpoint.
+    assert fake_httpx.calls[0][0] == "https://api.orcarouter.ai/v1/models"
+
+
+@pytest.mark.asyncio
+async def test_probe_orcarouter_auth_rejected(fake_httpx):
+    fake_httpx.queue.append(_FakeResp(status_code=401))
+    out = await cs.test_connection(_conn(kind="orcarouter"))
+    assert out["ok"] is False
+    assert "auth rejected" in out["detail"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_agents_connections.py
+++ b/backend/tests/test_agents_connections.py
@@ -150,6 +150,27 @@ async def test_create_then_list_via_http(client: AsyncClient, auth_headers: dict
     assert len(r.json()) == 1
 
 
+async def test_create_orcarouter_connection_via_http(client: AsyncClient, auth_headers: dict):
+    """A named OrcaRouter connection stores no base_url and no plaintext key."""
+    r = await client.post(
+        "/api/agents/connections",
+        json={
+            "name": "OrcaRouter",
+            "kind": "orcarouter",
+            "api_key": "sk-orca-real-and-private",
+            "default_model": "openai/gpt-4o-mini",
+        },
+        headers=auth_headers,
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["kind"] == "orcarouter"
+    assert body["base_url"] is None
+    assert body["has_api_key"] is True
+    assert "api_key" not in body
+    assert "sk-orca-real-and-private" not in r.text
+
+
 async def test_api_key_never_returned(client: AsyncClient, auth_headers: dict):
     r = await client.post(
         "/api/agents/connections",

--- a/backend/tests/test_agents_providers.py
+++ b/backend/tests/test_agents_providers.py
@@ -35,8 +35,8 @@ from app.agents.providers.openai import (
 pytestmark = pytest.mark.asyncio
 
 
-def test_registry_lists_all_four_providers():
-    assert set(list_providers()) == {"ollama", "openai", "anthropic", "openai_compatible"}
+def test_registry_lists_all_five_providers():
+    assert set(list_providers()) == {"ollama", "openai", "anthropic", "openai_compatible", "orcarouter"}
 
 
 def test_registry_unknown_raises():

--- a/frontend/src/components/agents/connection-form-dialog.tsx
+++ b/frontend/src/components/agents/connection-form-dialog.tsx
@@ -32,6 +32,10 @@ const KIND_LABELS: Record<LlmConnectionKind, { label: string; needsBaseUrl: bool
   openai: { label: 'OpenAI', needsBaseUrl: false, needsKey: true, modelHint: 'gpt-4o-mini', urlHint: '', defaultModel: 'gpt-4o-mini' },
   anthropic: { label: 'Anthropic', needsBaseUrl: false, needsKey: true, modelHint: 'claude-haiku-4-5', urlHint: '', defaultModel: 'claude-haiku-4-5' },
   openai_compatible: { label: 'OpenAI-compatible (LM Studio, vLLM, Groq, Together, …)', needsBaseUrl: true, needsKey: false, modelHint: 'llama3.1-70b', urlHint: 'http://192.168.1.142:1234' },
+  // OrcaRouter is a hosted gateway with a public endpoint, so it needs no
+  // base URL (mirroring OpenAI/Anthropic). The model id uses the router's
+  // own provider/model format.
+  orcarouter: { label: 'OrcaRouter', needsBaseUrl: false, needsKey: true, modelHint: 'openai/gpt-4o-mini', urlHint: 'https://api.orcarouter.ai/v1', defaultModel: 'openai/gpt-4o-mini' },
 }
 
 export function ConnectionFormDialog({ open, onOpenChange, connection }: Props) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1342,7 +1342,7 @@ export interface Agent {
   updated_at: string
 }
 
-export type LlmConnectionKind = 'ollama' | 'openai' | 'anthropic' | 'openai_compatible'
+export type LlmConnectionKind = 'ollama' | 'openai' | 'anthropic' | 'openai_compatible' | 'orcarouter'
 
 export interface LlmConnection {
   id: string


### PR DESCRIPTION
## What

Adds **OrcaRouter** as a named LLM provider connection in the AI Agents
feature, mirroring the existing named providers (`openai`, `anthropic`).

OrcaRouter ([https://www.orcarouter.ai](https://www.orcarouter.ai)) is an
OpenAI-compatible router exposing 200+ models (OpenAI, Anthropic, Google,
DeepSeek, ...) behind a single API key, and it accepts the same
`provider/model` id format as OpenRouter. It already worked through the
generic "OpenAI-compatible" connection kind — this makes it a first-class,
named option:

- **Backend**: new `OrcaRouterProvider` (extends the OpenAI-compatible
  provider with a preset `https://api.orcarouter.ai/v1` endpoint),
  registered in the provider registry. The connection probe ("Test") and
  the env-default executor path (`AGENTS_ORCAROUTER_API_KEY`) handle the
  new kind.
- **Frontend**: `orcarouter` connection kind in the connections form —
  needs no base URL (public endpoint is preset, like OpenAI/Anthropic),
  requires an API key, defaults to model `openai/gpt-4o-mini`.
- **README**: listed OrcaRouter in the AI Agents provider list.

## Why

Without a named kind, users had to know and type `https://api.orcarouter.ai/v1`
into the generic "OpenAI-compatible" form. A named kind presets the endpoint,
defaults the model id, and surfaces OrcaRouter as a supported option — the
same treatment the other named providers get.

## How to Test

1. Backend: `cd backend && uv sync --all-extras && uv run pytest tests/test_agents_providers.py tests/test_agents_connection_service.py tests/test_agents_connections.py`
2. Frontend: `cd frontend && npm install && npm run build`
3. Live API (real OrcaRouter key): `POST https://api.orcarouter.ai/v1/chat/completions`
   with model `openai/gpt-4o-mini` streams a completion; `GET /v1/models`
   returns 207 models including `openai/gpt-4o-mini`.
4. UI: Settings → AI Agents → Connections → Add connection → pick
   "OrcaRouter", paste your `sk-orca-...` key → Test → OK, then set a
   default model like `openai/gpt-4o-mini`.

## Related Issue

None.

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
      — no i18n keys added: provider-kind labels in this form are inline
      English by existing convention (e.g. the "OpenAI-compatible (LM Studio,
      vLLM, Groq, Together, …)" label is inline too)
- [ ] For a large or core change, I discussed it first
      — small additive provider kind, no core-path changes
