### PR TITLE
chore: ignore a .venv symlink, not only a .venv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.venv/
+.venv
 .env
 secrets/
 .worktrees/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,8 +1,8 @@
 __pycache__/
 *.py[cod]
 .env
-.venv/
-venv/
+.venv
+venv
 *.egg-info/
 dist/
 build/


### PR DESCRIPTION
`.venv/` with a trailing slash matches directories only.

Point a git worktree at the main checkout's environment — `ln -s .../backend/.venv`, the ordinary way to run the suite in a worktree without installing it twice — and the resulting symlink is not ignored. It reaches the index on the next `git add -A` and lands in a commit. That is how one turned up in a pull request here.

Dropping the slash covers a directory and a symlink both, and is how `node_modules` is already written in `frontend/.gitignore` — which is why a symlink of that name has never had the same problem.

Verified against a real symlink: `git status` no longer reports it and `git add -A --dry-run` no longer stages it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `.gitignore` patterns so `.venv` and `venv` directories and symlinks are ignored. This keeps shared virtual environments out of Git worktree status and staging.

- Shared virtual environments no longer appear as untracked files.
- `git add -A` does not stage these paths.

Risk: none of database migration, auth, money math, or sync provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->