### PR TITLE
fix(dashboard): include pending spend in category widget

### DIFF
--- a/backend/tests/test_credit_card_accounting_mode.py
+++ b/backend/tests/test_credit_card_accounting_mode.py
@@ -488,6 +488,35 @@ class TestDashboardSummary:
 
 class TestSpendingByCategory:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["cash", "accrual"])
+    async def test_pending_credit_card_spend_is_available_in_projected_total(
+        self, session, test_user, test_workspace, cc_account, test_categories, mode
+    ):
+        """The dashboard category widget can include pending card spend.
+
+        ``total`` remains the settled-only value used by the actual/forecast
+        split, while ``projected_total`` is the all-in value that must match
+        the dashboard drill-down.
+        """
+        food = test_categories[0]
+        today = date.today()
+        pending = await _make_tx(
+            session, test_user.id, cc_account.id, today,
+            Decimal("100"), effective_date=today, category_id=food.id,
+        )
+        pending.status = "pending"
+        await session.commit()
+        await _set_mode(session, mode)
+
+        spending = await dashboard_service.get_spending_by_category(
+            session, test_workspace.id, test_user.id, month=today.replace(day=1)
+        )
+        food_row = next(row for row in spending if row.category_id == str(food.id))
+
+        assert food_row.total == 0.0
+        assert food_row.projected_total == 100.0
+
+    @pytest.mark.asyncio
     async def test_category_breakdown_follows_mode(
         self, session, test_user, test_workspace, cc_account, test_categories
     ):

--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -366,6 +366,7 @@ async def test_pending_and_future_rows_are_current_vs_projected(
 ):
     """Pending and future rows affect the forecast, never a manual current balance."""
     today = date.today()
+    future_date = today + timedelta(days=3)
     acc_resp = await client.post(
         "/api/accounts",
         json={"name": "Forecast split", "type": "checking", "balance": 1000.00, "currency": "BRL"},
@@ -388,7 +389,7 @@ async def test_pending_and_future_rows_are_current_vs_projected(
             "amount": 200.00,
             "currency": "BRL",
             "type": "debit",
-            "date": (today + timedelta(days=3)).isoformat(),
+            "date": future_date.isoformat(),
             "status": "posted",
         },
     ):
@@ -398,7 +399,9 @@ async def test_pending_and_future_rows_are_current_vs_projected(
 
     resp = await client.get(
         "/api/dashboard/summary",
-        params={"month": _current_month_str()},
+        # Query the month containing the future row so the assertion remains
+        # valid when today + 3 days crosses a month boundary.
+        params={"month": future_date.replace(day=1).isoformat()},
         headers=auth_headers,
     )
     assert resp.status_code == 200

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -424,7 +424,12 @@ export default function DashboardPage() {
       .filter(s => s.category_id !== null)
       .map(s => {
         const budget = s.category_id ? budgetMap.get(s.category_id) : undefined
-        const actual = s.total
+        // The category widget must show the same spend set as its drill-down:
+        // settled transactions plus pending/future rows and recurring
+        // projections. The API keeps `total` as settled-only for callers that
+        // need the actual/forecast split, while `projected_total` is the
+        // user-visible all-in amount.
+        const actual = s.projected_total
         const prevAmount = budget ? Number(budget.prev_month_amount) : 0
         let momPct: number | null = null
         if (prevAmount > 0) {

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -430,7 +430,7 @@ export default function DashboardPage() {
         // need the actual/forecast split, while `projected_total` is the
         // user-visible all-in amount.
         const actual = s.projected_total
-        const prevAmount = budget ? Number(budget.prev_month_amount) : 0
+        const prevAmount = budget ? Number(budget.projected_prev_month_amount) : 0
         let momPct: number | null = null
         if (prevAmount > 0) {
           momPct = ((actual - prevAmount) / prevAmount) * 100

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -684,6 +684,7 @@ export interface SpendingByCategory {
   category_icon: string
   category_color: string
   total: number
+  projected_total: number
   percentage: number
 }
 


### PR DESCRIPTION
## What

Make the dashboard category widget display the same all-in spend set as its drill-down, including pending, future, and recurring projected spending.

## Why

The widget displayed only settled spend through `total`, while the drill-down also showed pending card transactions and projections. This caused categories to display zero or a lower amount even though clicking them showed spending.

## CI note

The backend CI also exposed a date-boundary issue in an existing forecast regression test: it created the future transaction at `today + 3 days` but always queried the current month. When those dates cross a month boundary, the transaction is correctly excluded from current-month results and the test incorrectly expects 700. The test now queries the month containing the future transaction. This only stabilizes the test and does not change dashboard production logic.

## How to Test

1. Set credit-card accounting mode to cash and create a categorized pending credit-card debit.
2. Open the dashboard and confirm the category widget includes the pending amount.
3. Repeat with accrual mode.
4. Run:

   `cd backend && uv run pytest -q tests/test_credit_card_accounting_mode.py -k 'pending_credit_card_spend or category_breakdown or summary_honors_effective_bill_date'`

## Related Issue

Addresses [issue #567](https://github.com/securo-finance/securo/issues/567) and complements [PR #716](https://github.com/securo-finance/securo/pull/716).

## Checklist

- [x] Backend tests pass (targeted: 6 passed)
- [x] Frontend build passes (`npm run build`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Translations updated (no user-facing strings changed)
- [x] For a large or core change, I discussed it first (issue #567 / PR #716)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The category widget now includes pending, future, and recurring projected spending. This keeps its totals and month-over-month changes consistent with the drill-down.

- Category totals include projected spending.
- Category trends include projected spending for both months.
- Pending credit-card spending remains excluded from settled totals.

Risk: money math.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
