### PR TITLE
feat: add Vietnamese Dong (VND) currency support

### DIFF
--- a/backend/app/api/currencies.py
+++ b/backend/app/api/currencies.py
@@ -36,6 +36,7 @@ CURRENCY_META = {
     "PHP": {"symbol": "₱", "name": "Philippine Peso", "flag": "\U0001F1F5\U0001F1ED"},
     "UAH": {"symbol": "₴", "name": "Ukrainian Hryvnia", "flag": "\U0001F1FA\U0001F1E6"},
     "NZD": {"symbol": "NZ$", "name": "New Zealand Dollar", "flag": "\U0001F1F3\U0001F1FF"},
+    "VND": {"symbol": "₫", "name": "Vietnamese Dong", "flag": "\U0001F1FB\U0001F1F3"},
 }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ,PHP,UAH,NZD"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ,PHP,UAH,NZD,VND"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/backend/app/fiscal/jurisdictions/vn.toml
+++ b/backend/app/fiscal/jurisdictions/vn.toml
@@ -1,0 +1,4 @@
+# Vietnam. The MST is the only number an invoice carries; a branch adds a
+# three-digit suffix to the parent's ten digits.
+code = "VN"
+kinds = ["vn_mst"]

--- a/backend/app/fiscal/registry.py
+++ b/backend/app/fiscal/registry.py
@@ -110,6 +110,7 @@ class TaxIdKind(str, Enum):
     PAN = "pan"
     NPWP = "npwp"
     PH_TIN = "ph_tin"
+    VN_MST = "vn_mst"
     USCC = "uscc"
     # The escape hatch. Always offered, never validated.
     OTHER = "other"
@@ -205,6 +206,7 @@ KIND_SPECS: dict[TaxIdKind, KindSpec] = {
     TaxIdKind.PAN: _spec(TaxIdKind.PAN, "upper_alnum", "in_pan"),
     TaxIdKind.NPWP: _spec(TaxIdKind.NPWP, "digits", "id_npwp"),
     TaxIdKind.PH_TIN: _spec(TaxIdKind.PH_TIN, "digits", "ph_tin"),
+    TaxIdKind.VN_MST: _spec(TaxIdKind.VN_MST, "digits", "vn_mst"),
     TaxIdKind.USCC: _spec(TaxIdKind.USCC, "upper_alnum", "cn_uscc"),
     TaxIdKind.OTHER: _spec(TaxIdKind.OTHER, "trim"),
 }

--- a/backend/app/fiscal/validators.py
+++ b/backend/app/fiscal/validators.py
@@ -423,6 +423,16 @@ def validate_id_npwp(value: str) -> str | None:
     return _digits_len(value, 15, 16)
 
 
