### PR TITLE
fix: map Pluggy savings subtypes

### DIFF
--- a/backend/app/providers/pluggy.py
+++ b/backend/app/providers/pluggy.py
@@ -194,7 +194,7 @@ def _build_bill_data(raw: dict) -> Optional[BillData]:
 
 def _build_account_data(acc: dict, type_mapper) -> AccountData:
     """Map a Pluggy account payload to AccountData, including creditData when present."""
-    account_type = type_mapper(acc.get("type", ""))
+    account_type = type_mapper(acc.get("type", ""), acc.get("subtype"))
     credit_data = acc.get("creditData") or {}
 
     credit_limit: Optional[Decimal] = None
@@ -759,7 +759,12 @@ class PluggyProvider(BankProvider):
         return None
 
     @staticmethod
-    def _map_account_type(pluggy_type: str) -> str:
+    def _map_account_type(pluggy_type: str, pluggy_subtype: Optional[str] = None) -> str:
+        # Pluggy reports both checking and savings accounts as BANK, with the
+        # distinction carried in subtype (e.g. SAVINGS_ACCOUNT). Prefer the
+        # subtype so a savings account is not displayed as checking.
+        if (pluggy_subtype or "").upper() in {"SAVINGS", "SAVINGS_ACCOUNT"}:
+            return "savings"
         mapping = {
             "BANK": "checking",
             "CREDIT": "credit_card",

--- a/backend/tests/test_providers_pluggy.py
+++ b/backend/tests/test_providers_pluggy.py
@@ -372,3 +372,20 @@ def test_build_account_data_without_number_leaves_mask_none():
     acc = {"id": "acc-2", "name": "Conta", "type": "BANK", "balance": 0}
     out = _build_account_data(acc, PluggyProvider._map_account_type)
     assert out.masked_number is None
+
+
+def test_build_account_data_maps_bank_savings_subtype_to_savings():
+    from app.providers.pluggy import _build_account_data
+
+    acc = {
+        "id": "acc-savings",
+        "name": "Poupança",
+        "type": "BANK",
+        "subtype": "SAVINGS_ACCOUNT",
+        "balance": 0,
+        "currencyCode": "BRL",
+    }
+
+    out = _build_account_data(acc, PluggyProvider._map_account_type)
+
+    assert out.type == "savings"

--- a/backend/tests/test_providers_pluggy.py
+++ b/backend/tests/test_providers_pluggy.py
@@ -389,3 +389,43 @@ def test_build_account_data_maps_bank_savings_subtype_to_savings():
     out = _build_account_data(acc, PluggyProvider._map_account_type)
 
     assert out.type == "savings"
+
+
+@pytest.mark.parametrize(
+    "pluggy_type,pluggy_subtype,expected",
+    [
+        ("BANK", "CHECKING_ACCOUNT", "checking"),
+        ("BANK", "SAVINGS_ACCOUNT", "savings"),
+        ("CREDIT", "CREDIT_CARD", "credit_card"),
+        # `subtype` is documented as always present, but a payload that omits
+        # it must still fall back to the `type` mapping.
+        ("BANK", None, "checking"),
+        ("CREDIT", None, "credit_card"),
+        # Unknown values keep the historical "checking" default.
+        ("SOMETHING_NEW", None, "checking"),
+    ],
+)
+def test_map_account_type_covers_pluggy_type_subtype_pairs(
+    pluggy_type, pluggy_subtype, expected
+):
+    """Pluggy's enums are `type` ∈ (BANK, CREDIT) and `subtype` ∈
+    (CHECKING_ACCOUNT, SAVINGS_ACCOUNT, CREDIT_CARD). Pin every real pair so
+    the savings branch can't swallow the others.
+    """
+    assert PluggyProvider._map_account_type(pluggy_type, pluggy_subtype) == expected
+
+
+def test_build_account_data_without_subtype_still_maps_bank_to_checking():
+    from app.providers.pluggy import _build_account_data
+
+    acc = {
+        "id": "acc-checking",
+        "name": "Conta Corrente",
+        "type": "BANK",
+        "balance": 0,
+        "currencyCode": "BRL",
+    }
+
+    out = _build_account_data(acc, PluggyProvider._map_account_type)
+
+    assert out.type == "checking"


### PR DESCRIPTION
## Summary

Maps Pluggy `SAVINGS` and `SAVINGS_ACCOUNT` subtypes to Securo `savings` accounts before applying the broad `BANK` mapping.

Closes #660.

## Validation

- `cd backend && uv run --extra dev pytest tests/test_providers_pluggy.py -q`
- 21 passed

The change is limited to initial account mapping. Existing connected accounts retain any manually selected type by design.