### PR TITLE
fix: use pathFile in the pr labels comment, not an undeclared trigger

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -137,9 +137,17 @@ jobs:
             const requires = level === 'high'
               ? 'It needs two approvals, an agreed design on the issue, and a rollback plan.'
               : 'It needs a review from the area owner and tests on the changed path.';
+            // Name the source that decided. When the diff came out riskier
+            // than triage expected, that gap is worth reading rather than
+            // silently overwriting.
+            const why = fromIssue
+              ? `inherited from #${issueRef}`
+              : (pathFile ? `this PR touches \`${pathFile}\`` : 'the changed paths');
+            const gap = (!fromIssue && issueLevel
+                         && ORDER.indexOf(pathLevel) > ORDER.indexOf(issueLevel))
+              ? ` This came out riskier than #${issueRef} estimated (risk: ${issueLevel}).` : '';
             const note = skipped
               ? ` (${skipped} lines in generated files were not counted for size.)` : '';
             await github.rest.issues.createComment({ ...repo, issue_number: pr.number,
               body: `Labelled \`risk: ${level}\` and \`size: ${size}\` automatically: ` +
-                    `this PR touches \`${trigger}\` and changes ${lines} reviewable lines. ` +
-                    `${requires}${note}` });
+                    `${why}, ${lines} reviewable lines. ${requires}${gap}${note}` });


### PR DESCRIPTION
Fixes #697.

`${trigger}` was never declared, so every PR labelled `risk: medium` or `risk: high` ended the run with a `ReferenceError`.

**Scope of the bug:** the labels were already applied before the comment call, so nothing was mislabelled. The visible effect was a red job on the PR and a missing explanatory comment.

**How it got in:** the variable was renamed to `pathFile` in the change that made risk take the higher of the issue and the diff, and the comment was supposed to be rewritten in the same pass. That rewrite silently did not apply. A syntax check passes on this, because an undeclared identifier is a runtime error rather than a parse error, and `pull_request_target` always runs the base branch's copy of the workflow, so the PR that introduced it could not have exercised it either.

This restores what that pass intended, on top of the fix: the comment now names which source decided the level, and says so when the diff came out riskier than the linked issue estimated.

Thanks @jrvidotti for the precise report, the line and the variable name were both right.