### PR TITLE
docs: add the roadmap to the README nav and shorten the links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License: AGPL-3.0" /></a>
   <a href="https://discord.gg/rUqTKtQ9S4"><img src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white" alt="Join our Discord" /></a>
   <br />
-  <a href="https://usesecuro.com/">Website</a> · <a href="https://demo.usesecuro.com/">Try our Demo</a> · <a href="https://docs.usesecuro.com/">Read the Docs</a> · <a href="https://discord.gg/rUqTKtQ9S4">Discord</a> · <a href="https://cal.com/tassio/15min">Talk to the maintainer</a>
+  <a href="https://usesecuro.com/">Website</a> · <a href="https://demo.usesecuro.com/">Demo</a> · <a href="https://www.usesecuro.com/roadmap">Roadmap</a> · <a href="https://docs.usesecuro.com/">Docs</a> · <a href="https://discord.gg/rUqTKtQ9S4">Discord</a> · <a href="https://cal.com/tassio/15min">Talk to the maintainer</a>
 </p>
 
 <h3 align="center">Finance apps want your data. This one doesn't.</h3>


### PR DESCRIPTION
The header nav is a row of destinations, so the verbs in "Try our Demo" and "Read the Docs" add length without adding meaning. Trimming them to **Demo** and **Docs** leaves room for the roadmap on the same line.

```
Website · Demo · Roadmap · Docs · Discord · Talk to the maintainer
```

The roadmap answers the question a first-time visitor asks right after "what is this": what are you building now. That puts it next to the demo rather than a paragraph further down.

Link verified: `https://www.usesecuro.com/roadmap` returns 200 and redirects to `/en/roadmap`, so it follows the visitor's locale rather than pinning one.

One open question: I kept the order you had written, with Roadmap between Demo and Docs. If you meant Demo, Docs, then Roadmap, say so and I will swap the two.