### PR TITLE
fix(i18n): offer Dutch where the language is actually chosen

### DIFF
--- a/frontend/src/locales/i18n.test.ts
+++ b/frontend/src/locales/i18n.test.ts
@@ -192,6 +192,20 @@ describe('i18n locale files', () => {
     }
   })
 
+  // Every screen that offers a language picker reads SUPPORTED_LANGS, so a
+  // translation that ships a bundle without landing in that list is offered
+  // nowhere. Read the source rather than importing it: the module initialises
+  // i18next against browser APIs this node-environment suite does not have.
+  it('offers every locale bundle in SUPPORTED_LANGS', () => {
+    const source = readFileSync(path.join(LOCALES_DIR, '..', 'lib', 'i18n.ts'), 'utf-8')
+    const block = source.match(/SUPPORTED_LANGS[^=]*=\s*\[([\s\S]*?)\]/)
+    expect(block, 'SUPPORTED_LANGS not found in lib/i18n.ts').not.toBeNull()
+
+    const offered = [...block![1].matchAll(/code:\s*'([^']+)'/g)].map((m) => m[1])
+    expect(LOCALES.filter((locale) => !offered.includes(locale)).sort()).toEqual([])
+    expect(offered.filter((code) => !LOCALES.includes(code)).sort()).toEqual([])
+  })
+
   it('contains imported-description normalization labels in every locale', () => {
     const required = [
       'transactions.originalDescription',

--- a/frontend/src/pages/admin/settings.tsx
+++ b/frontend/src/pages/admin/settings.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'next-themes'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { admin as adminApi, currencies as currenciesApi } from '@/lib/api'
 import { resolveDisplayLocale, resolveDateLocale, type NumberFormat, type DateFormat } from '@/lib/format'
-import { resolveSupportedLang } from '@/lib/i18n'
+import { resolveSupportedLang, SUPPORTED_LANGS } from '@/lib/i18n'
 import { useAuth } from '@/contexts/auth-context'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -657,16 +657,9 @@ export default function AdminSettingsPage() {
                     onChange={(e) => setFormLanguage(e.target.value)}
                     className="w-full h-10 rounded-lg border border-input bg-card px-3 text-sm"
                   >
-                    <option value="en">English</option>
-                    <option value="de">Deutsch</option>
-                    <option value="ru">Русский</option>
-                    <option value="uk">Українська</option>
-                    <option value="pt-BR">Português (BR)</option>
-                    <option value="pt-PT">Português (PT)</option>
-                    <option value="es">Español</option>
-                    <option value="pl">Polski</option>
-                    <option value="it">Italiano</option>
-                    <option value="fr">Français</option>
+                    {SUPPORTED_LANGS.map(({ code, label }) => (
+                      <option key={code} value={code}>{label}</option>
+                    ))}
                   </select>
                 </div>
                 <div className="space-y-1.5">

--- a/frontend/src/pages/workspace-settings.tsx
+++ b/frontend/src/pages/workspace-settings.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/components/ui/dialog'
 import { AlertTriangle, Archive, Plus, Save, Trash2, Users } from 'lucide-react'
 import { WORKSPACE_KIND_LABEL_KEY } from '@/lib/workspace-kinds'
+import { SUPPORTED_LANGS } from '@/lib/i18n'
 import { countryFlag } from '@/lib/country-flag'
 import { countryName } from '@/lib/country-name'
 import type { WorkspaceKind, WorkspaceMember, WorkspaceRole } from '@/types'
@@ -435,16 +436,9 @@ export default function WorkspaceSettingsPage() {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="__none__">—</SelectItem>
-                  <SelectItem value="ru">Русский</SelectItem>
-                  <SelectItem value="de">Deutsch</SelectItem>
-                  <SelectItem value="uk">Українська</SelectItem>
-                  <SelectItem value="en">English</SelectItem>
-                  <SelectItem value="pt-BR">Português (BR)</SelectItem>
-                  <SelectItem value="pt-PT">Português (PT)</SelectItem>
-                  <SelectItem value="es">Español</SelectItem>
-                  <SelectItem value="pl">Polski</SelectItem>
-                  <SelectItem value="it">Italiano</SelectItem>
-                  <SelectItem value="fr">Français</SelectItem>
+                  {SUPPORTED_LANGS.map(({ code, label }) => (
+                    <SelectItem key={code} value={code}>{label}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>


### PR DESCRIPTION
The Dutch translation (#653) registered `nl` in `SUPPORTED_LANGS` and in the two UI language menus, but the workspace and instance default-language selectors keep their own hand-written lists and were left behind. You could read the interface in Dutch and still not set a workspace or an instance to it.

Both now render from `SUPPORTED_LANGS`, which is what that list exists for, and `i18n.test.ts` asserts every locale bundle on disk is offered there — so the next translation lands everywhere at once instead of in three places out of five.

- `pages/workspace-settings.tsx` — workspace default language
- `pages/admin/settings.tsx` — instance default language for new users

Verified in the browser: picking Nederlands saves and takes effect (number and date formatting switch with it).