### PR TITLE
feat: add Singapore Dollar (SGD) currency support

### DIFF
--- a/backend/app/api/currencies.py
+++ b/backend/app/api/currencies.py
@@ -37,6 +37,7 @@ CURRENCY_META = {
     "UAH": {"symbol": "₴", "name": "Ukrainian Hryvnia", "flag": "\U0001F1FA\U0001F1E6"},
     "NZD": {"symbol": "NZ$", "name": "New Zealand Dollar", "flag": "\U0001F1F3\U0001F1FF"},
     "VND": {"symbol": "₫", "name": "Vietnamese Dong", "flag": "\U0001F1FB\U0001F1F3"},
+    "SGD": {"symbol": "S$", "name": "Singapore Dollar", "flag": "\U0001F1F8\U0001F1EC"},
 }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ,PHP,UAH,NZD,VND"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ,PHP,UAH,NZD,VND,SGD"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/backend/app/fiscal/jurisdictions/sg.toml
+++ b/backend/app/fiscal/jurisdictions/sg.toml
@@ -1,0 +1,4 @@
+# Singapore. The UEN identifies every registered entity and doubles as the
+# GST registration number, so an invoice carries the one number.
+code = "SG"
+kinds = ["sg_uen"]

--- a/backend/app/fiscal/registry.py
+++ b/backend/app/fiscal/registry.py
@@ -111,6 +111,7 @@ class TaxIdKind(str, Enum):
     NPWP = "npwp"
     PH_TIN = "ph_tin"
     VN_MST = "vn_mst"
+    SG_UEN = "sg_uen"
     USCC = "uscc"
     # The escape hatch. Always offered, never validated.
     OTHER = "other"
@@ -207,6 +208,7 @@ KIND_SPECS: dict[TaxIdKind, KindSpec] = {
     TaxIdKind.NPWP: _spec(TaxIdKind.NPWP, "digits", "id_npwp"),
     TaxIdKind.PH_TIN: _spec(TaxIdKind.PH_TIN, "digits", "ph_tin"),
     TaxIdKind.VN_MST: _spec(TaxIdKind.VN_MST, "digits", "vn_mst"),
+    TaxIdKind.SG_UEN: _spec(TaxIdKind.SG_UEN, "upper_alnum", "sg_uen"),
     TaxIdKind.USCC: _spec(TaxIdKind.USCC, "upper_alnum", "cn_uscc"),
     TaxIdKind.OTHER: _spec(TaxIdKind.OTHER, "trim"),
 }

--- a/backend/app/fiscal/validators.py
+++ b/backend/app/fiscal/validators.py
@@ -466,6 +466,31 @@ def validate_in_pan(value: str) -> str | None:
     return None
 
 
+def validate_sg_uen(value: str) -> str | None:
+    """A UEN in one of the three shapes ACRA issues, each ending in a check
+    letter:
+
+      - business:      eight digits plus the letter (53012345A)
+      - local company: year, five digits, the letter (201012345A)
+      - other entity:  T/S/R, two year digits, two letters, four digits, letter
+
+    The check letter's algorithm is not published, so only the shape is
+    enforced: refusing on a reverse-engineered rule would reject real numbers.
+    """
+    if len(value) not in (9, 10):
+        return "length"
+    if not value[-1].isalpha():
+        return "invalid"
+    body = value[:-1]
+    if len(value) == 9:
+        return None if body.isdigit() else "invalid"
+    if body.isdigit():
+        return None
+    if value[0] in "TSR" and body[1:3].isdigit() and body[3:5].isalpha() and body[5:].isdigit():
+        return None
+    return "invalid"
+
+
 def validate_cn_uscc(value: str) -> str | None:
     """Eighteen characters from a restricted alphabet: I, O, S, V and Z are
     excluded to keep the code unambiguous when read aloud."""
@@ -515,4 +540,5 @@ VALIDATORS: dict[str, Callable[[str], str | None]] = {
     "in_gstin": validate_in_gstin,
     "in_pan": validate_in_pan,
     "cn_uscc": validate_cn_uscc,
+    "sg_uen": validate_sg_uen,
 }

--- a/backend/tests/test_currencies_api.py
+++ b/backend/tests/test_currencies_api.py
@@ -82,3 +82,15 @@ async def test_currencies_include_vnd_with_metadata(client: AsyncClient):
     assert vnd["symbol"] == "₫"
     assert vnd["name"] == "Vietnamese Dong"
     assert vnd["flag"] == "🇻🇳"
+
+
+@pytest.mark.asyncio
+async def test_currencies_include_sgd_with_metadata(client: AsyncClient):
+    response = await client.get("/api/currencies")
+    data = response.json()
+    sgd = next((currency for currency in data if currency["code"] == "SGD"), None)
+
+    assert sgd is not None
+    assert sgd["symbol"] == "S$"
+    assert sgd["name"] == "Singapore Dollar"
+    assert sgd["flag"] == "🇸🇬"