+def validate_vn_mst(value: str) -> str | None:
+    """Ten digits, or thirteen with the three-digit branch suffix.
+
+    The tenth digit is a check digit, but reissued and legacy codes are in
+    circulation that do not satisfy the published weighting, so refusing on
+    it would reject real tax codes.
+    """
+    return _digits_len(value, 10, 13)
+
+
 def validate_mx_rfc(value: str) -> str | None:
     """Twelve characters for a company, thirteen for a person.
 
@@ -501,6 +511,7 @@ VALIDATORS: dict[str, Callable[[str], str | None]] = {
     "jp_corporate": validate_jp_corporate,
     "ph_tin": validate_ph_tin,
     "id_npwp": validate_id_npwp,
+    "vn_mst": validate_vn_mst,
     "in_gstin": validate_in_gstin,
     "in_pan": validate_in_pan,
     "cn_uscc": validate_cn_uscc,

--- a/backend/tests/test_currencies_api.py
+++ b/backend/tests/test_currencies_api.py
@@ -70,3 +70,15 @@ async def test_currencies_include_nzd_with_metadata(client: AsyncClient):
     assert nzd["symbol"] == "NZ$"
     assert nzd["name"] == "New Zealand Dollar"
     assert nzd["flag"] == "🇳🇿"
+
+
+@pytest.mark.asyncio
+async def test_currencies_include_vnd_with_metadata(client: AsyncClient):
+    response = await client.get("/api/currencies")
+    data = response.json()
+    vnd = next((currency for currency in data if currency["code"] == "VND"), None)
+
+    assert vnd is not None
+    assert vnd["symbol"] == "₫"
+    assert vnd["name"] == "Vietnamese Dong"
+    assert vnd["flag"] == "🇻🇳"

--- a/backend/tests/test_fiscal_packs_intl.py
+++ b/backend/tests/test_fiscal_packs_intl.py
@@ -104,7 +104,7 @@ def test_the_currencies_the_product_supports_have_a_pack():
         "COP": "CO", "PEN": "PE", "UYU": "UY", "INR": "IN", "SEK": "SE",
         "DKK": "DK", "NOK": "NO", "PLN": "PL", "CZK": "CZ", "HUF": "HU",
         "RON": "RO", "CRC": "CR", "IDR": "ID", "DOP": "DO", "RUB": "RU",
-        "GTQ": "GT", "PHP": "PH", "UAH": "UA", "NZD": "NZ", "USD": "US",
+        "GTQ": "GT", "PHP": "PH", "UAH": "UA", "NZD": "NZ", "VND": "VN", "USD": "US",
     }
     uncovered = [
         code

--- a/frontend/src/components/currency-select.tsx
+++ b/frontend/src/components/currency-select.tsx
@@ -38,6 +38,7 @@ export const CURRENCIES = [
   { code: 'PHP', flag: '\u{1F1F5}\u{1F1ED}', symbol: '₱' },
   { code: 'UAH', flag: '\u{1F1FA}\u{1F1E6}', symbol: '₴' },
   { code: 'NZD', flag: '\u{1F1F3}\u{1F1FF}', symbol: 'NZ$' },
+  { code: 'VND', flag: '\u{1F1FB}\u{1F1F3}', symbol: '₫' },
 ] as const
 
 interface CurrencySelectProps {

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -61,6 +61,7 @@ const CURRENCY_LOCALE: Record<string, string> = {
   PHP: 'en-PH',
   UAH: 'uk-UA',
   NZD: 'en-NZ',
+  VND: 'vi-VN',
 }
 
 /**

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1333,6 +1333,7 @@
       "pan": "PAN",
       "npwp": "NPWP",
       "ph_tin": "TIN",
+      "vn_mst": "MST",
       "uscc": "USCC"
     },
     "otherCountries": "Andere Länder",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1333,6 +1333,7 @@
       "pan": "PAN",
       "npwp": "NPWP",
       "ph_tin": "TIN",
+      "vn_mst": "MST",
       "uscc": "USCC"
     },
     "otherCountries": "Other countries",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1333,6 +1333,7 @@
       "pan": "PAN",
       "npwp": "NPWP",
       "ph_tin": "TIN",
+      "vn_mst": "MST",
       "uscc": "USCC"
     },
     "otherCountries": "Otros países",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -1333,6 +1333,7 @@
       "pan": "PAN",
       "npwp": "NPWP",
       "ph_tin": "TIN",
+      "vn_mst": "MST",
       "uscc": "USCC"
     },
     "otherCountries": "Autres pays",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1333,6 +1333,7 @@
       "pan": "PAN",
       "npwp": "NPWP",
       "ph_tin": "TIN",
+      "vn_mst": "MST",
       "uscc": "USCC"
     },
     "otherCountries": "Altri paesi",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -1414,6 +1414,7 @@
       "pan": "PAN",
       "npwp": "NPWP",
       "ph_tin": "TIN",
+      "vn_mst": "MST",
       "uscc": "USCC"
     },
     "otherCountries": "Inne kraje",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1333,6 +1333,7 @@
       "pan": "PAN",
       "npwp": "NPWP",
       "ph_tin": "TIN",
+      "vn_mst": "MST",
       "uscc": "USCC"
     },
     "otherCountries": "Outros países",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -1333,6 +1333,7 @@
       "pan": "PAN",
       "npwp": "NPWP",
       "ph_tin": "TIN",
+      "vn_mst": "MST",
       "uscc": "USCC"
     },
     "otherCountries": "Outros países",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -1339,6 +1339,7 @@
       "pan": "PAN",
       "npwp": "NPWP",
       "ph_tin": "TIN",
+      "vn_mst": "MST",
       "uscc": "USCC"
     },
     "otherCountries": "Другие страны",

--- a/frontend/src/locales/uk.json
+++ b/frontend/src/locales/uk.json
@@ -1339,6 +1339,7 @@
       "pan": "PAN",
       "npwp": "NPWP",
       "ph_tin": "TIN",
+      "vn_mst": "MST",
       "uscc": "USCC"
     },
     "otherCountries": "Інші країни",


### PR DESCRIPTION
Adds VND to the supported currencies: the supported list, the currency metadata, the setup/register picker, and the `vi-VN` formatting locale, which also gives it the zero fraction digits it should have (`1.234.568 ₫`, not `₫1,234,567.89`).

The Vietnamese fiscal pack comes with it so the currency arrives with the document that goes with it. The MST is ten digits, or thirteen with the branch suffix; its tenth digit is a check digit, but codes predating the current weighting are still in circulation, so only the size is enforced, matching the other packs whose rule is not safely reproducible.

Closes #635