### PR TITLE
fix: clarify dashboard invested assets label

### DIFF
--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -286,7 +286,7 @@
     "categorizeNow": "Jetzt kategorisieren",
     "allCategorized": "Alles erledigt!",
     "allCategorizedDesc": "Alle Transaktionen sind kategorisiert",
-    "assetsValue": "Vermögenswerte",
+    "assetsValue": "Investiertes Vermögen",
     "currencyBreakdown": "Aufteilung nach Währung",
     "convertedFrom": "Umgerechnet von {{currency}}",
     "fxRateUsed": "Wechselkurs: {{rate}}",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -286,7 +286,7 @@
     "categorizeNow": "Categorize now",
     "allCategorized": "All caught up!",
     "allCategorizedDesc": "All transactions are categorized",
-    "assetsValue": "Assets",
+    "assetsValue": "Invested assets",
     "currencyBreakdown": "Per-currency breakdown",
     "convertedFrom": "Converted from {{currency}}",
     "fxRateUsed": "FX rate: {{rate}}",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -286,7 +286,7 @@
     "categorizeNow": "Categorizar ahora",
     "allCategorized": "¡Todo al día!",
     "allCategorizedDesc": "Todas las transacciones están categorizadas",
-    "assetsValue": "Activos",
+    "assetsValue": "Activos invertidos",
     "currencyBreakdown": "Desglose por moneda",
     "convertedFrom": "Convertido desde {{currency}}",
     "fxRateUsed": "Tipo de cambio: {{rate}}",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -286,7 +286,7 @@
     "categorizeNow": "Catégoriser maintenant",
     "allCategorized": "Tout est à jour !",
     "allCategorizedDesc": "Toutes les transactions sont catégorisées",
-    "assetsValue": "Actifs",
+    "assetsValue": "Actifs investis",
     "currencyBreakdown": "Répartition par devise",
     "convertedFrom": "Converti depuis {{currency}}",
     "fxRateUsed": "Taux de change : {{rate}}",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -286,7 +286,7 @@
     "categorizeNow": "Categorizza ora",
     "allCategorized": "Tutto in ordine!",
     "allCategorizedDesc": "Tutte le transazioni sono categorizzate",
-    "assetsValue": "Beni",
+    "assetsValue": "Beni investiti",
     "currencyBreakdown": "Dettaglio per valuta",
     "convertedFrom": "Convertito da {{currency}}",
     "fxRateUsed": "Tasso di cambio: {{rate}}",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -286,7 +286,7 @@
     "categorizeNow": "Categoriseer nu",
     "allCategorized": "Alles in orde!",
     "allCategorizedDesc": "Alle transacties zijn gecategoriseerd",
-    "assetsValue": "Activa",
+    "assetsValue": "Geïnvesteerde activa",
     "currencyBreakdown": "Uitsplitsing per valuta",
     "convertedFrom": "Geconverteerd van {{currency}}",
     "fxRateUsed": "Wisselkoers: {{rate}}",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -292,7 +292,7 @@
     "categorizeNow": "Skategoryzuj teraz",
     "allCategorized": "Wszystko ogarnięte!",
     "allCategorizedDesc": "Wszystkie transakcje są skategoryzowane",
-    "assetsValue": "Aktywa",
+    "assetsValue": "Zainwestowane aktywa",
     "currencyBreakdown": "Podział wg waluty",
     "convertedFrom": "Przeliczono z {{currency}}",
     "fxRateUsed": "Kurs FX: {{rate}}",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -286,7 +286,7 @@
     "categorizeNow": "Categorizar agora",
     "allCategorized": "Tudo em dia!",
     "allCategorizedDesc": "Todas as transações estão categorizadas",
-    "assetsValue": "Patrimônio",
+    "assetsValue": "Patrimônio investido",
     "currencyBreakdown": "Detalhamento por moeda",
     "convertedFrom": "Convertido de {{currency}}",
     "fxRateUsed": "Taxa de câmbio: {{rate}}",

--- a/frontend/src/locales/pt-PT.json
+++ b/frontend/src/locales/pt-PT.json
@@ -286,7 +286,7 @@
     "categorizeNow": "Categorizar agora",
     "allCategorized": "Tudo em dia!",
     "allCategorizedDesc": "Todas as transações estão categorizadas",
-    "assetsValue": "Património",
+    "assetsValue": "Património investido",
     "currencyBreakdown": "Detalhamento por moeda",
     "convertedFrom": "Convertido de {{currency}}",
     "fxRateUsed": "Taxa de câmbio: {{rate}}",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -286,7 +286,7 @@
     "categorizeNow": "Категоризировать сейчас",
     "allCategorized": "Всё в порядке!",
     "allCategorizedDesc": "Все транзакции категоризированы",
-    "assetsValue": "Активы",
+    "assetsValue": "Инвестированные активы",
     "currencyBreakdown": "Разбивка по валютам",
     "convertedFrom": "Конвертировано из {{currency}}",
     "fxRateUsed": "Курс: {{rate}}",

--- a/frontend/src/locales/uk.json
+++ b/frontend/src/locales/uk.json
@@ -286,7 +286,7 @@
     "categorizeNow": "Категоризувати зараз",
     "allCategorized": "Усе гаразд!",
     "allCategorizedDesc": "Усі транзакції категоризовано",
-    "assetsValue": "Активи",
+    "assetsValue": "Інвестовані активи",
     "currencyBreakdown": "Розбивка за валютами",
     "convertedFrom": "Конвертовано з {{currency}}",
     "fxRateUsed": "Курс: {{rate}}",


### PR DESCRIPTION
Closes #686. Renames the dashboard metric to make clear that it represents registered invested assets rather than the user's complete net worth. This changes no calculations and updates the existing label consistently across all supported locales.