### PR TITLE
fix(tests): scope the workspace wallet assertion to one workspace

### DIFF
--- a/backend/tests/test_connection_service.py
+++ b/backend/tests/test_connection_service.py
@@ -3789,13 +3789,29 @@ async def test_sync_holdings_never_touches_another_workspaces_wallets(
     )
     assert minted is not None
     assert minted.workspace_id == test_workspace.id
-    # The asset follows its connection into this workspace (leaving the
-    # other workspace's wallet behind); it never straddles the two.
-    moved = await session.scalar(select(Asset).where(Asset.external_id == "h-1"))
+    # Asset identity is per workspace, so "h-1" now names one asset in each
+    # of them. Look the pair up separately: an unscoped query matches both
+    # rows and returns whichever the database hands back first.
+    moved = await session.scalar(
+        select(Asset).where(
+            Asset.external_id == "h-1",
+            Asset.workspace_id == test_workspace.id,
+        )
+    )
     assert moved is not None
-    assert moved.workspace_id == test_workspace.id
     assert moved.group_id == minted.id
     assert moved.is_archived is False
+    # The other workspace's asset is left exactly as it was found.
+    foreign_asset = await session.scalar(
+        select(Asset).where(
+            Asset.external_id == "h-1",
+            Asset.workspace_id == other_ws.id,
+        )
+    )
+    assert foreign_asset is not None
+    assert foreign_asset.group_id == foreign_id
+    assert foreign_asset.is_archived is True
+    assert foreign_asset.connection_id is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`test_sync_holdings_never_touches_another_workspaces_wallets` fails at random on main. It took down #783, a `.gitignore` change that cannot affect it.

**Cause.** #750 made asset identity per workspace, so `external_id = "h-1"` now names one asset in the connection's workspace and another in the workspace the test deliberately sets up next to it. The assertion looked the id up without scoping:

```python
moved = await session.scalar(select(Asset).where(Asset.external_id == "h-1"))
assert moved.workspace_id == test_workspace.id
```

Two rows match and there is no ORDER BY, so it asserts on whichever one the database hands back.

**Change.** Scope the lookup to the connection's workspace, and assert the other workspace's asset directly — untouched group, still archived, still unlinked — instead of leaving it implied. That is the invariant the test is named for.

**Measured on one machine:** 16 green / 9 red in 25 runs before, 25 green after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The workspace wallet test now scopes asset lookups to the correct workspace. It also verifies that the other workspace’s asset remains unchanged.

- The synced asset moves to the correct wallet and becomes active.
- The other workspace’s asset remains archived, unlinked, and in its original wallet.

Risk: none of these areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->