### PR TITLE
feat(payees): identify a counterparty by its document and original name, not its display name

### DIFF
--- a/backend/alembic/versions/076_payee_original_name.py
+++ b/backend/alembic/versions/076_payee_original_name.py
@@ -1,0 +1,50 @@
+"""remember what the provider called a payee, so renaming one survives sync
+
+Revision ID: 076
+Revises: 075
+Create Date: 2026-08-25
+
+Sync identified a counterparty by its display name alone, which is the one
+field a person is invited to change. Correcting a payee the bank had named
+after a document therefore made the next sync fail to recognise it and
+insert a duplicate.
+
+The backfill is the point of this migration: setting `original_name` to the
+current `name` for every existing row makes every payee already in the
+database rename-safe immediately, with no heuristics and nothing to detect.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "076"
+down_revision: Union[str, None] = "075"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("payees", sa.Column("original_name", sa.String(255), nullable=True))
+
+    # Every row that exists now was named by whoever created it, and for the
+    # sync-created majority that is exactly the string the provider will send
+    # again on the next run. Seeding it is what lets an existing install
+    # rename a payee without waiting for it to be re-synced first.
+    op.execute("UPDATE payees SET original_name = name")
+
+    # Deliberately not unique. Two payees can legitimately end up sharing an
+    # original_name — after a merge, or alongside a hand-created row — and a
+    # constraint would turn that into a sync-time IntegrityError, which is
+    # the failure this whole change exists to stop causing (issue #678).
+    op.create_index(
+        "ix_payees_workspace_original_name",
+        "payees",
+        ["workspace_id", "original_name"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_payees_workspace_original_name", table_name="payees")
+    op.drop_column("payees", "original_name")

--- a/backend/alembic/versions/077_backfill_payee_tax_ids_from_original_name.py
+++ b/backend/alembic/versions/077_backfill_payee_tax_ids_from_original_name.py
@@ -1,0 +1,168 @@
+"""recover the document from payees the bank named after one
+
+Revision ID: 077
+Revises: 076
+Create Date: 2026-08-26
+
+Migration 076 gave every payee an `original_name` and made the lookup fall
+back to it, which is what lets a rename survive. This one goes further and
+recovers the *document* from those rows.
+
+The rows in question are the ones this whole change exists for: a Pix to an
+individual arrives with `receiver.name: null`, so the provider falls back to
+the CPF and the payee ends up literally named `529.982.247-25`. Reading it
+back out of `original_name` gets those payees onto the document-first
+lookup immediately, rather than only once the same counterparty happens to
+be paid again.
+
+Two things it is careful about:
+
+- A name is only treated as a document when it is *nothing but* a document.
+  "52.288.516 OZEIAS AMORIM VIEIRA" is an MEI trading name that opens with a
+  CNPJ root, not a CNPJ, and must not be read as one. Check digits alone
+  would not settle that — an eleven-digit string passes them by luck about
+  once in a hundred — so anything left over after the digits and their
+  punctuation disqualifies the row.
+- It never replaces a document a payee already carries. A value somebody
+  entered by hand is more considered than one inferred from a name here.
+
+CNPJ is handled alongside CPF. The reporter's data has no CNPJ-named payees,
+because institutions withhold an individual's name but not a company's, but
+the two cases are the same mechanism and excluding one would be arbitrary.
+
+Validation goes through `app.fiscal.registry.normalise_and_validate`, the
+same call `payee_service._apply_tax_ids` makes, so a document recovered here
+is stored byte-identically to one entered through the form. The usual reason
+to keep a migration free of application imports — that the code may change
+underneath it — is weak for this particular import: CPF and CNPJ check
+digits are fixed by law, and duplicating the arithmetic would create two
+copies free to drift apart.
+"""
+
+import uuid
+from typing import Optional, Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.fiscal.registry import TaxIdKind, normalise_and_validate
+
+revision: str = "077"
+down_revision: Union[str, None] = "076"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+#: Punctuation a Brazilian document is allowed to wear. Anything else in the
+#: name means the name is not a bare document.
+_DOCUMENT_PUNCTUATION = set(". -/")
+
+#: The legal nature each document settles, mirroring what the service layer
+#: stamps when it creates a payee from a document.
+_TYPE_BY_KIND = {TaxIdKind.CPF.value: "person", TaxIdKind.CNPJ.value: "company"}
+
+
+def _classify(name: Optional[str]) -> Optional[tuple[str, str]]:
+    """(kind, normalised value) when this name is a document and nothing else."""
+    if not name:
+        return None
+    stripped = name.strip()
+    if not stripped:
+        return None
+    if any(c not in _DOCUMENT_PUNCTUATION and not c.isdigit() for c in stripped):
+        return None
+    # The two shapes are unambiguous by length, so trying both settles which
+    # one this is without the migration having to know the rule itself.
+    for kind in (TaxIdKind.CPF, TaxIdKind.CNPJ):
+        value, error = normalise_and_validate(kind, stripped)
+        if not error:
+            return kind.value, value
+    return None
+
+
+def _candidates(conn) -> list[tuple]:
+    """Payees whose original_name is a bare document, with what it resolves to."""
+    rows = conn.execute(
+        sa.text(
+            "SELECT id, workspace_id, original_name, type FROM payees "
+            "WHERE original_name IS NOT NULL"
+        )
+    ).fetchall()
+    found = []
+    for row in rows:
+        classified = _classify(row.original_name)
+        if classified is not None:
+            found.append((row, *classified))
+    return found
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    candidates = _candidates(conn)
+    if not candidates:
+        return
+
+    taken = {
+        (r.payee_id, r.kind)
+        for r in conn.execute(sa.text("SELECT payee_id, kind FROM payee_tax_ids")).fetchall()
+    }
+
+    documents = []
+    natures = []
+    for payee, kind, digits in candidates:
+        if (payee.id, kind) in taken:
+            continue
+        documents.append(
+            {
+                "id": uuid.uuid4(),
+                "payee_id": payee.id,
+                "workspace_id": payee.workspace_id,
+                "kind": kind,
+                "value": digits,
+            }
+        )
+        # Only where nothing has been said yet. A nature somebody chose
+        # outranks one inferred from a name, even a wrong one.
+        if payee.type is None:
+            natures.append({"payee_id": payee.id, "nature": _TYPE_BY_KIND[kind]})
+
+    if documents:
+        conn.execute(
+            sa.text(
+                "INSERT INTO payee_tax_ids (id, payee_id, workspace_id, kind, value) "
+                "VALUES (:id, :payee_id, :workspace_id, :kind, :value)"
+            ),
+            documents,
+        )
+    if natures:
+        conn.execute(
+            sa.text("UPDATE payees SET type = :nature WHERE id = :payee_id"),
+            natures,
+        )
+
+
+def downgrade() -> None:
+    """Remove the documents this migration could have inferred.
+
+    Reversible only up to a point, and deliberately so. A document somebody
+    typed by hand that happens to equal the one inferred here is
+    indistinguishable from it — but since the stored value is identical,
+    dropping it loses no information the upgrade did not already supply.
+
+    `payees.type` is left as it stands. The upgrade only filled it where
+    nothing had been said, and there is no record of which rows those were;
+    clearing it by shape would discard natures that predate this migration.
+    """
+    conn = op.get_bind()
+    stale = [
+        {"payee_id": payee.id, "kind": kind, "value": digits}
+        for payee, kind, digits in _candidates(conn)
+    ]
+    if stale:
+        conn.execute(
+            sa.text(
+                "DELETE FROM payee_tax_ids "
+                "WHERE payee_id = :payee_id AND kind = :kind AND value = :value"
+            ),
+            stale,
+        )

--- a/backend/app/models/payee.py
+++ b/backend/app/models/payee.py
@@ -31,6 +31,19 @@ class Payee(Base):
         UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), index=True
     )
     name: Mapped[str] = mapped_column(String(255))
+    # What the provider called this counterparty when the row was created.
+    #
+    # `name` is the one field a person is invited to edit, and sync used to
+    # identify a counterparty by it alone — so correcting "529.982.247-25"
+    # to a real name meant the next sync no longer recognised it and
+    # inserted a second payee. Keeping the original string gives the
+    # lookup something stable to fall back on, and the rename sticks.
+    #
+    # Set once, at creation, from the raw counterparty text and never
+    # updated afterwards, for the same reason `source` is not: it records
+    # what arrived, not what the row has since become. Null on rows a
+    # person typed in by hand, which no provider will ever send.
+    original_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     # Legal nature: `person` or `company`, and null when unknown.
     #
     # Null is the common case and is not a gap to be filled: sync names a

--- a/backend/app/providers/base.py
+++ b/backend/app/providers/base.py
@@ -91,6 +91,15 @@ class TransactionData:
     pluggy_category: Optional[str] = None
     status: str = "posted"  # posted, pending
     payee: Optional[str] = None
+    # The counterparty's fiscal document, when the provider reports one.
+    # `kind` is a `fiscal.registry.TaxIdKind` value; `value` is raw and gets
+    # normalised and validated at the point it is stored. Carried separately
+    # from `payee` because it identifies the counterparty rather than naming
+    # it, and it is the only part of a bank descriptor stable enough to
+    # survive somebody correcting the name. Providers that expose no such
+    # field leave both None and behave exactly as before.
+    payee_tax_id_kind: Optional[str] = None
+    payee_tax_id_value: Optional[str] = None
     raw_data: Optional[dict] = None
     # Installment metadata (parcelamento) — populated by CC providers that expose it.
     installment_number: Optional[int] = None

--- a/backend/app/providers/pluggy.py
+++ b/backend/app/providers/pluggy.py
@@ -451,6 +451,12 @@ class PluggyProvider(BankProvider):
                     # Smart payee extraction (merchant → payment data → None)
                     payee = self._extract_payee(txn, txn_type, payee_source)
 
+                    # Extracted regardless of payee_source and regardless of
+                    # whether a name was found: the document identifies the
+                    # counterparty, so it is worth keeping even for the ones
+                    # that already came named.
+                    tax_id_kind, tax_id_value = self._extract_tax_id(txn, txn_type)
+
                     # Bank-provided conversion for international transactions
                     amt_in_acct = txn.get("amountInAccountCurrency")
                     amount_in_account_currency = (
@@ -496,6 +502,8 @@ class PluggyProvider(BankProvider):
                             pluggy_category=txn.get("category"),
                             status=status,
                             payee=payee,
+                            payee_tax_id_kind=tax_id_kind,
+                            payee_tax_id_value=tax_id_value,
                             raw_data=txn,
                             installment_number=inst_number if isinstance(inst_number, int) else None,
                             total_installments=inst_total if isinstance(inst_total, int) else None,
@@ -757,6 +765,50 @@ class PluggyProvider(BankProvider):
                         return doc["value"]
 
         return None
+
+    #: Pluggy names a document by its Brazilian type. Mapped to the fiscal
+    #: registry's vocabulary rather than passed through, so an unfamiliar
+    #: type is ignored instead of being stored as a kind nothing validates.
+    _TAX_ID_KIND_BY_PLUGGY_TYPE = {
+        "CPF": "cpf",
+        "CNPJ": "cnpj",
+    }
+
+    @classmethod
+    def _extract_tax_id(cls, txn: dict, txn_type: str) -> tuple[Optional[str], Optional[str]]:
+        """The counterparty's document, as (kind, value), or (None, None).
+
+        Same side of the payment as `_extract_payee` reads for the name: on a
+        debit the money went to the receiver, on a credit it came from the
+        payer.
+
+        Deliberately independent of `payee_source`. That setting chooses what
+        to *call* a counterparty; this identifies it, and the two want
+        different answers — a payee named from a merchant descriptor still
+        benefits from carrying the CNPJ that came alongside it.
+
+        Note the document survives here even when the description masks it.
+        Institutions redact the document in the descriptor text
+        (`***.204.531-**`) while sending it in full under paymentData, so
+        this payload is the only place it can be read reliably.
+        """
+        payment_data = txn.get("paymentData")
+        if not payment_data:
+            return None, None
+
+        party = payment_data.get("receiver") if txn_type == "debit" else payment_data.get("payer")
+        if not party:
+            return None, None
+
+        doc = party.get("documentNumber")
+        if not doc:
+            return None, None
+
+        kind = cls._TAX_ID_KIND_BY_PLUGGY_TYPE.get(str(doc.get("type") or "").upper())
+        value = doc.get("value")
+        if not kind or not value:
+            return None, None
+        return kind, value
 
     @staticmethod
     def _map_account_type(pluggy_type: str, pluggy_subtype: Optional[str] = None) -> str:

--- a/backend/app/schemas/payee.py
+++ b/backend/app/schemas/payee.py
@@ -70,6 +70,11 @@ class PayeeRead(BaseModel):
     id: uuid.UUID
     user_id: uuid.UUID
     name: str
+    # Read-only, and exposed so the UI can show what the bank actually sent
+    # next to a name somebody has since corrected. Never accepted on the way
+    # in: it records what a provider said, and a client claiming otherwise
+    # would defeat the point, exactly as for `source`.
+    original_name: Optional[str] = None
     type: Optional[PayeeType] = None
     # Read-only. Exposed so a client picker can tell the handful of
     # counterparties somebody entered on purpose from the hundreds sync

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -50,7 +50,7 @@ from app.services.rule_engine import merge_notes
 from app.services.rule_service import apply_rules_to_transaction, preview_rules_for_transaction
 from app.services.transfer_detection_service import detect_transfer_pairs
 from app.services.fx_rate_service import stamp_primary_amount
-from app.services.payee_service import get_or_create_payee
+from app.services.payee_service import get_or_create_payee, tax_id_from_provider
 
 logger = logging.getLogger(__name__)
 
@@ -1064,11 +1064,19 @@ async def handle_oauth_callback(
             category_id = await _match_pluggy_category(
                 session, workspace_id, txn_data.pluggy_category, enabled=use_provider_cats
             )
-            # Resolve payee entity from raw payee text
+            # Resolve payee entity from raw payee text, plus the document
+            # when the provider sent one — that is what lets a counterparty
+            # renamed by hand still be recognised on the next run.
             payee_id = None
             if txn_data.payee:
                 payee_entity = await get_or_create_payee(
-                    session, user_id, txn_data.payee, workspace_id=workspace_id
+                    session,
+                    user_id,
+                    txn_data.payee,
+                    workspace_id=workspace_id,
+                    tax_id=tax_id_from_provider(
+                        txn_data.payee_tax_id_kind, txn_data.payee_tax_id_value
+                    ),
                 )
                 payee_id = payee_entity.id
 
@@ -1860,6 +1868,9 @@ async def sync_connection(
                         user_id,
                         txn_data.payee,
                         workspace_id=workspace_id,
+                        tax_id=tax_id_from_provider(
+                            txn_data.payee_tax_id_kind, txn_data.payee_tax_id_value
+                        ),
                     )
                     sync_payee_id = sync_payee_entity.id
 

--- a/backend/app/services/payee_service.py
+++ b/backend/app/services/payee_service.py
@@ -65,6 +65,50 @@ async def get_payee(session: AsyncSession, payee_id: uuid.UUID, workspace_id: uu
     return result.scalar_one_or_none()
 
 
+def _normalised_tax_id(tax_id: Optional[tuple[TaxIdKind, str]]) -> Optional[tuple[TaxIdKind, str]]:
+    """Store-ready document, or None when there is nothing usable.
+
+    Deliberately swallows an invalid value instead of raising. This runs on
+    the sync path, where the document is whatever an institution chose to
+    send; a malformed one means "match by name instead", never "fail the
+    whole sync". The manual API keeps raising, because there a person typed
+    it and wants to be told.
+    """
+    if tax_id is None:
+        return None
+    kind, raw = tax_id
+    if not raw:
+        return None
+    value, error = normalise_and_validate(kind, raw)
+    if error:
+        return None
+    return kind, value
+
+
+#: Legal nature implied by a document. A CPF belongs to an individual and a
+#: CNPJ to a company; nothing else in the registry settles the question, so
+#: nothing else appears here.
+_TYPE_BY_TAX_ID_KIND = {
+    TaxIdKind.CPF: "person",
+    TaxIdKind.CNPJ: "company",
+}
+
+
+def tax_id_from_provider(kind: Optional[str], value: Optional[str]) -> Optional[tuple[TaxIdKind, str]]:
+    """Turn a provider's document fields into something `get_or_create_payee` takes.
+
+    A kind outside the registry returns None rather than raising: providers
+    add document types on their own schedule, and an unrecognised one means
+    this payment tells us nothing about identity, not that the sync is broken.
+    """
+    if not kind or not value:
+        return None
+    try:
+        return TaxIdKind(kind), value
+    except ValueError:
+        return None
+
+
 async def get_or_create_payee(
     session: AsyncSession,
     user_id: uuid.UUID,
@@ -72,17 +116,31 @@ async def get_or_create_payee(
     *,
     workspace_id: Optional[uuid.UUID] = None,
     source: str = "sync",
+    tax_id: Optional[tuple[TaxIdKind, str]] = None,
 ) -> Payee:
-    """Find a payee by name (case-insensitive) or create a new one.
+    """Find the payee this counterparty already is, or create it.
 
     `user_id` is kept first for backwards compatibility with import/connection
     sync paths. When `workspace_id` is provided, the lookup scopes by workspace;
     otherwise the autostamp listener fills it in on insert.
 
+    Resolution runs document, then name, then original name. The document
+    comes first because it identifies the counterparty rather than describing
+    it: the same person reached through two channels carries one CPF but may
+    arrive under two different descriptors. The display name comes next
+    because it is the most current thing anybody has said about the row. The
+    original name is the backstop, and the reason a rename now survives —
+    matching on the display name alone meant correcting a payee the bank had
+    named after a document made the next sync insert a second one.
+
+    A hit fills in whatever the existing row is missing, so payees created
+    before any of this acquire their document and original name the first
+    time sync sees them again, with no migration to run.
+
     `source` is stamped only on rows this call creates. An existing payee is
-    returned untouched, so a counterparty somebody entered by hand keeps
-    saying so even after sync sees the same name — the same protection that
-    already keeps sync from overwriting manual edits.
+    returned untouched in every other respect, so a counterparty somebody
+    entered by hand keeps saying so even after sync sees the same name — the
+    same protection that already keeps sync from overwriting manual edits.
 
     Defaults to `sync` because that is what this function is for: the bulk
     path that turns bank descriptors into rows. The CSV importer passes
@@ -95,22 +153,93 @@ async def get_or_create_payee(
     if len(name) > 255:
         name = name[:255]
 
-    lookup = select(Payee).where(func.lower(Payee.name) == name.lower())
-    if workspace_id is not None:
-        lookup = lookup.where(Payee.workspace_id == workspace_id)
-    else:
-        lookup = lookup.where(Payee.user_id == user_id)
-    result = await session.execute(lookup)
-    payee = result.scalar_one_or_none()
-    if payee:
+    def _scoped(stmt):
+        """Confine a lookup to the caller's workspace, or user when it has none."""
+        if workspace_id is not None:
+            return stmt.where(Payee.workspace_id == workspace_id)
+        return stmt.where(Payee.user_id == user_id)
+
+    # Oldest wins, always. Nothing stops two payees sharing a document or an
+    # original name — a merge or a hand-created row can produce it — and a
+    # lookup that raised on the second one would be a sync failure over data
+    # the user is entitled to have.
+    def _first(stmt):
+        return _scoped(stmt).order_by(Payee.created_at, Payee.id).limit(1)
+
+    normalised = _normalised_tax_id(tax_id)
+
+    payee: Optional[Payee] = None
+
+    if normalised is not None:
+        kind, value = normalised
+        result = await session.execute(
+            _first(
+                select(Payee)
+                .join(PayeeTaxId, PayeeTaxId.payee_id == Payee.id)
+                .where(PayeeTaxId.kind == kind.value, PayeeTaxId.value == value)
+            )
+        )
+        payee = result.scalars().first()
+
+    if payee is None:
+        result = await session.execute(_first(select(Payee).where(func.lower(Payee.name) == name.lower())))
+        payee = result.scalars().first()
+
+    if payee is None:
+        result = await session.execute(
+            _first(select(Payee).where(func.lower(Payee.original_name) == name.lower()))
+        )
+        payee = result.scalars().first()
+
+    if payee is not None:
+        # Backfill on the way past. The row was created before it could carry
+        # these, and the next rename depends on them being there.
+        if payee.original_name is None:
+            payee.original_name = name
+        if normalised is not None:
+            await _attach_tax_id_if_missing(session, payee, normalised)
+        await session.flush()
         return payee
 
