### PR TITLE
fix: apply rules to generated recurring transactions

### DIFF
--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -37,7 +37,11 @@ from app.services.account_service import (
 from app.services.asset_group_service import ensure_group_for_connection
 from app.services.credit_card_service import apply_effective_date
 from app.services.rule_engine import merge_notes
-from app.services.rule_service import apply_rules_to_transaction, preview_rules_for_transaction
+from app.services.rule_service import (
+    apply_rules_to_transaction,
+    preview_rules_for_transaction,
+    recurring_placeholder_rule_ignore,
+)
 from app.services.transfer_detection_service import detect_transfer_pairs
 from app.services.fx_rate_service import stamp_primary_amount
 from app.services.payee_service import get_or_create_payee
@@ -1479,6 +1483,11 @@ async def sync_connection(
                 if placeholder:
                     if placeholder.is_ignored:
                         continue
+                    deferred_rule_ignore = (
+                        await recurring_placeholder_rule_ignore(
+                            session, user_id, placeholder
+                        )
+                    )
                     placeholder.external_id = txn_data.external_id
                     placeholder.source = "sync"
                     placeholder.status = txn_data.status
@@ -1499,7 +1508,7 @@ async def sync_connection(
                     placeholder.notes = merge_notes(
                         placeholder.notes, preview.notes
                     )
-                    if preview.is_ignored:
+                    if preview.is_ignored or deferred_rule_ignore:
                         placeholder.is_ignored = True
                     merged_count += 1
                     continue

--- a/backend/app/services/import_service.py
+++ b/backend/app/services/import_service.py
@@ -20,7 +20,11 @@ from app.schemas.transaction import TransactionImport
 from app.services import recurring_match_service
 from app.services.credit_card_service import apply_effective_date
 from app.services.rule_engine import apply_rule_actions, evaluate_conditions, merge_notes
-from app.services.rule_service import apply_rules_to_transaction, preview_rules_for_transaction
+from app.services.rule_service import (
+    apply_rules_to_transaction,
+    preview_rules_for_transaction,
+    recurring_placeholder_rule_ignore,
+)
 from app.services.fx_rate_service import stamp_primary_amount
 from app.services.payee_service import get_or_create_payee
 
@@ -804,6 +808,9 @@ async def import_transactions(
             preview.description,
         )
         if placeholder and not placeholder.is_ignored:
+            deferred_rule_ignore = await recurring_placeholder_rule_ignore(
+                session, user_id, placeholder
+            )
             placeholder.source = source
             placeholder.external_id = txn_data.external_id
             placeholder.import_id = import_log.id
@@ -823,7 +830,7 @@ async def import_transactions(
             if placeholder.payee_id is None:
                 placeholder.payee_id = preview.payee_id
             placeholder.notes = merge_notes(placeholder.notes, preview.notes)
-            if preview.is_ignored:
+            if preview.is_ignored or deferred_rule_ignore:
                 placeholder.is_ignored = True
             imported += 1
             continue

--- a/backend/app/services/recurring_match_service.py
+++ b/backend/app/services/recurring_match_service.py
@@ -65,6 +65,11 @@ def _best_by_similarity(
         if cand.is_ignored:
             continue
         score = _description_similarity(cand.description, description)
+        if cand.description_is_rule_managed:
+            score = max(
+                score,
+                _description_similarity(cand.original_description, description),
+            )
         if score > best_score:
             best_score = score
             best = cand

--- a/backend/app/services/recurring_transaction_service.py
+++ b/backend/app/services/recurring_transaction_service.py
@@ -322,7 +322,17 @@ async def generate_pending(
                 apply_effective_date(transaction, account)
                 session.add(transaction)
                 await session.flush()
-                await apply_rules_to_transaction(session, user_id, transaction)
+                await apply_rules_to_transaction(
+                    session,
+                    user_id,
+                    transaction,
+                    # An ignored pending placeholder is deliberately excluded
+                    # from recurring matching. Defer only the automatic ignore
+                    # until the incoming charge is reconciled; every other rule
+                    # action lands now, and an explicit later user ignore still
+                    # protects the placeholder from promotion.
+                    skip_ignore_action=is_synced_account,
+                )
                 await stamp_primary_amount(session, user_id, transaction)
                 count += 1
 

--- a/backend/app/services/recurring_transaction_service.py
+++ b/backend/app/services/recurring_transaction_service.py
@@ -14,6 +14,7 @@ from app.schemas.recurring_transaction import RecurringTransactionCreate, Recurr
 from app.services import recurring_match_service
 from app.services.credit_card_service import apply_effective_date
 from app.services.fx_rate_service import stamp_primary_amount
+from app.services.rule_service import apply_rules_to_transaction
 
 
 async def _verify_account_in_workspace(
@@ -306,6 +307,7 @@ async def generate_pending(
                 is_synced_account = account is not None and account.connection_id is not None
                 transaction = Transaction(
                     user_id=user_id,
+                    workspace_id=recurring.workspace_id,
                     account_id=recurring.account_id,
                     category_id=recurring.category_id,
                     description=recurring.description,
@@ -320,6 +322,7 @@ async def generate_pending(
                 apply_effective_date(transaction, account)
                 session.add(transaction)
                 await session.flush()
+                await apply_rules_to_transaction(session, user_id, transaction)
                 await stamp_primary_amount(session, user_id, transaction)
                 count += 1
 

--- a/backend/app/services/rule_engine.py
+++ b/backend/app/services/rule_engine.py
@@ -178,6 +178,7 @@ def apply_rule_actions(
     category_already_set: bool,
     *,
     skip_description: bool = False,
+    skip_ignore: bool = False,
 ) -> bool:
     """Apply actions in-place and return the updated category-set flag."""
     for action in actions:
@@ -216,7 +217,7 @@ def apply_rule_actions(
             if new_tags not in existing:
                 tx.notes = (existing + " " + new_tags).strip() if existing else new_tags
 
-        elif op == "ignore":
+        elif op == "ignore" and not skip_ignore:
             tx.is_ignored = True
 
     return category_already_set

--- a/backend/app/services/rule_service.py
+++ b/backend/app/services/rule_service.py
@@ -1145,6 +1145,7 @@ async def preview_rules_for_transaction(
 async def apply_rules_to_transaction(
     session: AsyncSession, user_id: uuid.UUID, transaction: Transaction,
     skip_category_rules: bool = False,
+    skip_ignore_action: bool = False,
 ) -> None:
     """Apply all active rules to a transaction, modifying it in-place. Commits nothing.
 
@@ -1152,6 +1153,10 @@ async def apply_rules_to_transaction(
     haven't been migrated to pass workspace_id directly; rules are scoped by
     workspace via the transaction's own workspace_id when available, falling
     back to the legacy user filter so historical rows still match.
+
+    `skip_ignore_action` lets lifecycle callers defer an automatic ignore while
+    a pending row must remain eligible for reconciliation. Other matching
+    actions still apply normally.
     """
     rule_filter = Rule.user_id == user_id
     if getattr(transaction, "workspace_id", None) is not None:
@@ -1169,7 +1174,12 @@ async def apply_rules_to_transaction(
         conditions = rule.conditions or []
         actions = rule.actions or []
         if evaluate_conditions(rule.conditions_op, conditions, transaction):
-            category_set = apply_rule_actions(actions, transaction, category_set)
+            category_set = apply_rule_actions(
+                actions,
+                transaction,
+                category_set,
+                skip_ignore=skip_ignore_action,
+            )
 
 
 async def apply_single_rule(

--- a/backend/app/services/rule_service.py
+++ b/backend/app/services/rule_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.rule import Rule
 from app.models.category import Category
 from app.models.payee import Payee
+from app.models.recurring_transaction import RecurringTransaction
 from app.models.transaction import Transaction
 from app.schemas.rule import RuleCreate, RuleExportPayload, RuleImportResponse, RuleUpdate
 from app.services.rule_engine import evaluate_conditions, apply_rule_actions
@@ -1180,6 +1181,54 @@ async def apply_rules_to_transaction(
                 category_set,
                 skip_ignore=skip_ignore_action,
             )
+
+
+async def recurring_placeholder_rule_ignore(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    placeholder: Transaction,
+) -> bool:
+    """Re-evaluate only the deferred ignore on a generated occurrence."""
+    recurring_id = placeholder.recurring_transaction_id
+    if recurring_id is None:
+        return False
+    if placeholder.status != "pending":
+        return False
+
+    result = await session.execute(
+        select(RecurringTransaction).where(
+            RecurringTransaction.id == recurring_id,
+            RecurringTransaction.user_id == user_id,
+            RecurringTransaction.workspace_id == placeholder.workspace_id,
+        )
+    )
+    recurring = result.scalar_one_or_none()
+    if recurring is None or recurring.account_id is None:
+        return False
+
+    occurrence = Transaction(
+        user_id=recurring.user_id,
+        workspace_id=recurring.workspace_id,
+        account_id=recurring.account_id,
+        category_id=recurring.category_id,
+        description=recurring.description,
+        original_description=None,
+        description_is_rule_managed=False,
+        amount=recurring.amount,
+        currency=recurring.currency,
+        date=placeholder.date,
+        effective_date=placeholder.effective_date,
+        type=recurring.type,
+        source="recurring",
+        status=placeholder.status,
+        payee=None,
+        payee_id=None,
+        notes=None,
+        is_ignored=False,
+        recurring_transaction_id=recurring.id,
+    )
+    await apply_rules_to_transaction(session, user_id, occurrence)
+    return bool(occurrence.is_ignored)
 
 
 async def apply_single_rule(

--- a/backend/tests/test_recurring_match_import.py
+++ b/backend/tests/test_recurring_match_import.py
@@ -16,6 +16,7 @@ from app.schemas.rule import RuleAction, RuleCondition, RuleCreate
 from app.schemas.transaction import TransactionImport
 from app.services.import_service import import_transactions
 from app.services.recurring_transaction_service import create_recurring_transaction
+from app.services.recurring_transaction_service import generate_pending
 from app.services.rule_service import create_rule
 
 
@@ -100,6 +101,89 @@ async def test_import_merges_into_placeholder(session, test_user, test_workspace
     assert txs[0].source == "csv"
     assert txs[0].recurring_transaction_id == bill_id
     assert txs[0].original_description == "NETFLIX SUBSCRIPTION"
+
+
+@pytest.mark.asyncio
+async def test_import_reconciles_rule_ignored_generated_placeholder(
+    session, test_user, test_workspace, test_account
+):
+    account_id = test_account.id
+    await create_rule(
+        session,
+        test_workspace.id,
+        test_user.id,
+        RuleCreate(
+            name="Ignore imported Netflix charge",
+            conditions=[
+                RuleCondition(
+                    field="description",
+                    op="contains",
+                    value="Netflix Subscription",
+                )
+            ],
+            actions=[
+                RuleAction(op="append_notes", value="#auto-ignored"),
+                RuleAction(op="ignore", value=True),
+            ],
+            apply_to_existing=False,
+        ),
+    )
+    bill = await _make_bill(
+        session,
+        test_workspace,
+        test_user,
+        test_account,
+        start_date=date(2026, 1, 10),
+    )
+    bill_id = bill.id
+
+    assert await generate_pending(
+        session, test_user.id, up_to=date(2026, 1, 10)
+    ) == 1
+    placeholder = (
+        await session.execute(
+            select(Transaction).where(
+                Transaction.recurring_transaction_id == bill_id
+            )
+        )
+    ).scalar_one()
+    placeholder_id = placeholder.id
+    assert placeholder.status == "pending"
+    assert placeholder.notes == "#auto-ignored"
+    assert placeholder.is_ignored is False
+
+    incoming = TransactionImport(
+        description="NETFLIX SUBSCRIPTION",
+        amount=Decimal("39.90"),
+        date=date(2026, 1, 11),
+        type="debit",
+        currency="BRL",
+    )
+    with patch(
+        "app.services.import_service.stamp_primary_amount",
+        new_callable=AsyncMock,
+    ):
+        imported, skipped, _, _ = await import_transactions(
+            session,
+            test_workspace.id,
+            test_user.id,
+            account_id,
+            [incoming],
+            "csv",
+        )
+
+    assert (imported, skipped) == (1, 0)
+    txs = await _real_txs(session, account_id)
+    assert len(txs) == 1
+    merged = txs[0]
+    assert merged.id == placeholder_id
+    assert merged.source == "csv"
+    assert merged.status == "posted"
+    assert merged.recurring_transaction_id == bill_id
+    assert merged.notes == "#auto-ignored"
+    assert merged.is_ignored is True
+    refreshed = await session.get(RecurringTransaction, bill_id)
+    assert refreshed.next_occurrence == date(2026, 2, 10)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_recurring_match_import.py
+++ b/backend/tests/test_recurring_match_import.py
@@ -14,9 +14,11 @@ from app.models.transaction import Transaction
 from app.schemas.recurring_transaction import RecurringTransactionCreate
 from app.schemas.rule import RuleAction, RuleCondition, RuleCreate
 from app.schemas.transaction import TransactionImport
+from app.services import recurring_match_service
 from app.services.import_service import import_transactions
 from app.services.recurring_transaction_service import create_recurring_transaction
 from app.services.recurring_transaction_service import generate_pending
+from app.services.rule_engine import evaluate_conditions
 from app.services.rule_service import create_rule
 
 
@@ -104,21 +106,30 @@ async def test_import_merges_into_placeholder(session, test_user, test_workspace
 
 
 @pytest.mark.asyncio
-async def test_import_reconciles_rule_ignored_generated_placeholder(
+async def test_import_preserves_deferred_rule_ignore_after_fuzzy_placeholder_match(
     session, test_user, test_workspace, test_account
 ):
     account_id = test_account.id
-    await create_rule(
+    recurring_description = "ACME Internet Monthly"
+    incoming_description = "ACME Internet"
+    assert (
+        recurring_match_service._description_similarity(
+            recurring_description, incoming_description
+        )
+        >= recurring_match_service._SIMILARITY_THRESHOLD
+    )
+
+    rule = await create_rule(
         session,
         test_workspace.id,
         test_user.id,
         RuleCreate(
-            name="Ignore imported Netflix charge",
+            name="Ignore generated ACME import",
             conditions=[
                 RuleCondition(
                     field="description",
                     op="contains",
-                    value="Netflix Subscription",
+                    value=recurring_description,
                 )
             ],
             actions=[
@@ -133,6 +144,8 @@ async def test_import_reconciles_rule_ignored_generated_placeholder(
         test_workspace,
         test_user,
         test_account,
+        description=recurring_description,
+        amount=Decimal("89.90"),
         start_date=date(2026, 1, 10),
     )
     bill_id = bill.id
@@ -148,16 +161,34 @@ async def test_import_reconciles_rule_ignored_generated_placeholder(
         )
     ).scalar_one()
     placeholder_id = placeholder.id
+    assert evaluate_conditions(rule.conditions_op, rule.conditions, placeholder)
     assert placeholder.status == "pending"
     assert placeholder.notes == "#auto-ignored"
     assert placeholder.is_ignored is False
 
     incoming = TransactionImport(
-        description="NETFLIX SUBSCRIPTION",
-        amount=Decimal("39.90"),
+        external_id="deferred-ignore-import",
+        description=incoming_description,
+        amount=Decimal("89.90"),
         date=date(2026, 1, 11),
         type="debit",
         currency="BRL",
+    )
+    incoming_rule_target = Transaction(
+        user_id=test_user.id,
+        workspace_id=test_workspace.id,
+        account_id=account_id,
+        description=incoming.description,
+        original_description=incoming.description,
+        amount=incoming.amount,
+        currency=incoming.currency or "BRL",
+        date=incoming.date,
+        type=incoming.type,
+        source="csv",
+        status="posted",
+    )
+    assert not evaluate_conditions(
+        rule.conditions_op, rule.conditions, incoming_rule_target
     )
     with patch(
         "app.services.import_service.stamp_primary_amount",
@@ -177,9 +208,13 @@ async def test_import_reconciles_rule_ignored_generated_placeholder(
     assert len(txs) == 1
     merged = txs[0]
     assert merged.id == placeholder_id
+    assert merged.external_id == incoming.external_id
     assert merged.source == "csv"
     assert merged.status == "posted"
     assert merged.recurring_transaction_id == bill_id
+    assert merged.description == recurring_description
+    assert merged.original_description == incoming_description
+    assert merged.description_is_rule_managed is False
     assert merged.notes == "#auto-ignored"
     assert merged.is_ignored is True
     refreshed = await session.get(RecurringTransaction, bill_id)

--- a/backend/tests/test_recurring_match_sync.py
+++ b/backend/tests/test_recurring_match_sync.py
@@ -28,11 +28,13 @@ from app.models.recurring_transaction import RecurringTransaction
 from app.models.transaction import Transaction
 from app.schemas.recurring_transaction import RecurringTransactionCreate
 from app.schemas.rule import RuleAction, RuleCondition, RuleCreate
+from app.services import recurring_match_service
 from app.services.connection_service import _description_similarity, sync_connection
 from app.services.recurring_transaction_service import (
     create_recurring_transaction,
     generate_pending,
 )
+from app.services.rule_engine import evaluate_conditions
 from app.services.rule_service import create_rule
 from app.services.transaction_service import toggle_ignore_transaction
 
@@ -599,28 +601,34 @@ async def test_sync_promotes_pending_placeholder_to_posted(
 
 
 @pytest.mark.asyncio
-async def test_sync_reconciles_rule_ignored_generated_placeholder(
+async def test_sync_rule_managed_description_preserves_recurring_match_signal(
     session, test_user, test_workspace, conn_account
 ):
     conn, account = conn_account
     conn_id, account_id = conn.id, account.id
+    recurring_description = "ACME Internet Monthly"
+    incoming_description = "ACME Internet"
+    assert (
+        recurring_match_service._description_similarity(
+            recurring_description, incoming_description
+        )
+        >= recurring_match_service._SIMILARITY_THRESHOLD
+    )
+
     await create_rule(
         session,
         test_workspace.id,
         test_user.id,
         RuleCreate(
-            name="Ignore generated Netflix charge",
+            name="Normalize generated ACME charge",
             conditions=[
                 RuleCondition(
                     field="description",
                     op="contains",
-                    value="Netflix Subscription",
+                    value=recurring_description,
                 )
             ],
-            actions=[
-                RuleAction(op="append_notes", value="#auto-ignored"),
-                RuleAction(op="ignore", value=True),
-            ],
+            actions=[RuleAction(op="set_description", value="ISP")],
             apply_to_existing=False,
         ),
     )
@@ -629,6 +637,8 @@ async def test_sync_reconciles_rule_ignored_generated_placeholder(
         test_workspace,
         test_user,
         account,
+        description=recurring_description,
+        amount=Decimal("89.90"),
         start_date=date(2025, 1, 10),
     )
     bill_id = bill.id
@@ -645,15 +655,139 @@ async def test_sync_reconciles_rule_ignored_generated_placeholder(
     ).scalar_one()
     placeholder_id = placeholder.id
     assert placeholder.status == "pending"
-    assert placeholder.notes == "#auto-ignored"
-    assert placeholder.is_ignored is False
+    assert placeholder.description == "ISP"
+    assert placeholder.original_description == recurring_description
+    assert placeholder.description_is_rule_managed is True
 
     provider = _provider(
         [
             _tx(
-                external_id="rule-ignored-sync",
-                description="NETFLIX SUBSCRIPTION",
-                amount=Decimal("39.90"),
+                external_id="acme-description-sync",
+                description=incoming_description,
+                amount=Decimal("89.90"),
+                date=date(2025, 1, 11),
+            )
+        ]
+    )
+    await _run_sync(
+        session,
+        conn_id,
+        test_workspace,
+        test_user,
+        provider,
+        mock_rules=False,
+    )
+
+    txs = await _all_txs(session, account_id)
+    assert len(txs) == 1, [
+        (
+            tx.id,
+            tx.source,
+            tx.status,
+            tx.description,
+            tx.original_description,
+            tx.recurring_transaction_id,
+        )
+        for tx in txs
+    ]
+    merged = txs[0]
+    assert merged.id == placeholder_id
+    assert merged.external_id == "acme-description-sync"
+    assert merged.source == "sync"
+    assert merged.status == "posted"
+    assert merged.recurring_transaction_id == bill_id
+    assert merged.description == "ISP"
+    assert merged.original_description == incoming_description
+    assert merged.description_is_rule_managed is True
+    assert not any(tx.source == "recurring" for tx in txs)
+
+
+
+
+@pytest.mark.asyncio
+async def test_sync_preserves_deferred_rule_ignore_after_fuzzy_placeholder_match(
+    session, test_user, test_workspace, conn_account
+):
+    conn, account = conn_account
+    conn_id, account_id = conn.id, account.id
+    recurring_description = "ACME Internet Monthly"
+    incoming_description = "ACME Internet"
+    assert (
+        recurring_match_service._description_similarity(
+            recurring_description, incoming_description
+        )
+        >= recurring_match_service._SIMILARITY_THRESHOLD
+    )
+
+    rule = await create_rule(
+        session,
+        test_workspace.id,
+        test_user.id,
+        RuleCreate(
+            name="Ignore generated ACME charge",
+            conditions=[
+                RuleCondition(
+                    field="description",
+                    op="contains",
+                    value=recurring_description,
+                )
+            ],
+            actions=[
+                RuleAction(op="append_notes", value="#auto-ignored"),
+                RuleAction(op="ignore", value=True),
+            ],
+            apply_to_existing=False,
+        ),
+    )
+    bill = await _make_bill(
+        session,
+        test_workspace,
+        test_user,
+        account,
+        description=recurring_description,
+        amount=Decimal("89.90"),
+        start_date=date(2025, 1, 10),
+    )
+    bill_id = bill.id
+
+    assert await generate_pending(
+        session, test_user.id, up_to=date(2025, 1, 10)
+    ) == 1
+    placeholder = (
+        await session.execute(
+            select(Transaction).where(
+                Transaction.recurring_transaction_id == bill_id
+            )
+        )
+    ).scalar_one()
+    placeholder_id = placeholder.id
+    assert evaluate_conditions(rule.conditions_op, rule.conditions, placeholder)
+    assert placeholder.status == "pending"
+    assert placeholder.notes == "#auto-ignored"
+    assert placeholder.is_ignored is False
+
+    incoming_rule_target = Transaction(
+        user_id=test_user.id,
+        workspace_id=test_workspace.id,
+        account_id=account_id,
+        description=incoming_description,
+        original_description=incoming_description,
+        amount=Decimal("89.90"),
+        currency="BRL",
+        date=date(2025, 1, 11),
+        type="debit",
+        source="sync",
+        status="posted",
+    )
+    assert not evaluate_conditions(
+        rule.conditions_op, rule.conditions, incoming_rule_target
+    )
+    provider = _provider(
+        [
+            _tx(
+                external_id="deferred-ignore-sync",
+                description=incoming_description,
+                amount=Decimal("89.90"),
                 date=date(2025, 1, 11),
             )
         ]
@@ -671,10 +805,13 @@ async def test_sync_reconciles_rule_ignored_generated_placeholder(
     assert len(txs) == 1
     merged = txs[0]
     assert merged.id == placeholder_id
-    assert merged.external_id == "rule-ignored-sync"
+    assert merged.external_id == "deferred-ignore-sync"
     assert merged.source == "sync"
     assert merged.status == "posted"
     assert merged.recurring_transaction_id == bill_id
+    assert merged.description == recurring_description
+    assert merged.original_description == incoming_description
+    assert merged.description_is_rule_managed is False
     assert merged.notes == "#auto-ignored"
     assert merged.is_ignored is True
     refreshed = await session.get(RecurringTransaction, bill_id)

--- a/backend/tests/test_recurring_match_sync.py
+++ b/backend/tests/test_recurring_match_sync.py
@@ -34,6 +34,7 @@ from app.services.recurring_transaction_service import (
     generate_pending,
 )
 from app.services.rule_service import create_rule
+from app.services.transaction_service import toggle_ignore_transaction
 
 
 @pytest_asyncio.fixture
@@ -595,6 +596,143 @@ async def test_sync_promotes_pending_placeholder_to_posted(
     assert merged.original_description == "NETFLIX SUBSCRIPTION"
     refreshed = await session.get(RecurringTransaction, bill_id)
     assert refreshed.next_occurrence == date(2025, 2, 10)  # NOT advanced again
+
+
+@pytest.mark.asyncio
+async def test_sync_reconciles_rule_ignored_generated_placeholder(
+    session, test_user, test_workspace, conn_account
+):
+    conn, account = conn_account
+    conn_id, account_id = conn.id, account.id
+    await create_rule(
+        session,
+        test_workspace.id,
+        test_user.id,
+        RuleCreate(
+            name="Ignore generated Netflix charge",
+            conditions=[
+                RuleCondition(
+                    field="description",
+                    op="contains",
+                    value="Netflix Subscription",
+                )
+            ],
+            actions=[
+                RuleAction(op="append_notes", value="#auto-ignored"),
+                RuleAction(op="ignore", value=True),
+            ],
+            apply_to_existing=False,
+        ),
+    )
+    bill = await _make_bill(
+        session,
+        test_workspace,
+        test_user,
+        account,
+        start_date=date(2025, 1, 10),
+    )
+    bill_id = bill.id
+
+    assert await generate_pending(
+        session, test_user.id, up_to=date(2025, 1, 10)
+    ) == 1
+    placeholder = (
+        await session.execute(
+            select(Transaction).where(
+                Transaction.recurring_transaction_id == bill_id
+            )
+        )
+    ).scalar_one()
+    placeholder_id = placeholder.id
+    assert placeholder.status == "pending"
+    assert placeholder.notes == "#auto-ignored"
+    assert placeholder.is_ignored is False
+
+    provider = _provider(
+        [
+            _tx(
+                external_id="rule-ignored-sync",
+                description="NETFLIX SUBSCRIPTION",
+                amount=Decimal("39.90"),
+                date=date(2025, 1, 11),
+            )
+        ]
+    )
+    await _run_sync(
+        session,
+        conn_id,
+        test_workspace,
+        test_user,
+        provider,
+        mock_rules=False,
+    )
+
+    txs = await _all_txs(session, account_id)
+    assert len(txs) == 1
+    merged = txs[0]
+    assert merged.id == placeholder_id
+    assert merged.external_id == "rule-ignored-sync"
+    assert merged.source == "sync"
+    assert merged.status == "posted"
+    assert merged.recurring_transaction_id == bill_id
+    assert merged.notes == "#auto-ignored"
+    assert merged.is_ignored is True
+    refreshed = await session.get(RecurringTransaction, bill_id)
+    assert refreshed.next_occurrence == date(2025, 2, 10)
+
+
+@pytest.mark.asyncio
+async def test_sync_does_not_reconcile_explicitly_ignored_generated_placeholder(
+    session, test_user, test_workspace, conn_account
+):
+    conn, account = conn_account
+    conn_id, account_id = conn.id, account.id
+    bill = await _make_bill(
+        session,
+        test_workspace,
+        test_user,
+        account,
+        start_date=date(2025, 1, 10),
+    )
+    bill_id = bill.id
+    assert await generate_pending(
+        session, test_user.id, up_to=date(2025, 1, 10)
+    ) == 1
+    placeholder = (
+        await session.execute(
+            select(Transaction).where(
+                Transaction.recurring_transaction_id == bill_id
+            )
+        )
+    ).scalar_one()
+    placeholder_id = placeholder.id
+    ignored = await toggle_ignore_transaction(
+        session, placeholder_id, test_workspace.id
+    )
+    assert ignored is not None
+    assert ignored.is_ignored is True
+
+    provider = _provider(
+        [
+            _tx(
+                external_id="explicitly-ignored-sync",
+                description="NETFLIX SUBSCRIPTION",
+                amount=Decimal("39.90"),
+                date=date(2025, 1, 11),
+            )
+        ]
+    )
+    await _run_sync(session, conn_id, test_workspace, test_user, provider)
+
+    txs = await _all_txs(session, account_id)
+    assert len(txs) == 2
+    preserved = next(tx for tx in txs if tx.id == placeholder_id)
+    assert preserved.source == "recurring"
+    assert preserved.external_id is None
+    assert preserved.is_ignored is True
+    assert preserved.recurring_transaction_id == bill_id
+    incoming = next(tx for tx in txs if tx.external_id == "explicitly-ignored-sync")
+    assert incoming.recurring_transaction_id is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_recurring_transaction_service.py
+++ b/backend/tests/test_recurring_transaction_service.py
@@ -671,6 +671,7 @@ async def test_generate_pending_applies_workspace_rules_to_new_occurrence(
         actions=[
             RuleAction(op="set_payee", value=str(payee.id)),
             RuleAction(op="append_notes", value="#subscription"),
+            RuleAction(op="ignore", value=True),
         ],
     )
     await _create_description_rule(
@@ -698,6 +699,7 @@ async def test_generate_pending_applies_workspace_rules_to_new_occurrence(
     assert transaction.workspace_id == test_workspace.id
     assert transaction.payee_id == payee.id
     assert transaction.notes == "#subscription"
+    assert transaction.is_ignored is True
     assert transaction.status == "posted"
     assert transaction.recurring_transaction_id == recurring.id
 

--- a/backend/tests/test_recurring_transaction_service.py
+++ b/backend/tests/test_recurring_transaction_service.py
@@ -8,7 +8,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
+from app.models.payee import Payee
 from app.models.transaction import Transaction
+from app.models.workspace import Workspace, WorkspaceMember
+from app.schemas.rule import RuleAction, RuleCondition, RuleCreate
 from app.schemas.recurring_transaction import RecurringTransactionCreate, RecurringTransactionUpdate
 from app.services.recurring_transaction_service import (
     _advance_date,
@@ -21,6 +24,7 @@ from app.services.recurring_transaction_service import (
     get_recurring_transactions,
     update_recurring_transaction,
 )
+from app.services.rule_service import create_rule
 
 
 @pytest_asyncio.fixture
@@ -37,6 +41,69 @@ async def test_account_for_recurring(session: AsyncSession, test_user) -> Accoun
     await session.commit()
     await session.refresh(account)
     return account
+
+
+async def _create_description_rule(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    name: str,
+    match: str,
+    actions: list[RuleAction],
+    is_active: bool = True,
+) -> None:
+    await create_rule(
+        session,
+        workspace_id,
+        user_id,
+        RuleCreate(
+            name=name,
+            conditions=[
+                RuleCondition(field="description", op="contains", value=match)
+            ],
+            actions=actions,
+            is_active=is_active,
+            apply_to_existing=False,
+        ),
+    )
+
+
+async def _create_due_recurring(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    user_id: uuid.UUID,
+    account: Account,
+    *,
+    description: str,
+    amount: Decimal,
+):
+    return await create_recurring_transaction(
+        session,
+        workspace_id,
+        user_id,
+        RecurringTransactionCreate(
+            description=description,
+            amount=amount,
+            currency=account.currency,
+            type="debit",
+            frequency="monthly",
+            start_date=date(2025, 1, 1),
+            account_id=account.id,
+        ),
+    )
+
+
+async def _generated_transaction(
+    session: AsyncSession, recurring_id: uuid.UUID
+) -> Transaction:
+    return (
+        await session.execute(
+            select(Transaction).where(
+                Transaction.recurring_transaction_id == recurring_id
+            )
+        )
+    ).scalar_one()
 
 
 # ---------------------------------------------------------------------------
@@ -579,6 +646,181 @@ async def test_generate_pending(session: AsyncSession, test_user, test_workspace
     # next_occurrence should be advanced past cutoff
     await session.refresh(rec)
     assert rec.next_occurrence == date(2025, 4, 1)
+
+@pytest.mark.asyncio
+async def test_generate_pending_applies_workspace_rules_to_new_occurrence(
+    session: AsyncSession,
+    test_user,
+    test_workspace,
+    test_account_for_recurring,
+):
+    payee = Payee(
+        user_id=test_user.id,
+        workspace_id=test_workspace.id,
+        name="Internet Provider",
+    )
+    session.add(payee)
+    await session.flush()
+
+    await _create_description_rule(
+        session,
+        test_workspace.id,
+        test_user.id,
+        name="Classify generated internet charge",
+        match="Internet Provider",
+        actions=[
+            RuleAction(op="set_payee", value=str(payee.id)),
+            RuleAction(op="append_notes", value="#subscription"),
+        ],
+    )
+    await _create_description_rule(
+        session,
+        test_workspace.id,
+        test_user.id,
+        name="Inactive generated charge rule",
+        match="Internet Provider",
+        actions=[RuleAction(op="append_notes", value="#inactive")],
+        is_active=False,
+    )
+    recurring = await _create_due_recurring(
+        session,
+        test_workspace.id,
+        test_user.id,
+        test_account_for_recurring,
+        description="Internet Provider Monthly",
+        amount=Decimal("99.90"),
+    )
+
+    assert await generate_pending(
+        session, test_user.id, up_to=date(2025, 1, 1)
+    ) == 1
+    transaction = await _generated_transaction(session, recurring.id)
+    assert transaction.workspace_id == test_workspace.id
+    assert transaction.payee_id == payee.id
+    assert transaction.notes == "#subscription"
+    assert transaction.status == "posted"
+    assert transaction.recurring_transaction_id == recurring.id
+
+    assert await generate_pending(
+        session, test_user.id, up_to=date(2025, 1, 1)
+    ) == 0
+    assert await _generated_transaction(session, recurring.id) == transaction
+
+
+@pytest.mark.asyncio
+async def test_generate_pending_scopes_rules_to_recurring_workspace(
+    session: AsyncSession,
+    test_user,
+    test_workspace,
+):
+    second_workspace = Workspace(
+        id=uuid.uuid4(),
+        name="Shared",
+        kind="personal",
+        created_by_user_id=test_user.id,
+        default_currency="BRL",
+    )
+    session.add(second_workspace)
+    await session.flush()
+    session.add(
+        WorkspaceMember(
+            id=uuid.uuid4(),
+            workspace_id=second_workspace.id,
+            user_id=test_user.id,
+            role="owner",
+        )
+    )
+    second_account = Account(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        workspace_id=second_workspace.id,
+        name="Shared Account",
+        type="checking",
+        balance=Decimal("1000"),
+        currency="BRL",
+    )
+    session.add(second_account)
+    await session.commit()
+
+    await _create_description_rule(
+        session,
+        test_workspace.id,
+        test_user.id,
+        name="First workspace rule",
+        match="Shared Internet",
+        actions=[RuleAction(op="append_notes", value="#wrong-workspace")],
+    )
+    await _create_description_rule(
+        session,
+        second_workspace.id,
+        test_user.id,
+        name="Second workspace rule",
+        match="Shared Internet",
+        actions=[RuleAction(op="append_notes", value="#right-workspace")],
+    )
+    recurring = await _create_due_recurring(
+        session,
+        second_workspace.id,
+        test_user.id,
+        second_account,
+        description="Shared Internet",
+        amount=Decimal("79.90"),
+    )
+
+    assert await generate_pending(
+        session, test_user.id, up_to=date(2025, 1, 1)
+    ) == 1
+    transaction = await _generated_transaction(session, recurring.id)
+    assert transaction.workspace_id == second_workspace.id
+    assert transaction.notes == "#right-workspace"
+
+
+@pytest.mark.asyncio
+async def test_generate_pending_does_not_reapply_rules_to_existing_real_transaction(
+    session: AsyncSession,
+    test_user,
+    test_workspace,
+    test_account_for_recurring,
+):
+    await _create_description_rule(
+        session,
+        test_workspace.id,
+        test_user.id,
+        name="Do not reapply to linked transactions",
+        match="Already Classified",
+        actions=[RuleAction(op="append_notes", value="#reapplied")],
+    )
+    recurring = await _create_due_recurring(
+        session,
+        test_workspace.id,
+        test_user.id,
+        test_account_for_recurring,
+        description="Already Classified",
+        amount=Decimal("25"),
+    )
+    real_transaction = Transaction(
+        user_id=test_user.id,
+        workspace_id=test_workspace.id,
+        account_id=test_account_for_recurring.id,
+        description="Already Classified",
+        amount=Decimal("25"),
+        currency="BRL",
+        date=date(2025, 1, 1),
+        type="debit",
+        source="manual",
+        status="posted",
+        notes="#classified",
+    )
+    session.add(real_transaction)
+    await session.commit()
+
+    assert await generate_pending(
+        session, test_user.id, up_to=date(2025, 1, 1)
+    ) == 0
+    await session.refresh(real_transaction)
+    assert real_transaction.recurring_transaction_id == recurring.id
+    assert real_transaction.notes == "#classified"
+
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Generated recurring occurrences currently bypass the transaction rule engine, so matching rules do not apply actions such as setting a payee or appending notes.

This applies the existing rule flow when a new recurring occurrence is generated while preserving reconciliation behavior for connected accounts.

## Changes

- apply active workspace rules to newly generated recurring occurrences;
- keep already-existing real transactions unchanged when they are linked to a recurring definition;
- preserve the pre-rule description as a recurring-match signal when `set_description` normalized a generated occurrence;
- defer automatic `ignore` on pending connected-account placeholders so they remain eligible for reconciliation;
- restore that deferred ignore decision when sync/import promotes the placeholder;
- keep explicit user-ignore match-blocking;
- retain workspace isolation, rule priority/chaining, and nested condition-group behavior.

Deferred ignore is evaluated using the active rule set at promotion time; generation-time rule state is not snapshotted.

## Testing

Regression coverage includes:

- `set_payee` and `append_notes` on generated occurrences;
- inactive-rule exclusion;
- workspace isolation;
- duplicate prevention;
- existing-real-transaction behavior;
- rule-managed description reconciliation;
- deferred ignore through sync and import;
- explicit user-ignore preventing reconciliation.

Validation after rebasing onto current `main`:

- relevant recurring/rule suite: 137 passed;
- full backend suite: 3,051 passed, 45 skipped;
- Ruff: passed;
- ty: passed;
- fork CI: passed.

Closes #568