### PR TITLE
fix: stop match-type label from wrapping in add-to-rule dialog

### DIFF
--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -1534,9 +1534,9 @@ function AddTransactionToRuleDialog({
             )}
           </div>
 
-          <div className="grid grid-cols-[140px_1fr] gap-3">
+          <div className="grid grid-cols-[auto_1fr] gap-3">
             <div className="space-y-2">
-              <Label>{t('transactions.matchOperator')}</Label>
+              <Label className="whitespace-nowrap">{t('transactions.matchOperator')}</Label>
               <Select
                 value={matchOp}
                 onValueChange={(value) => setMatchOp(value as 'contains' | 'starts_with')}


### PR DESCRIPTION
## Summary

Closes #692.

- The "add transaction to a rule" dialog laid out the match-type select and the description-match input in a grid with a fixed 140px column for the match-type label.
- That width fits "Match type" in English but wraps longer translations onto two lines (pt-BR/pt-PT "Tipo de correspondência", es "Tipo de coincidencia", fr "Type de correspondance", de "Übereinstimmungstyp", it "Tipo di corrispondenza"), misaligning the field against the description-match input next to it.
- Sized the column to its content (`grid-cols-[auto_1fr]` + `whitespace-nowrap` on the label) instead of a fixed pixel width, so it stays on one line in every locale.

No changes to the underlying matching logic, only the layout.

## Test plan

- [x] `npx vitest run` (139 tests passed)
- [x] `npm run build` (tsc + vite build, no errors)
- [x] `npm run lint` (0 errors; pre-existing warnings unrelated to this change)
- [x] Validated the same change on a personal fork/deployment before opening this PR

## Screenshots

| Before | After |
|--------|--------|
| <img width="552" height="432" alt="image" src="https://github.com/user-attachments/assets/8217a97b-cd66-4624-8513-9f50728c1bb1" /> | <img width="523" height="341" alt="image" src="https://github.com/user-attachments/assets/9fc457b1-1cd2-4278-90b6-9edbb9943ac3" /> |