### PR TITLE
fix(tests): two tests that fail on the 31st of the month

### DIFF
--- a/backend/tests/test_dashboard_api.py
+++ b/backend/tests/test_dashboard_api.py
@@ -366,6 +366,15 @@ async def test_pending_and_future_rows_are_current_vs_projected(
 ):
     """Pending and future rows affect the forecast, never a manual current balance."""
     today = date.today()
+    # The summary is scoped to one month, so a future row past the end of
+    # it is simply not in the window — which is why this asserted 900
+    # instead of 700 on the 31st. Three days out where there is room,
+    # clamped to the month, and skipped on the last day, where a future
+    # row inside the current month cannot exist at all.
+    last_day = calendar.monthrange(today.year, today.month)[1]
+    if today.day == last_day:
+        pytest.skip("no future days left in the current month")
+    future = today.replace(day=min(today.day + 3, last_day))
     acc_resp = await client.post(
         "/api/accounts",
         json={"name": "Forecast split", "type": "checking", "balance": 1000.00, "currency": "BRL"},
@@ -388,7 +397,7 @@ async def test_pending_and_future_rows_are_current_vs_projected(
             "amount": 200.00,
             "currency": "BRL",
             "type": "debit",
-            "date": (today + timedelta(days=3)).isoformat(),
+            "date": future.isoformat(),
             "status": "posted",
         },
     ):

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -1229,11 +1229,16 @@ async def test_cash_flow_recurring_credit_increases_balance(
     )
 
     today = date.today()
-    salary_day = date(today.year + (today.month // 12), (today.month % 12) + 1, today.day)
+    # Anchored to the 1st rather than today's day-of-month: building next
+    # month's date from `today.day` raises on the 31st whenever the month
+    # that follows has 30 days, which made this test fail seven times a
+    # year for reasons that had nothing to do with cash flow.
+    next_month = date(today.year + (today.month // 12), (today.month % 12) + 1, 1)
+    salary_day = next_month
     await _make_recurring(
         session, test_user.id, account.id,
         amount=3000, txn_type="credit", frequency="monthly",
-        day_of_month=today.day, next_occurrence=salary_day,
+        day_of_month=1, next_occurrence=salary_day,
     )
 
     report = await get_cash_flow_report(session, test_workspace.id, test_user.id, months=3, interval="daily")


### PR DESCRIPTION
Both fail today on a clean `main`, and neither has anything to do with what it tests.

**`test_cash_flow_recurring_credit_increases_balance`** built next month's date from `today.day`:

```
ValueError: day 31 must be in range 1..30 for month 9 in year 2026
```

That raises whenever the month after this one is shorter — seven days a year. The salary date is anchored to the 1st; which day it lands on was never what the test was about.

**`test_pending_and_future_rows_are_current_vs_projected`** dated its future row three days out and asserted it against a summary scoped to the current month. On the 31st that row lands in September, outside the window, so the projection came back 900 instead of 700. The offset is clamped to the end of the month, and the test skips on the last day, where a future row inside the current month cannot exist at all — the guard `test_dashboard_service_coverage` already uses for the same reason.

Tests only. No production code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Date-dependent tests now handle month-end dates correctly. No production code changed.

- Recurring credits use the first day of the following month.
- Future dashboard dates stay within the current month and skip on the last day.

Risk: none of database migration, auth, money math, or sync provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->