-    payee = Payee(user_id=user_id, name=name, source=source)
+    payee = Payee(user_id=user_id, name=name, original_name=name, source=source)
     if workspace_id is not None:
         payee.workspace_id = workspace_id
+    if normalised is not None:
+        payee.type = _TYPE_BY_TAX_ID_KIND.get(normalised[0])
     session.add(payee)
     await session.flush()
+    if normalised is not None:
+        await _attach_tax_id_if_missing(session, payee, normalised)
+        await session.flush()
     return payee
+
+
+async def _attach_tax_id_if_missing(
+    session: AsyncSession,
+    payee: Payee,
+    tax_id: tuple[TaxIdKind, str],
+) -> None:
+    """Add a document to a payee that has none of that kind.
+
+    Add, never replace: `_apply_tax_ids` owns replacement because a person
+    editing the form is stating the complete set. A provider is not — it
+    reports one document about one payment, and letting that overwrite what
+    somebody entered by hand would lose the more considered value.
+    """
+    kind, value = tax_id
+    existing = await session.execute(
+        select(PayeeTaxId).where(PayeeTaxId.payee_id == payee.id, PayeeTaxId.kind == kind.value)
+    )
+    if existing.scalars().first() is not None:
+        return
+    session.add(
+        PayeeTaxId(
+            payee_id=payee.id,
+            workspace_id=payee.workspace_id,
+            kind=kind.value,
+            value=value,
+        )
+    )
 
 
 async def _apply_tax_ids(

--- a/backend/tests/test_migration_077_classify.py
+++ b/backend/tests/test_migration_077_classify.py
@@ -1,0 +1,75 @@
+"""The rule migration 077 uses to decide that a payee name *is* a document.
+
+Worth a test of its own because the failure it guards against is silent and
+wrong rather than loud: attaching somebody's CPF to a shop because the
+shop's name happened to contain eleven digits that passed the check digits.
+Check digits alone let that through roughly once in a hundred, so the
+migration also requires the name to be nothing but a document, and that is
+the part most likely to be "simplified" later by someone who reads only the
+maths.
+
+Loaded through importlib because a migration filename starts with a digit
+and is not importable as a module path.
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_PATH = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "alembic"
+    / "versions"
+    / "077_backfill_payee_tax_ids_from_original_name.py"
+)
+_spec = importlib.util.spec_from_file_location("migration_077", _PATH)
+assert _spec is not None and _spec.loader is not None, f"cannot load {_PATH}"
+migration_077 = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(migration_077)
+
+classify = migration_077._classify
+
+#: Fictitious but check-digit-valid, because the whole point is the maths.
+CPF = "529.982.247-25"
+CNPJ = "11.222.333/0001-81"
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        (CPF, ("cpf", "52998224725")),
+        ("52998224725", ("cpf", "52998224725")),
+        ("  529.982.247-25  ", ("cpf", "52998224725")),
+        (CNPJ, ("cnpj", "11222333000181")),
+        ("11222333000181", ("cnpj", "11222333000181")),
+        ("11.222.333 0001-81", ("cnpj", "11222333000181")),  # bank writes / as a space
+    ],
+)
+def test_a_bare_document_is_recognised(name, expected):
+    assert classify(name) == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # An MEI trades under "<CNPJ root> <person's name>". The root is not a
+        # CNPJ, and the name is not a document — this is the case that made
+        # the letters rule necessary.
+        "11.222.333 JOHN DOE SILVA",
+        "JOHN DOE SILVA",
+        "UBER *TRIP",
+        "LOJA 52998224725 LTDA",  # a real CPF, but the name is not one
+        "529.982.247-26",  # second check digit wrong
+        "529.982.247-15",  # first check digit wrong
+        "111.111.111-11",  # repdigits pass the maths and are never issued
+        "11.111.111/1111-11",
+        "1234567890",  # too short for either
+        "529982247251",  # twelve digits: neither shape
+        "",
+        "   ",
+        None,
+    ],
+)
+def test_anything_else_is_refused(name):
+    assert classify(name) is None

--- a/backend/tests/test_payee_identity.py
+++ b/backend/tests/test_payee_identity.py
@@ -1,0 +1,310 @@
+"""A payee's identity is not its display name.
+
+Sync used to recognise a counterparty by `lower(name)` alone. Because the
+bank names a Pix counterparty after their CPF whenever it withholds the
+name, users renamed those payees — and the next sync, still sending the
+CPF, failed to find them and inserted a duplicate. The display name is the
+one field a person is invited to change, so these tests pin down the two
+things that now carry identity instead: the original name the provider
+sent, and the fiscal document.
+
+The documents below are fictitious but check-digit-valid, because
+`normalise_and_validate` rejects anything else and a placeholder that
+silently failed validation would make these tests pass for the wrong
+reason.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.fiscal.registry import TaxIdKind
+from app.models.payee import Payee, PayeeTaxId
+from app.schemas.payee import PayeeCreate, PayeeUpdate
+from app.services.payee_service import (
+    create_payee,
+    get_or_create_payee,
+    tax_id_from_provider,
+    update_payee,
+)
+
+#: What the bank sends when it withholds an individual's name.
+CPF = "529.982.247-25"
+CNPJ = "11.222.333/0001-81"
+
+
+# ---------------------------------------------------------------------------
+# The reported regression
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_survives_the_next_sync(session: AsyncSession, test_user, test_workspace):
+    """Rename a payee the bank named after a CPF; sync must still find it.
+
+    This is the bug in full: before `original_name` existed, the second call
+    matched nothing and created a second payee for one real person.
+    """
+    created = await get_or_create_payee(session, test_user.id, CPF, workspace_id=test_workspace.id)
+
+    renamed = await update_payee(session, created.id, test_workspace.id, PayeeUpdate(name="Jane Doe"))
+    assert renamed is not None
+    assert renamed.name == "Jane Doe"
+
+    again = await get_or_create_payee(session, test_user.id, CPF, workspace_id=test_workspace.id)
+    assert again.id == created.id
+
+    rows = await session.execute(select(Payee).where(Payee.workspace_id == test_workspace.id))
+    assert len(rows.scalars().all()) == 1
+
+
+@pytest.mark.asyncio
+async def test_rename_survives_even_when_the_descriptor_changes(
+    session: AsyncSession, test_user, test_workspace
+):
+    """The document outlives both the display name and the original one.
+
+    A counterparty reached through a second channel arrives under a
+    different descriptor, so neither name lookup can match. Only the
+    document can, which is why it is tried first.
+    """
+    tax_id = (TaxIdKind.CNPJ, CNPJ)
+    created = await get_or_create_payee(
+        session, test_user.id, "ACME LTDA", workspace_id=test_workspace.id, tax_id=tax_id
+    )
+    await update_payee(session, created.id, test_workspace.id, PayeeUpdate(name="Acme"))
+
+    again = await get_or_create_payee(
+        session, test_user.id, "ACME *STORE 4471", workspace_id=test_workspace.id, tax_id=tax_id
+    )
+    assert again.id == created.id
+
+
+# ---------------------------------------------------------------------------
+# original_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_stamps_original_name(session: AsyncSession, test_user, test_workspace):
+    payee = await get_or_create_payee(session, test_user.id, CPF, workspace_id=test_workspace.id)
+    assert payee.original_name == CPF
+
+
+@pytest.mark.asyncio
+async def test_update_never_touches_original_name(session: AsyncSession, test_user, test_workspace):
+    """`original_name` records what arrived, not what the row has become.
+
+    If an edit could rewrite it, renaming twice would strand the payee just
+    as the original bug did.
+    """
+    payee = await get_or_create_payee(session, test_user.id, CPF, workspace_id=test_workspace.id)
+
+    await update_payee(session, payee.id, test_workspace.id, PayeeUpdate(name="Jane Doe"))
+    await update_payee(session, payee.id, test_workspace.id, PayeeUpdate(name="Jane R. Doe"))
+
+    assert payee.original_name == CPF
+    again = await get_or_create_payee(session, test_user.id, CPF, workspace_id=test_workspace.id)
+    assert again.id == payee.id
+
+
+@pytest.mark.asyncio
+async def test_manual_creation_leaves_original_name_null(
+    session: AsyncSession, test_user, test_workspace
+):
+    """Nobody sent this name over the wire, so there is no original to keep."""
+    payee = await create_payee(
+        session, test_workspace.id, test_user.id, PayeeCreate(name="Hand Typed")
+    )
+    assert payee.original_name is None
+
+
+@pytest.mark.asyncio
+async def test_name_hit_backfills_a_missing_original_name(
+    session: AsyncSession, test_user, test_workspace
+):
+    """A payee created before this column existed heals on the next sync.
+
+    Without this the backfill would only reach rows the migration touched,
+    and a hand-created payee adopted by sync would still be renameable into
+    a duplicate.
+    """
+    manual = await create_payee(
+        session, test_workspace.id, test_user.id, PayeeCreate(name="Corner Shop")
+    )
+    assert manual.original_name is None
+
+    adopted = await get_or_create_payee(
+        session, test_user.id, "corner shop", workspace_id=test_workspace.id
+    )
+    assert adopted.id == manual.id
+    assert adopted.original_name == "corner shop"
+    # Adoption must not relabel a row somebody entered on purpose.
+    assert adopted.source == "manual"
+
+
+@pytest.mark.asyncio
+async def test_display_name_outranks_original_name(session: AsyncSession, test_user, test_workspace):
+    """The current name is the most recent thing anybody said about a row.
+
+    When one payee's original name collides with another's display name,
+    the display name wins, and the result is at least deterministic.
+    """
+    renamed = await get_or_create_payee(session, test_user.id, CPF, workspace_id=test_workspace.id)
+    await update_payee(session, renamed.id, test_workspace.id, PayeeUpdate(name="Jane Doe"))
+
+    literal = await create_payee(session, test_workspace.id, test_user.id, PayeeCreate(name=CPF))
+
+    hit = await get_or_create_payee(session, test_user.id, CPF, workspace_id=test_workspace.id)
+    assert hit.id == literal.id
+
+
+# ---------------------------------------------------------------------------
+# Documents
+# ---------------------------------------------------------------------------
+
+
+async def _tax_ids(session: AsyncSession, payee_id: uuid.UUID) -> dict[str, str]:
+    rows = await session.execute(select(PayeeTaxId).where(PayeeTaxId.payee_id == payee_id))
+    return {row.kind: row.value for row in rows.scalars().all()}
+
+
+@pytest.mark.asyncio
+async def test_sync_stores_the_document_normalised(
+    session: AsyncSession, test_user, test_workspace
+):
+    """The table and its index existed all along; nothing ever wrote to them."""
+    payee = await get_or_create_payee(
+        session,
+        test_user.id,
+        CPF,
+        workspace_id=test_workspace.id,
+        tax_id=(TaxIdKind.CPF, CPF),
+    )
+    assert await _tax_ids(session, payee.id) == {"cpf": "52998224725"}
+
+
+@pytest.mark.asyncio
+async def test_document_settles_the_legal_nature(session: AsyncSession, test_user, test_workspace):
+    """A CPF means an individual and a CNPJ a company. Nothing else guesses."""
+    person = await get_or_create_payee(
+        session, test_user.id, CPF, workspace_id=test_workspace.id, tax_id=(TaxIdKind.CPF, CPF)
+    )
+    company = await get_or_create_payee(
+        session, test_user.id, "ACME", workspace_id=test_workspace.id, tax_id=(TaxIdKind.CNPJ, CNPJ)
+    )
+    unknown = await get_or_create_payee(
+        session, test_user.id, "UBER *TRIP", workspace_id=test_workspace.id
+    )
+
+    assert person.type == "person"
+    assert company.type == "company"
+    assert unknown.type is None
+
+
+@pytest.mark.asyncio
+async def test_name_hit_attaches_a_missing_document(
+    session: AsyncSession, test_user, test_workspace
+):
+    payee = await get_or_create_payee(session, test_user.id, "ACME", workspace_id=test_workspace.id)
+    assert await _tax_ids(session, payee.id) == {}
+
+    again = await get_or_create_payee(
+        session, test_user.id, "ACME", workspace_id=test_workspace.id, tax_id=(TaxIdKind.CNPJ, CNPJ)
+    )
+    assert again.id == payee.id
+    assert await _tax_ids(session, payee.id) == {"cnpj": "11222333000181"}
+
+
+@pytest.mark.asyncio
+async def test_provider_never_overwrites_a_hand_entered_document(
+    session: AsyncSession, test_user, test_workspace
+):
+    """A person editing the form states the whole set; a payment does not.
+
+    One payment reports one document. Letting it replace a value somebody
+    considered and typed would lose the better of the two.
+    """
+    payee = await create_payee(
+        session,
+        test_workspace.id,
+        test_user.id,
+        PayeeCreate(name="ACME", tax_ids=[{"kind": "cnpj", "value": CNPJ}]),
+    )
+
+    await get_or_create_payee(
+        session,
+        test_user.id,
+        "ACME",
+        workspace_id=test_workspace.id,
+        tax_id=(TaxIdKind.CNPJ, "11.444.777/0001-61"),
+    )
+    assert await _tax_ids(session, payee.id) == {"cnpj": "11222333000181"}
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_document_never_breaks_a_sync(
+    session: AsyncSession, test_user, test_workspace
+):
+    """Fall back to the name rather than failing over a bank's bad value."""
+    payee = await get_or_create_payee(
+        session,
+        test_user.id,
+        "ACME",
+        workspace_id=test_workspace.id,
+        tax_id=(TaxIdKind.CNPJ, "00.000.000/0000-00"),
+    )
+    assert payee.name == "ACME"
+    assert await _tax_ids(session, payee.id) == {}
+    assert payee.type is None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_document_resolves_to_the_oldest(
+    session: AsyncSession, test_user, test_workspace
+):
+    """Two payees may legitimately share a document; raising would be a sync failure.
+
+    There is no unique constraint on purpose — issue #678 is what happens
+    when sync turns pre-existing data into an IntegrityError.
+    """
+    first = await get_or_create_payee(
+        session, test_user.id, "ACME ONE", workspace_id=test_workspace.id, tax_id=(TaxIdKind.CNPJ, CNPJ)
+    )
+    second = await create_payee(
+        session,
+        test_workspace.id,
+        test_user.id,
+        PayeeCreate(name="ACME TWO", tax_ids=[{"kind": "cnpj", "value": CNPJ}]),
+    )
+    assert first.id != second.id
+
+    hit = await get_or_create_payee(
+        session, test_user.id, "ACME THREE", workspace_id=test_workspace.id, tax_id=(TaxIdKind.CNPJ, CNPJ)
+    )
+    assert hit.id == first.id
+
+
+# ---------------------------------------------------------------------------
+# tax_id_from_provider
+# ---------------------------------------------------------------------------
+
+
+def test_tax_id_from_provider_maps_known_kinds():
+    assert tax_id_from_provider("cpf", CPF) == (TaxIdKind.CPF, CPF)
+
+
+@pytest.mark.parametrize(
+    "kind,value",
+    [
+        ("passport", "X1234567"),  # a kind the registry does not know
+        (None, CPF),
+        ("cpf", None),
+        ("cpf", ""),
+    ],
+)
+def test_tax_id_from_provider_declines_what_it_cannot_use(kind, value):
+    """An unusable document means "match by name", not "raise"."""
+    assert tax_id_from_provider(kind, value) is None

--- a/backend/tests/test_providers_pluggy_tax_id.py
+++ b/backend/tests/test_providers_pluggy_tax_id.py
@@ -1,0 +1,131 @@
+"""Parser tests for `PluggyProvider._extract_tax_id`.
+
+The counterparty's document is the only part of a Pix payload stable enough
+to survive somebody correcting the payee's name, so these pin down that it
+is read from the right side of the payment, that it is read independently
+of whatever the connection's `payee_source` says, and that an unfamiliar
+document type is ignored rather than stored as a kind nothing validates.
+
+The httpx client is stubbed out, so no network traffic happens.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.providers.pluggy import PluggyProvider
+
+CPF = "529.982.247-25"
+CNPJ = "11.222.333/0001-81"
+
+
+def _mock_httpx_client(results: list[dict]) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(return_value={"results": results, "totalPages": 1})
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+async def _fetch(txns: list[dict], payee_source: str = "auto"):
+    provider = PluggyProvider()
+    fake_client = _mock_httpx_client(txns)
+    with patch.object(
+        PluggyProvider, "_ensure_api_key", new=AsyncMock(return_value="fake-key")
+    ), patch("app.providers.pluggy.httpx.AsyncClient", return_value=fake_client):
+        return await provider.get_transactions(
+            {"item_id": "i"}, "acc-ext-1", payee_source=payee_source
+        )
+
+
+def _pix(txn_type: str, *, receiver: dict | None = None, payer: dict | None = None) -> dict:
+    return {
+        "id": "t1",
+        "description": "PIX",
+        "amount": -10 if txn_type == "DEBIT" else 10,
+        "date": "2026-07-09T03:00:00.000Z",
+        "type": txn_type,
+        "paymentData": {"receiver": receiver, "payer": payer},
+    }
+
+
+def _doc(kind: str, value: str) -> dict:
+    return {"name": None, "documentNumber": {"type": kind, "value": value}}
+
+
+@pytest.mark.asyncio
+async def test_debit_reads_the_receiver():
+    """On a debit the money went to the receiver, so that is the counterparty."""
+    result = await _fetch([
+        _pix("DEBIT", receiver=_doc("CPF", CPF), payer=_doc("CNPJ", CNPJ)),
+    ])
+    assert result[0].payee_tax_id_kind == "cpf"
+    assert result[0].payee_tax_id_value == CPF
+
+
+@pytest.mark.asyncio
+async def test_credit_reads_the_payer():
+    result = await _fetch([
+        _pix("CREDIT", receiver=_doc("CPF", CPF), payer=_doc("CNPJ", CNPJ)),
+    ])
+    assert result[0].payee_tax_id_kind == "cnpj"
+    assert result[0].payee_tax_id_value == CNPJ
+
+
+@pytest.mark.asyncio
+async def test_document_is_kept_even_when_the_name_came_through():
+    """A named counterparty still benefits from carrying its document.
+
+    `_extract_payee` stops at the name, so extracting the document only as a
+    fallback would leave every correctly-named company without one.
+    """
+    receiver = {"name": "ACME LTDA", "documentNumber": {"type": "CNPJ", "value": CNPJ}}
+    result = await _fetch([_pix("DEBIT", receiver=receiver)])
+    assert result[0].payee == "ACME LTDA"
+    assert result[0].payee_tax_id_value == CNPJ
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payee_source", ["auto", "none", "description", "merchant", "payment_data"])
+async def test_extraction_ignores_payee_source(payee_source):
+    """`payee_source` chooses what to call a counterparty, not how to identify it."""
+    result = await _fetch([_pix("DEBIT", receiver=_doc("CPF", CPF))], payee_source=payee_source)
+    assert result[0].payee_tax_id_value == CPF
+
+
+@pytest.mark.asyncio
+async def test_card_purchase_has_no_document():
+    """Card transactions carry no paymentData at all, and must not invent one."""
+    result = await _fetch([
+        {
+            "id": "t1",
+            "description": "COFFEE BAR",
+            "amount": -7,
+            "date": "2026-04-28T03:00:00.000Z",
+            "type": "DEBIT",
+            "paymentData": None,
+        }
+    ])
+    assert result[0].payee_tax_id_kind is None
+    assert result[0].payee_tax_id_value is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "receiver",
+    [
+        None,
+        {"name": "ACME", "documentNumber": None},
+        {"name": "ACME", "documentNumber": {"type": "PASSPORT", "value": "X1234567"}},
+        {"name": "ACME", "documentNumber": {"type": "CPF", "value": None}},
+    ],
+    ids=["no-party", "no-document", "unknown-type", "no-value"],
+)
+async def test_nothing_usable_yields_nothing(receiver):
+    result = await _fetch([_pix("DEBIT", receiver=receiver)])
+    assert result[0].payee_tax_id_kind is None
+    assert result[0].payee_tax_id_value is None


### PR DESCRIPTION
> Validated on a preview deployment of my own instance, so this is no longer a draft and
> is ready for review. #702 asked for the approach to be agreed before the code, so I'm
> still happy to change direction if you'd rather take a different one.

## What

Stops a payee's identity being its display name, which is the one field a user is
invited to edit.

- `payees.original_name` (migration `076`) records what the provider called the
  counterparty when the row was created, mirroring the existing
  `transactions.original_description`. Set once, never updated. The migration seeds it
  from `name` for every existing row.
- `PluggyProvider._extract_tax_id` reads the counterparty's CPF/CNPJ from
  `paymentData.{receiver,payer}.documentNumber` and carries it on `TransactionData`.
  Both sync paths pass it through to the payee lookup.
- `get_or_create_payee` now resolves **document → `lower(name)` → `lower(original_name)`
  → create**, filling in whatever a matched row is missing, and stamping `type` from the
  document kind (CPF ⇒ `person`, CNPJ ⇒ `company`) — the rule `models/payee.py` already
  documents but nothing implemented.
- Migration `077` backfills the document for payees whose `original_name` *is* a
  document, so they reach the document-first lookup without waiting to be re-synced.

Enable Banking, SimpleFIN and CSV import report no document; they leave it `None` and
behave exactly as before, but still gain `original_name`.

## Why

Full detail in #702. In short: `get_or_create_payee` matched only on `lower(name)`, so
renaming a sync-created payee made the next sync fail to find it and insert a duplicate,
splitting one counterparty's history across two rows.

That is not a rare path. For a Pix to an *individual*, the institution returns
`receiver.name: null` while still sending the document, so `_extract_payee` falls back to
the document and the payee ends up literally **named after a CPF**. Companies are
unaffected, because their name does come through. In my workspace that was 64 of 190
payees, covering 253 transactions — every one of them impossible to rename permanently.

Meanwhile `payee_tax_ids` and its `(workspace_id, kind, value)` index have existed since
migration `070`, with a comment saying document matching is exactly what the table is
for — and nothing had ever written to it. My production database had 0 rows in it.

Two deliberate non-goals:

- **No unique constraint** on `original_name` or on `(workspace_id, kind, value)`.
  Existing installs may already have two payees sharing either, and a constraint would
  turn that into a sync-time `IntegrityError` — the failure shape of #678. Every lookup
  takes the oldest match instead.
- **A malformed document never fails a sync.** On this path the value is whatever an
  institution chose to send, so it is validated and dropped on error. The manual API
  keeps raising, because there a person typed it and wants to be told.

Credit-card payees are **out of scope** here. Pluggy sends `merchant: null` *and*
`paymentData: null` for card purchases, so `_extract_payee` returns `None` and those
transactions get no payee at all. Happy to open that separately.

## How to Test

Automated:

1. `cd backend && uv run pytest` — 3206 pass. The regression itself is
   `tests/test_payee_identity.py::test_rename_survives_the_next_sync`.
2. `uv run ruff check . && uv run ty check .`
3. `uv run alembic heads` — single head, `077`.

Migrations, against a throwaway Postgres:

4. `alembic upgrade head`, then `downgrade -1` twice and `upgrade head` again. `076`
   backfills `original_name` for every pre-existing row; `077` is skip-if-present, so
   re-running produces no duplicates.

By hand, against a real Pluggy connection:

5. Find a payee whose name is a CPF, rename it, and resync. Before this change a second
   payee appears with the original name; after it, the rename holds and the
   transactions stay on the renamed row.

Worth a reviewer's attention: `077` decides *when* a name counts as a document. Check
digits alone are not enough — eleven arbitrary digits pass them by luck about once in a
hundred — so the name must be nothing but a document. That is what stops an MEI trading
name (a CNPJ root followed by a person's name, e.g. `11.222.333 JOHN DOE SILVA`) from
being read as a CNPJ. `tests/test_migration_077_classify.py` pins that down.

## Related Issue

Closes #702.

## Checklist

- [x] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`) — n/a, no frontend files changed
- [ ] Frontend builds (`npm run build`) — n/a, no frontend files changed
- [ ] Translations updated (if user-facing strings changed) — n/a, no user-facing strings
- [x] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes)) — #702
