### PR TITLE
fix(ci): let the migration guard fail in one job, not two

### DIFF
--- a/backend/tests/test_migration_chain.py
+++ b/backend/tests/test_migration_chain.py
@@ -4,6 +4,11 @@ The guard exists because two branches can each pick the same next revision
 number and stay green until they are both on main, where `alembic upgrade
 head` then refuses to run. These build that situation on disk and assert the
 guard reports it.
+
+Every case is synthetic, under tmp_path. The repository's own chain is checked
+by the Migration Chain CI job, not from here: a real clash belongs to that job
+alone, so it is not also reported as a backend test failure in a suite that has
+nothing to do with it.
 """
 
 import importlib.util
@@ -118,8 +123,3 @@ def test_empty_directory_is_reported(tmp_path: Path):
     empty.mkdir()
 
     assert any("no migration files found" in p for p in check(empty))
-
-
-def test_the_repository_chain_is_sound():
-    """The guard's own subject: this repo's real migrations."""
-    assert check(check_migration_chain.VERSIONS_DIR) == []


### PR DESCRIPTION
## What

Drops `test_the_repository_chain_is_sound` from the tests #720 added.

## Why

That test asserts the repository's own revision chain is sound, which is the same thing the Migration Chain job checks. On a PR that actually has a clash, both fail, so one problem is reported twice — and the second report lands on **Backend Tests**, where a contributor whose only mistake was picking a taken migration number goes looking for a bug in their own code.

This happened on #675 as soon as its branch was updated:

```
Migration Chain: failure
  revision id '074' is claimed by 2 files: 074_hide_default_categories.py,
  074_transaction_exclude_from_pnl.py

Backend Tests:   failure
  FAILED tests/test_migration_chain.py::test_the_repository_chain_is_sound
```

The first line is the useful one. The second is noise pointing at the wrong place.

## How

The eight synthetic cases stay — they are the actual unit tests for the guard, each building its scenario under `tmp_path`. Only the assertion about the live `versions/` directory goes, with a note in the module docstring saying where that check lives now.

## Testing

Replayed #675's collision locally with the fix applied:

```
job Migration Chain -> fails (correct)
test suite          -> 8 passed
```

`ruff` and `ty` clean.
