### PR TITLE
fix(tests): clamp the in-period row in the connected summary tests

### DIFF
--- a/backend/tests/test_account_service.py
+++ b/backend/tests/test_account_service.py
@@ -861,7 +861,13 @@ async def test_get_account_summary_opening_balance_connected_excludes_period_pen
     month_start = today.replace(day=1)
     prev_month = (month_start - timedelta(days=1)).replace(day=1)
     await _add_txn(session, test_user.id, account.id, 500, "credit", prev_month + timedelta(days=5))
-    await _add_txn(session, test_user.id, account.id, 300, "credit", month_start + timedelta(days=2))
+    await _add_txn(
+        session, test_user.id, account.id, 300, "credit",
+        # Clamped like the pending row below: on the 1st of the month this
+        # would otherwise land in the future, fall outside the period the
+        # summary backs out, and leave the provider snapshot counting it.
+        min(month_start + timedelta(days=2), today),
+    )
     pending_day = min(month_start + timedelta(days=4), today)
     await _add_txn(session, test_user.id, account.id, 20, "debit", pending_day, status="pending")
 
@@ -894,7 +900,13 @@ async def test_get_account_summary_connected_keeps_recurring_pending_in_the_walk
     month_start = today.replace(day=1)
     prev_month = (month_start - timedelta(days=1)).replace(day=1)
     await _add_txn(session, test_user.id, account.id, 500, "credit", prev_month + timedelta(days=5))
-    await _add_txn(session, test_user.id, account.id, 300, "credit", month_start + timedelta(days=2))
+    await _add_txn(
+        session, test_user.id, account.id, 300, "credit",
+        # Clamped like the pending row below: on the 1st of the month this
+        # would otherwise land in the future, fall outside the period the
+        # summary backs out, and leave the provider snapshot counting it.
+        min(month_start + timedelta(days=2), today),
+    )
     await _add_txn(
         session, test_user.id, account.id, 20, "debit",
         min(month_start + timedelta(days=4), today),
@@ -928,7 +940,13 @@ async def test_get_account_summary_connected_excludes_future_rows_from_opening_b
     month_start = today.replace(day=1)
     prev_month = (month_start - timedelta(days=1)).replace(day=1)
     await _add_txn(session, test_user.id, account.id, 500, "credit", prev_month + timedelta(days=5))
-    await _add_txn(session, test_user.id, account.id, 300, "credit", month_start + timedelta(days=2))
+    await _add_txn(
+        session, test_user.id, account.id, 300, "credit",
+        # Clamped like the pending row below: on the 1st of the month this
+        # would otherwise land in the future, fall outside the period the
+        # summary backs out, and leave the provider snapshot counting it.
+        min(month_start + timedelta(days=2), today),
+    )
     await _add_txn(
         session, test_user.id, account.id, 20, "debit",
         min(month_start + timedelta(days=4), today), status="pending",


### PR DESCRIPTION
Three tests in `test_account_service.py` are red on main since the date rolled to the 1st:

```
test_get_account_summary_opening_balance_connected_excludes_period_pending
test_get_account_summary_connected_keeps_recurring_pending_in_the_walk
test_get_account_summary_connected_excludes_future_rows_from_opening_balance
```

**Cause.** Each places a posted row at `month_start + timedelta(days=2)` and asserts against a hardcoded provider snapshot of 780. On the 1st that row lands in the future, so `get_account_summary` does not back it out of the opening balance while the snapshot still counts it — 800 where 500 was expected.

The pending row directly below it was already clamped with `min(..., today)`. The posted row was not. This clamps it the same way: a no-op from the 3rd of the month onward, and each test still asserts what it was written for — the genuinely future row in the third test stays at `today + 10`.

**Not the same bug as #777.** That one fixed two tests in `test_dashboard_api.py` and `test_report_service.py` that failed on the 31st. These are different tests, in a file it never touched, failing on a different day.

**Verified:** full backend suite, 3399 passed, 46 skipped, ruff clean.

Worth noting the exposure: 556 uses of `date.today()` across 48 test files, 12 of which also compute month boundaries. Patching them as they fire means red CI on unpredictable days, blaming unrelated commits — #783, a `.gitignore` change, took the blame for one yesterday. A frozen clock in the test suite would end the class; happy to open that separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated three account summary tests to avoid future-dated rows on the first day of a month. This aligns the posted row with the existing pending-row handling.

- No user-visible behavior changes.

Risk: none

<!-- end of auto-generated comment: release notes by coderabbit.ai -->