### PR TITLE
ci: skip coverage badge updates in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
 
       - name: Update coverage badge
-        if: github.ref == 'refs/heads/main' && steps.backend-changes.outputs.run_backend == 'true'
+        if: github.repository == 'securo-finance/securo' && github.ref == 'refs/heads/main' && steps.backend-changes.outputs.run_backend == 'true'
         uses: schneegans/dynamic-badges-action@v1.9.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}


### PR DESCRIPTION
## Summary

- restrict coverage badge writes to the canonical Securo repository
- let forks run the full CI suite without Securo private Gist credentials

## Why

Fork pushes to main currently finish every application check successfully, then report a failed Backend Tests job because repository secrets are not inherited. The badge targets a Securo-owned Gist, so forks should skip only that repository-specific side effect.

Failing fork run: https://github.com/ADolkun/lovenest/actions/runs/32668171379

## Validation

- parsed .github/workflows/ci.yml successfully with Ruby YAML
- git diff --check