### PR TITLE
chore: release v0.14.3

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "securo-backend"
-version = "0.1.0"
+version = "0.14.3"
 description = "Securo API - Personal Finance Manager"
 requires-python = ">=3.11"
 # These ranges express intent; the resolved versions live in uv.lock, which is

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2485,7 +2485,7 @@ wheels = [
 
 [[package]]
 name = "securo-backend"
-version = "0.1.0"
+version = "0.14.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/charts/securo/Chart.yaml
+++ b/charts/securo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: securo
 description: A Helm chart for Securo Finance, an open-source personal finance application.
 type: application
-version: 0.1.0
-appVersion: "latest"
+version: 0.14.3
+appVersion: "0.14.3"
 icon: https://raw.githubusercontent.com/securo-finance/securo/main/favicons/android-icon-192x192.png
 home: https://github.com/securo-finance/securo
 sources:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "0.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "0.14.3",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.90.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.14.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump for v0.14.3: `backend/pyproject.toml`, `frontend/package.json`, `charts/securo/Chart.yaml`.

After merging, publish the `v0.14.3` GitHub release targeting `main` to build and push the images.
