### PR TITLE
fix(agents): keep the suggestion chips stable instead of shuffling on render

### DIFF
--- a/frontend/src/components/agents/chat-panel.tsx
+++ b/frontend/src/components/agents/chat-panel.tsx
@@ -440,25 +440,27 @@ function ChatEmptyState({ agent, onPick }: { agent: Agent; onPick: (text: string
     return null
   }, [agent.connection_id, agent.provider, agent.model, connections])
 
-  // Pull the localized prompt pool. Each locale ships ~10 short tips;
-  // we shuffle and take the first 6 so reopening a fresh chat doesn't
-  // always show the same chips.
+  // Pull the localized prompt pool. Each locale ships ~10 short tips.
   const allPrompts = useMemo<string[]>(() => {
     const raw = t('agents.emptyState.suggestions', { returnObjects: true })
     return Array.isArray(raw) ? (raw as string[]) : []
-    // Re-randomize each time the agent changes so switching agents
-    // refreshes the suggestion set too.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [t, agent.id])
+  }, [t])
 
+  // Each agent gets its own slice of the pool, taken by rotating the list
+  // from an offset derived from its id. Deriving instead of shuffling keeps
+  // the render pure, so the chips stay put instead of swapping themselves
+  // out on an unrelated re-render.
   const picks = useMemo(() => {
-    const pool = [...allPrompts]
-    for (let i = pool.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1))
-      ;[pool[i], pool[j]] = [pool[j], pool[i]]
+    if (allPrompts.length === 0) return []
+    let hash = 0
+    for (let i = 0; i < agent.id.length; i++) {
+      hash = (hash * 31 + agent.id.charCodeAt(i)) | 0
     }
-    return pool.slice(0, 3)
-  }, [allPrompts])
+    const start = Math.abs(hash) % allPrompts.length
+    return Array.from({ length: Math.min(3, allPrompts.length) }, (_, i) =>
+      allPrompts[(start + i) % allPrompts.length],
+    )
+  }, [allPrompts, agent.id])
 
   return (
     <div className="flex flex-col items-center justify-center text-center gap-5 py-12 min-h-[65vh]">


### PR DESCRIPTION
The agent empty-state chips were picked with a `Math.random()` shuffle inside a `useMemo`, so any unrelated re-render could swap the suggestions out from under the user mid-session. `eslint-plugin-react-hooks` 7.1 flags it as `react-hooks/purity`, which is the blocker on #670.

Rather than move the shuffle into an effect (which costs a render and makes the chips flicker in on mount), the picks are now **derived**: the tip pool is rotated from an offset hashed off the agent id. Each agent still gets its own set, the chips hold still, and the render stays pure. The `exhaustive-deps` disable that only existed to force the reshuffle goes away too.

Verified in the browser, two agents side by side, same locale:

| `basico` | `Testing agent` |
|---|---|
| how am I doing against my budgets → biggest expense category → expenses by category | biggest expense category → expenses by category → income vs expenses |

Reloading the page keeps each agent's set identical, which is the behavior change: before, it rerolled every time.

```
npm run lint    0 errors (40 pre-existing warnings)
npm run build   ✓ built in 4.30s
npm test        161 passed (22 files)
```

Unblocks #670.