### PR TITLE
docs: document OIDC_EXISTING_USER_LINK_MODE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ ENABLE_BANKING_APP_ID=
 # OIDC_SCOPES=openid email profile
 # OIDC_AUTO_REGISTER=true
 # OIDC_REQUIRE_VERIFIED_EMAIL=true
+# Link an OIDC login to an existing Securo account with the same email:
+#   disabled (default) never links, verified_email links only when the provider
+#   sends email_verified=true, email links on a matching email alone.
+# OIDC_EXISTING_USER_LINK_MODE=disabled
 # Optional: sync Securo admin/workspace roles from OIDC roles/groups
 # OIDC_SYNC_ROLES=true
 # OIDC_ROLES_CLAIM=groups

--- a/README.md
+++ b/README.md
@@ -118,6 +118,22 @@ OIDC_REDIRECT_URI=https://your-securo-host/api/auth/oidc/callback
 
 New OIDC users are auto-provisioned by default (`OIDC_AUTO_REGISTER=true`) using verified email addresses. Set `OIDC_AUTO_REGISTER=false` to allow only existing Securo users whose email matches the provider claim.
 
+### Linking existing accounts
+
+An account that already exists in Securo (created with a password) is never linked to an OIDC identity automatically, so the first SSO login of an existing user is rejected by default. `OIDC_EXISTING_USER_LINK_MODE` controls that:
+
+```
+OIDC_EXISTING_USER_LINK_MODE=disabled
+```
+
+| Value | Behavior |
+|-------|----------|
+| `disabled` (default) | Never link. Existing accounts must keep using password login. |
+| `verified_email` | Link the existing account when the provider sends `email_verified=true` for the same email. |
+| `email` | Link on a matching email alone, even without `email_verified`. |
+
+Use `verified_email` to move existing users to SSO without recreating their accounts and data. Only pick `email` if you trust your provider to own every address it asserts, since anyone able to set an email there could claim the matching Securo account. An OIDC identity already linked to another account is always rejected, in every mode.
+
 ### Optional OIDC role sync
 
 Securo can also synchronize provider roles/groups into its built-in permissions when `OIDC_SYNC_ROLES=true`. The default claim is `groups`, which works well with Authentik group mappings and Pocket ID role/group assignments.

--- a/charts/securo/values.yaml
+++ b/charts/securo/values.yaml
@@ -56,6 +56,7 @@ config:
   oidcRedirectUri: ""
   oidcScopes: "openid email profile"
   oidcAutoRegister: "true"
+  # Link OIDC logins to existing accounts with the same email: disabled, verified_email, or email
   oidcExistingUserLinkMode: "disabled"
   oidcRequireVerifiedEmail: "true"
   oidcSyncRoles: "false"


### PR DESCRIPTION
`OIDC_EXISTING_USER_LINK_MODE` has been supported since OIDC login landed, but it was documented nowhere: not in `.env.example` (which lists every other `OIDC_*` option), not in the README, and the docs site defers to `.env.example` for the full list. Existing password users adopting SSO hit a 403 with no way to find the fix short of reading `oidc_auth.py`.

Adds it to `.env.example`, a "Linking existing accounts" subsection in the README OIDC docs covering the three modes (`disabled`, `verified_email`, `email`) and their trade-offs, and a comment on the Helm value. Docs only, no behavior change.

Reported by @b52src in #275.