--- a/backend/tests/test_fiscal_packs_intl.py
+++ b/backend/tests/test_fiscal_packs_intl.py
@@ -104,7 +104,7 @@ def test_the_currencies_the_product_supports_have_a_pack():
         "COP": "CO", "PEN": "PE", "UYU": "UY", "INR": "IN", "SEK": "SE",
         "DKK": "DK", "NOK": "NO", "PLN": "PL", "CZK": "CZ", "HUF": "HU",
         "RON": "RO", "CRC": "CR", "IDR": "ID", "DOP": "DO", "RUB": "RU",
-        "GTQ": "GT", "PHP": "PH", "UAH": "UA", "NZD": "NZ", "VND": "VN", "USD": "US",
+        "GTQ": "GT", "PHP": "PH", "UAH": "UA", "NZD": "NZ", "VND": "VN", "SGD": "SG", "USD": "US",
     }
     uncovered = [
         code

--- a/frontend/src/components/currency-select.tsx
+++ b/frontend/src/components/currency-select.tsx
@@ -39,6 +39,7 @@ export const CURRENCIES = [
   { code: 'UAH', flag: '\u{1F1FA}\u{1F1E6}', symbol: '₴' },
   { code: 'NZD', flag: '\u{1F1F3}\u{1F1FF}', symbol: 'NZ$' },
   { code: 'VND', flag: '\u{1F1FB}\u{1F1F3}', symbol: '₫' },
+  { code: 'SGD', flag: '\u{1F1F8}\u{1F1EC}', symbol: 'S$' },
 ] as const
 
 interface CurrencySelectProps {

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -62,6 +62,7 @@ const CURRENCY_LOCALE: Record<string, string> = {
   UAH: 'uk-UA',
   NZD: 'en-NZ',
   VND: 'vi-VN',
+  SGD: 'en-SG',
 }
 
 /**

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -1339,6 +1339,7 @@
       "npwp": "NPWP",
       "ph_tin": "TIN",
       "vn_mst": "MST",
+      "sg_uen": "UEN",
       "uscc": "USCC"
     },
     "otherCountries": "Andere Länder",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1339,6 +1339,7 @@
       "npwp": "NPWP",
       "ph_tin": "TIN",
       "vn_mst": "MST",
+      "sg_uen": "UEN",
       "uscc": "USCC"
     },
     "otherCountries": "Other countries",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1339,6 +1339,7 @@
       "npwp": "NPWP",
       "ph_tin": "TIN",
       "vn_mst": "MST",
+      "sg_uen": "UEN",
       "uscc": "USCC"
     },
     "otherCountries": "Otros países",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -1339,6 +1339,7 @@
       "npwp": "NPWP",
       "ph_tin": "TIN",
       "vn_mst": "MST",
+      "sg_uen": "UEN",
       "uscc": "USCC"
     },
     "otherCountries": "Autres pays",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -1339,6 +1339,7 @@
       "npwp": "NPWP",
       "ph_tin": "TIN",
       "vn_mst": "MST",
+      "sg_uen": "UEN",
       "uscc": "USCC"
     },
     "otherCountries": "Altri paesi",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -1420,6 +1420,7 @@
       "npwp": "NPWP",
       "ph_tin": "TIN",
       "vn_mst": "MST",
+      "sg_uen": "UEN",
       "uscc": "USCC"
     },
     "otherCountries": "Inne kraje",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1339,6 +1339,7 @@
       "npwp": "NPWP",
       "ph_tin": "TIN",
       "vn_mst": "MST",
+      "sg_uen": "UEN",
       "uscc": "USCC"
     },
     "otherCountries": "Outros países",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -1339,6 +1339,7 @@
       "npwp": "NPWP",
       "ph_tin": "TIN",
       "vn_mst": "MST",
+      "sg_uen": "UEN",
       "uscc": "USCC"
     },
     "otherCountries": "Outros países",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -1345,6 +1345,7 @@
       "npwp": "NPWP",
       "ph_tin": "TIN",
       "vn_mst": "MST",
+      "sg_uen": "UEN",
       "uscc": "USCC"
     },
     "otherCountries": "Другие страны",

--- a/frontend/src/locales/uk.json
+++ b/frontend/src/locales/uk.json
@@ -1345,6 +1345,7 @@
       "npwp": "NPWP",
       "ph_tin": "TIN",
       "vn_mst": "MST",
+      "sg_uen": "UEN",
       "uscc": "USCC"
     },
     "otherCountries": "Інші країни",


### PR DESCRIPTION
Adds SGD across the supported list, the currency metadata, the setup/register picker and the `en-SG` formatting locale. The symbol is `S$`, following the `C$`/`A$`/`NZ$` convention so the dollar currencies stay apart at a glance.

The Singapore fiscal pack comes with it, the same way VND brought Vietnam's in #638, so the currency arrives with the document that goes with it. The UEN identifies every registered entity and doubles as the GST registration number, and it comes in the three shapes ACRA issues: eight digits plus a check letter, a year plus five digits plus the letter, or the `T`/`S`/`R` entity form. The check letter's algorithm is not published, so only the shape is enforced, matching the other packs whose rule cannot be reproduced safely.

Closes #641