### PR TITLE
test: pin dashboard forecast date

### DIFF
--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -362,10 +362,17 @@ async def test_total_balance_computed_from_transactions(client, auth_headers):
 
 @pytest.mark.asyncio
 async def test_pending_and_future_rows_are_current_vs_projected(
-    client, auth_headers
+    client, auth_headers, monkeypatch
 ):
     """Pending and future rows affect the forecast, never a manual current balance."""
-    today = date.today()
+    class FixedDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 8, 15)
+
+    monkeypatch.setattr("app.services.account_service._Date", FixedDate)
+    monkeypatch.setattr("app.services.dashboard_service.date", FixedDate)
+    today = FixedDate.today()
     acc_resp = await client.post(
         "/api/accounts",
         json={"name": "Forecast split", "type": "checking", "balance": 1000.00, "currency": "BRL"},
@@ -398,7 +405,7 @@ async def test_pending_and_future_rows_are_current_vs_projected(
 
     resp = await client.get(
         "/api/dashboard/summary",
-        params={"month": _current_month_str()},
+        params={"month": today.replace(day=1).isoformat()},
         headers=auth_headers,
     )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- freeze the dashboard and opening-balance clocks inside the forecast split test
- derive transaction dates and requested month from the same mid-month date
- keep production behavior unchanged

## Root cause
The test used today plus three days but queried only the current month. On the last three UTC days of a month, the future transaction moves into the next month and is correctly excluded, making the hard-coded projected balance fail.

## Validation
- UTC regression: passed
- Pacific/Kiritimati regression: passed
- Dashboard API tests: 18 passed, 1 skipped
- Ruff and diff check: passed
- Independent Standards and Spec reviews: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The forecast split test now uses one fixed mid-month date for transaction dates and the requested month. This prevents month-boundary failures without changing production behavior.

- Production behavior remains unchanged.

Risk: none.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->