### PR TITLE
fix(frontend): derive display currency from active workspace

### DIFF
--- a/frontend/src/components/app-layout.tsx
+++ b/frontend/src/components/app-layout.tsx
@@ -88,7 +88,8 @@ export function AppLayout() {
   const { t } = useTranslation()
   const { user, logout, updateUser } = useAuth()
   const { activeAccountIds } = useCollectionFilter()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current: currentWorkspace } = useWorkspace()
+  const userCurrency = currentWorkspace?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const locale = useDisplayLocale()
   const { theme, setTheme, resolvedTheme } = useTheme()
   const location = useLocation()

--- a/frontend/src/components/bulk-add-to-group-dialog.tsx
+++ b/frontend/src/components/bulk-add-to-group-dialog.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner'
 
 import { groups as groupsApi, type GroupCreatePayload } from '@/lib/api'
 import { useAuth } from '@/contexts/auth-context'
+import { useWorkspace } from '@/contexts/workspace-context'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -76,7 +77,8 @@ function BulkAddToGroupForm({
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const { user } = useAuth()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
 
   // Track group creation state and fields
   const [isCreatingGroup, setIsCreatingGroup] = useState(false)

--- a/frontend/src/components/import-history.tsx
+++ b/frontend/src/components/import-history.tsx
@@ -39,8 +39,8 @@ export function ImportHistory({ entity }: ImportHistoryProps) {
   const dateLocale = useDateLocale()
   const queryClient = useQueryClient()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const [deleteTarget, setDeleteTarget] = useState<ImportLog | null>(null)
 
   const { data: logs = [] } = useQuery({

--- a/frontend/src/components/transaction-dialog.tsx
+++ b/frontend/src/components/transaction-dialog.tsx
@@ -5,6 +5,7 @@ import { useDateLocale, useDisplayLocale } from '@/hooks/use-display-locale'
 import { formatCurrency } from '@/lib/format'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '@/contexts/auth-context'
+import { useWorkspace } from '@/contexts/workspace-context'
 import { currencies as currenciesApi, transactions as transactionsApi, settings as settingsApi, payees as payeesApi, rules as rulesApi, categories as categoriesApi, categoryGroups as categoryGroupsApi } from '@/lib/api'
 import { localDateString } from '@/lib/date-utils'
 import { invalidateFinancialQueries } from '@/lib/invalidate-queries'
@@ -409,8 +410,9 @@ function TransactionForm({
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const { user } = useAuth()
+  const { current } = useWorkspace()
   const { privacyMode, MASK } = usePrivacyMode()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const dateLocale = useDateLocale()
   const displayLocale = useDisplayLocale()
   const sortedAccounts = useMemo(() => sortAccountsByDisplayName(accounts), [accounts])

--- a/frontend/src/components/transaction-drill-down.tsx
+++ b/frontend/src/components/transaction-drill-down.tsx
@@ -7,6 +7,7 @@ import { AlertTriangle, Info, Paperclip, X } from 'lucide-react'
 import { CategoryIcon } from '@/components/category-icon'
 import { ProjectedTransactionBadge } from '@/components/projected-transaction-badge'
 import { useAuth } from '@/contexts/auth-context'
+import { useWorkspace } from '@/contexts/workspace-context'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import type { Transaction } from '@/types'
 import { formatCurrency } from '@/lib/format'
@@ -50,8 +51,9 @@ export function TransactionDrillDown({
 }) {
   const { t } = useTranslation()
   const { user } = useAuth()
+  const { current } = useWorkspace()
   const { mask } = usePrivacyMode()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const locale = useDisplayLocale()
   const dateLocale = useDateLocale()
   const panelRef = useRef<HTMLDivElement>(null)

--- a/frontend/src/pages/account-detail.tsx
+++ b/frontend/src/pages/account-detail.tsx
@@ -274,8 +274,8 @@ export default function AccountDetailPage() {
   const { t, i18n } = useTranslation()
   const { mask, privacyMode, MASK } = usePrivacyMode()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const locale = useDisplayLocale()
   const dateLocale = useDateLocale()
   const isMobile = useIsMobile()

--- a/frontend/src/pages/accounts.tsx
+++ b/frontend/src/pages/accounts.tsx
@@ -65,8 +65,8 @@ export default function AccountsPage() {
   const dateLocale = useDateLocale()
   const { mask } = usePrivacyMode()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const queryClient = useQueryClient()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingAccount, setEditingAccount] = useState<Account | null>(null)
@@ -677,7 +677,8 @@ function AccountDialog({
 }) {
   const { t } = useTranslation()
   const { user } = useAuth()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const { data: supportedCurrencies } = useQuery({
     queryKey: ['currencies'],
     queryFn: currencies.list,

--- a/frontend/src/pages/assets.tsx
+++ b/frontend/src/pages/assets.tsx
@@ -190,8 +190,8 @@ export default function AssetsPage() {
   const dateLocale = useDateLocale()
   const { mask } = usePrivacyMode()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const queryClient = useQueryClient()
 
   const { data: supportedCurrencies } = useQuery({

--- a/frontend/src/pages/budgets.tsx
+++ b/frontend/src/pages/budgets.tsx
@@ -58,8 +58,8 @@ export default function BudgetsPage() {
   const { t, i18n } = useTranslation()
   const { mask } = usePrivacyMode()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const locale = useDisplayLocale()
   const queryClient = useQueryClient()
   const [selectedMonth, setSelectedMonth] = useState(currentMonth)

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -52,6 +52,7 @@ import { RuleDialog, type RuleDialogInitialData } from '@/components/rule-dialog
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useAuth } from '@/contexts/auth-context'
+import { useWorkspace } from '@/contexts/workspace-context'
 import { useCollectionFilter } from '@/contexts/collection-filter-context'
 import { resolveDateFnsLocale } from '@/lib/date-fns-locale'
 import type { Rule, Transaction } from '@/types'
@@ -95,7 +96,8 @@ export default function DashboardPage() {
   const { mask, privacyMode, MASK } = usePrivacyMode()
   const isMobile = useIsMobile()
   const { user } = useAuth()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const displayName = user?.preferences?.display_name || ''
   const locale = useDisplayLocale()
   const dateLocale = useDateLocale()

--- a/frontend/src/pages/goals.tsx
+++ b/frontend/src/pages/goals.tsx
@@ -138,8 +138,8 @@ export default function GoalsPage() {
   const { t } = useTranslation()
   const { mask } = usePrivacyMode()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const locale = useDisplayLocale()
   const queryClient = useQueryClient()
   const [dialogOpen, setDialogOpen] = useState(false)

--- a/frontend/src/pages/groups.tsx
+++ b/frontend/src/pages/groups.tsx
@@ -30,8 +30,8 @@ export default function GroupsPage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('active')
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editing, setEditing] = useState<Group | null>(null)

--- a/frontend/src/pages/import.tsx
+++ b/frontend/src/pages/import.tsx
@@ -52,8 +52,8 @@ function toReviewTransactions(txns: ImportPreviewTransaction[]): ImportReviewTra
 function TransactionImportPanel() {
   const { t } = useTranslation()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const locale = useDisplayLocale()
   const dateLocale = useDateLocale()
   const queryClient = useQueryClient()

--- a/frontend/src/pages/invoice-detail.tsx
+++ b/frontend/src/pages/invoice-detail.tsx
@@ -84,8 +84,8 @@ export default function InvoiceDetailPage() {
   const dateLocale = useDateLocale()
   const { mask } = usePrivacyMode()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const fallbackCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const fallbackCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
 
   const [linkOpen, setLinkOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)

--- a/frontend/src/pages/invoices.tsx
+++ b/frontend/src/pages/invoices.tsx
@@ -93,8 +93,8 @@ export default function InvoicesPage() {
   const dateLocale = useDateLocale()
   const { mask } = usePrivacyMode()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const currency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const currency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
 
   // `null` is "every year". The default is the current one, which is
   // what someone opening the page is almost always asking about.

--- a/frontend/src/pages/payees.tsx
+++ b/frontend/src/pages/payees.tsx
@@ -60,8 +60,8 @@ export default function PayeesPage() {
   const dateLocale = useDateLocale()
   const { mask } = usePrivacyMode()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   // No entry for an unset type: most rows come from sync, which cannot know
   // a legal nature from a bank descriptor, and a badge reading "unknown" on
   // hundreds of rows is noise rather than information.

--- a/frontend/src/pages/recurring.tsx
+++ b/frontend/src/pages/recurring.tsx
@@ -66,8 +66,8 @@ function RecurringTab() {
   const dateLocale = useDateLocale()
   const { mask } = usePrivacyMode()
   const { user } = useAuth()
-  const { canWrite } = useWorkspace()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const queryClient = useQueryClient()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editing, setEditing] = useState<RecurringTransaction | null>(null)

--- a/frontend/src/pages/reports.tsx
+++ b/frontend/src/pages/reports.tsx
@@ -26,6 +26,7 @@ import { PageHeader } from '@/components/page-header'
 import { CashflowSankey } from '@/components/reports/CashflowSankey'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { useAuth } from '@/contexts/auth-context'
+import { useWorkspace } from '@/contexts/workspace-context'
 import { useCollectionFilter } from '@/contexts/collection-filter-context'
 import type { ReportResponse, CategoryTrendItem } from '@/types'
 import { formatCurrency } from '@/lib/format'
@@ -135,7 +136,8 @@ export default function ReportsPage() {
   const { t } = useTranslation()
   const { mask, privacyMode, MASK } = usePrivacyMode()
   const { user } = useAuth()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const locale = useDisplayLocale()
 
   const [rangeKey, setRangeKey] = useState('1y')

--- a/frontend/src/pages/transactions.tsx
+++ b/frontend/src/pages/transactions.tsx
@@ -91,8 +91,8 @@ export default function TransactionsPage() {
   const isMobile = useIsMobile()
   const { user } = useAuth()
   const { activeAccountIds } = useCollectionFilter()
-  const { canWrite } = useWorkspace()
-  const userCurrency = user?.preferences?.currency_display ?? 'USD'
+  const { current, canWrite } = useWorkspace()
+  const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
   const queryClient = useQueryClient()
   const [page, setPage] = useState(1)
   const [limit, setLimit] = useState<number>(() => {


### PR DESCRIPTION
## Problem
Balances and totals across the app (accounts list, dashboard, transactions, budgets, goals, assets, reports, invoices, etc.) were formatted using the signed-in user's global `currency_display` preference, not the active workspace's `default_currency`.

Because `currency_display` is stored on the user (not the workspace), switching between two workspaces with different currencies (e.g. EUR vs. INR) didn't change what was displayed — the old currency stuck around until the user manually edited a workspace's currency (which happens to sync the preference as a side effect server-side).

## Fix
`userCurrency` (and equivalent local variables) now prefer the active workspace's `default_currency`, falling back to the user's `currency_display` preference only when no workspace is loaded yet:

```ts
const userCurrency = current?.default_currency ?? user?.preferences?.currency_display ?? 'USD'
```

Applied consistently across all pages/components that read `user.preferences.currency_display` for display/formatting purposes. Per-record currency pickers for creating new data (new account, new invoice, new goal, etc.) were left as-is since those are user-editable form defaults, not the reported display bug.

## Testing
- Verified no other files still read `user.preferences.currency_display` for display formatting without falling back through the workspace's `default_currency`.
- No backend changes needed; `Workspace.default_currency` was already available via `useWorkspace()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Display currency now follows the active workspace’s `default_currency`. If no workspace is loaded, the app uses the signed-in user’s preference, then `USD`.

- Balances, totals, accounts, dashboards, transactions, budgets, goals, assets, reports, invoices, and related views use the workspace currency.
- Creation forms keep their existing user-editable currency defaults.
- The change affects frontend display only.

Risk: none of database migration, auth, money math, or sync provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->