### PR TITLE
chore: pin ruff's lint rule selection

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -95,4 +95,8 @@ line-length = 100
 target-version = "py311"
 
 [tool.ruff.lint]
+# Ruff 0.16 widened its default rule set, so leaving the selection implicit
+# means a ruff bump silently changes what CI enforces. Pin the set we lint
+# against (ruff's pre-0.16 default) and change it deliberately, not by upgrade.
+select = ["E4", "E7", "E9", "F"]
 ignore = ["E711", "E712"]


### PR DESCRIPTION
Ruff 0.16 widened its default rule set. Our `[tool.ruff.lint]` block only set `ignore`, so the selection was implicit and the bump to 0.16.4 in #601 turned a clean `ruff check .` into **4258 errors** without a line of backend code changing.

This pins `select` to ruff's pre-0.16 default, so the rules CI enforces are explicit and a version bump can't redefine them.

No-op against the current code:

| | |
|---|---|
| `ruff@0.15.22 check .` (current lock) | All checks passed |
| `ruff@0.16.4 check .` (before this change) | 4258 errors |
| `ruff@0.16.4 check .` (after this change) | All checks passed |

Unblocks #601. Adopting parts of ruff's new default set (`I001`, `UP045`, `UP017` are the big ones and mostly auto-fixable) is worth doing separately, one rule family per PR, rather than inside a dependency bump.