### PR TITLE
fix(tests): make dashboard forecast test month-safe

### DIFF
--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -366,6 +366,11 @@ async def test_pending_and_future_rows_are_current_vs_projected(
 ):
     """Pending and future rows affect the forecast, never a manual current balance."""
     today = date.today()
+    future_date = today + timedelta(days=3)
+    
+    # Keep the queried month aligned with the future row at month boundaries.
+    forecast_month = future_date.replace(day=1).isoformat()
+    
     acc_resp = await client.post(
         "/api/accounts",
         json={"name": "Forecast split", "type": "checking", "balance": 1000.00, "currency": "BRL"},
@@ -388,7 +393,7 @@ async def test_pending_and_future_rows_are_current_vs_projected(
             "amount": 200.00,
             "currency": "BRL",
             "type": "debit",
-            "date": (today + timedelta(days=3)).isoformat(),
+            "date": future_date.isoformat(),
             "status": "posted",
         },
     ):
@@ -398,7 +403,7 @@ async def test_pending_and_future_rows_are_current_vs_projected(
 
     resp = await client.get(
         "/api/dashboard/summary",
-        params={"month": _current_month_str()},
+        params={"month": forecast_month},
         headers=auth_headers,
     )
     assert resp.status_code == 200


### PR DESCRIPTION
## What

Make `test_pending_and_future_rows_are_current_vs_projected` independent of the calendar month boundary.

The test now reuses the future transaction date and derives the dashboard month from that date, so the row under test is always inside the forecast period being requested.

## Why

The current regression test creates a future transaction with `today + timedelta(days=3)` but always queries the current month.

That makes the test date-dependent. Near the end of a month, the future row lands in the next month and is correctly excluded from the current-month projection, while the assertion still expects it to be included.

I reproduced this on 2026-08-29:

- `today`: `2026-08-29`
- future transaction: `2026-09-01`
- queried month: August 2026
- API result: `900.0`
- test expectation: `700.0`

So the production behavior was correct; the test fixture was querying the wrong forecast period.

This is also the same date-boundary condition noted in #742, but this PR keeps the fix isolated to the regression test so it can land independently of the dashboard behavior changes in that PR.

## How to Test

From `backend/`:

1. Run the targeted regression test:

   ```bash
   uv run pytest tests/test_dashboard_api.py::test_pending_and_future_rows_are_current_vs_projected -q


Result: `1 passed`.

2. Run the dashboard API test file:

   ```bash
   uv run pytest tests/test_dashboard_api.py -q
   ```

   Result: `18 passed, 1 skipped`.

3. Run lint and type checks:

   ```bash
   uv run ruff check .
   uv run ty check .
   uv lock --check
   ```

4. Run the full backend suite using the same pytest shape as CI:

   ```bash
   uv run pytest -n auto --dist loadfile \
     --cov=app \
     --cov-report=xml \
     --cov-report=term-missing \
     --cov-fail-under=60
   ```

   Result:

   * `3179 passed`
   * `46 skipped`
   * `0 failed`
   * `92.48%` coverage

The same change was also merged and validated through CI on my fork before opening this PR.

## Related Issue

Related to #742, which includes the same test stabilization alongside broader dashboard changes.

## Checklist

* [x] Backend tests pass (`pytest`)
* [x] Frontend lints clean (`npm run lint`) — n/a, no frontend changes
* [x] Frontend builds (`npm run build`) — n/a, no frontend changes
* [x] Translations updated (if user-facing strings changed) — n/a, no user-facing strings changed
* [x] For a large or core change, I discussed it first — n/a, isolated regression-test fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The dashboard forecast regression test now derives the queried month from the future transaction date. This prevents failures at month boundaries.

- No user-visible changes.

Risk: none of database migration, auth, money math, sync provider, or frontend behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->