### PR TITLE
fix(i18n): add the missing az_voen key to the Slovak locale

### DIFF
--- a/frontend/src/locales/sk.json
+++ b/frontend/src/locales/sk.json
@@ -1560,6 +1560,7 @@
       "ph_tin": "TIN",
       "vn_mst": "MST",
       "sg_uen": "UEN",
+      "az_voen": "VÖEN",
       "uscc": "USCC"
     },
     "otherCountries": "Ostatné krajiny",


### PR DESCRIPTION
`sk.json` is missing `fiscal.kind.az_voen`, so `i18n.test.ts` is red on main.

Neither PR was at fault on its own. #722 added the key to the eleven locales that existed when it was opened; #737 added `sk.json`, built from `en.json` as it stood before #722. They touch different files, so there was no conflict to resolve and both were green — the parity test only went red once the second one landed.

Value left untranslated as `VÖEN`, matching every other locale.

Verified: `npx vitest run src/locales/i18n.test.ts` → 47 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds the missing `fiscal.kind.az_voen` Slovak locale entry as `VÖEN`. This restores i18n key parity.

- Slovak users see the Azerbaijani tax identifier label.

Risk: none of database migration, auth, money math, or sync provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->