### PR TITLE
fix(enable-banking): credit-card balance handling

### DIFF
--- a/backend/alembic/versions/078_credit_card_balance_snapshots.py
+++ b/backend/alembic/versions/078_credit_card_balance_snapshots.py
@@ -1,0 +1,59 @@
+"""preserve credit card balance snapshots
+
+Revision ID: 078
+Revises: 077
+Create Date: 2026-08-31
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "078"
+down_revision: Union[str, None] = "077"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "accounts",
+        sa.Column("expected_balance", sa.Numeric(precision=15, scale=2), nullable=True),
+    )
+    op.add_column(
+        "accounts",
+        sa.Column("available_credit", sa.Numeric(precision=15, scale=2), nullable=True),
+    )
+    # Enable Banking cash-account signs are the inverse of Securo's card
+    # invariant. Existing rows were stored verbatim, so normalize them once;
+    # later syncs perform this conversion at the provider boundary.
+    op.execute(
+        sa.text(
+            """
+            UPDATE accounts
+            SET balance = -accounts.balance
+            FROM bank_connections
+            WHERE accounts.connection_id = bank_connections.id
+              AND accounts.type = 'credit_card'
+              AND bank_connections.provider = 'enable_banking'
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE accounts
+            SET balance = -accounts.balance
+            FROM bank_connections
+            WHERE accounts.connection_id = bank_connections.id
+              AND accounts.type = 'credit_card'
+              AND bank_connections.provider = 'enable_banking'
+            """
+        )
+    )
+    op.drop_column("accounts", "available_credit")
+    op.drop_column("accounts", "expected_balance")

--- a/backend/alembic/versions/085_credit_card_balance_snapshots.py
+++ b/backend/alembic/versions/085_credit_card_balance_snapshots.py
@@ -1,7 +1,7 @@
 """preserve credit card balance snapshots
 
-Revision ID: 078
-Revises: 077
+Revision ID: 085
+Revises: 084
 Create Date: 2026-08-31
 """
 
@@ -10,8 +10,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "078"
-down_revision: Union[str, None] = "077"
+revision: str = "085"
+down_revision: Union[str, None] = "084"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/models/account.py
+++ b/backend/app/models/account.py
@@ -23,7 +23,9 @@ class Account(Base):
     workspace_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), index=True
     )
-    connection_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("bank_connections.id"), nullable=True)
+    connection_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("bank_connections.id"), nullable=True
+    )
     external_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     name: Mapped[str] = mapped_column(String(255))
     display_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
@@ -32,13 +34,27 @@ class Account(Base):
     # not user-editable. Never holds the full identifier.
     masked_number: Mapped[Optional[str]] = mapped_column(String(4), nullable=True)
     type: Mapped[str] = mapped_column(String(50))  # checking, savings, credit_card
-    balance: Mapped[Decimal] = mapped_column(Numeric(precision=15, scale=2), default=Decimal("0.00"))
+    balance: Mapped[Decimal] = mapped_column(
+        Numeric(precision=15, scale=2), default=Decimal("0.00")
+    )
+    expected_balance: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(precision=15, scale=2), nullable=True
+    )
+    available_credit: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(precision=15, scale=2), nullable=True
+    )
     currency: Mapped[str] = mapped_column(String(3), default="USD")
-    balance_primary: Mapped[Optional[Decimal]] = mapped_column(Numeric(precision=15, scale=2), nullable=True)
-    credit_limit: Mapped[Optional[Decimal]] = mapped_column(Numeric(precision=15, scale=2), nullable=True)
+    balance_primary: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(precision=15, scale=2), nullable=True
+    )
+    credit_limit: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(precision=15, scale=2), nullable=True
+    )
     statement_close_day: Mapped[Optional[int]] = mapped_column(SmallInteger, nullable=True)
     payment_due_day: Mapped[Optional[int]] = mapped_column(SmallInteger, nullable=True)
-    minimum_payment: Mapped[Optional[Decimal]] = mapped_column(Numeric(precision=15, scale=2), nullable=True)
+    minimum_payment: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(precision=15, scale=2), nullable=True
+    )
     card_brand: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     card_level: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     # The institution this account is actually at. One connection can span
@@ -46,8 +62,10 @@ class Account(Base):
     # own institution_name/logo_url. Eager (selectin) because serialization
     # always reads it and lazy loads raise in async sessions.
     institution_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("institutions.id", ondelete="SET NULL"),
-        nullable=True, index=True,
+        UUID(as_uuid=True),
+        ForeignKey("institutions.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
     )
     is_closed: Mapped[bool] = mapped_column(Boolean, default=False)
     closed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -56,4 +74,6 @@ class Account(Base):
     institution: Mapped[Optional["Institution"]] = relationship(
         back_populates="accounts", lazy="selectin"
     )
-    transactions: Mapped[list["Transaction"]] = relationship(back_populates="account", cascade="all, delete-orphan")
+    transactions: Mapped[list["Transaction"]] = relationship(
+        back_populates="account", cascade="all, delete-orphan"
+    )

--- a/backend/app/providers/base.py
+++ b/backend/app/providers/base.py
@@ -60,6 +60,13 @@ class AccountData:
     type: str  # checking, savings, credit_card
     balance: Decimal
     currency: str
+    # Credit-card snapshots use Securo's internal sign convention: positive
+    # means debt, negative means credit/guthaben. ``balance`` is the booked
+    # snapshot; expected_balance may include pending transactions.
+    expected_balance: Optional[Decimal] = None
+    # Provider-reported spendable credit/funds. This is an absolute amount,
+    # not a signed balance, and must not be negated.
+    available_credit: Optional[Decimal] = None
     credit_limit: Optional[Decimal] = None
     statement_close_day: Optional[int] = None
     payment_due_day: Optional[int] = None
@@ -292,9 +299,7 @@ class BankProvider(ABC):
         """Create a connect token for widget-based flows. Override in widget providers."""
         raise NotImplementedError(f"{self.name} does not support widget connect tokens")
 
-    async def list_institutions(
-        self, country: Optional[str] = None
-    ) -> "InstitutionListData":
+    async def list_institutions(self, country: Optional[str] = None) -> "InstitutionListData":
         """List supported institutions (banks). Empty by default for providers
         that don't surface a selection step (Pluggy uses its own widget).
         """
@@ -339,8 +344,11 @@ class BankProvider(ABC):
 
     @abstractmethod
     async def get_transactions(
-        self, credentials: dict, account_external_id: str,
-        since: Optional[date] = None, payee_source: str = "auto",
+        self,
+        credentials: dict,
+        account_external_id: str,
+        since: Optional[date] = None,
+        payee_source: str = "auto",
     ) -> list[TransactionData]:
         """Fetch transactions for an account."""
         ...

--- a/backend/app/providers/enable_banking.py
+++ b/backend/app/providers/enable_banking.py
@@ -9,6 +9,7 @@ The flow requires the user to pick a country and bank before the
 authorization URL can be generated, so `get_oauth_url` takes
 `flow_params={"country", "institution_name"}`.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -99,6 +100,12 @@ def _pick_balance(balances: list[dict]) -> Optional[dict]:
         if key in by_type:
             return by_type[key]
     return balances[0] if isinstance(balances[0], dict) else None
+
+
+def _balance_of_type(balances: list[dict], *balance_types: str) -> Optional[dict]:
+    """Return the first requested ISO 20022 balance type present."""
+    by_type = {b.get("balance_type") or b.get("type"): b for b in balances if isinstance(b, dict)}
+    return next((by_type[k] for k in balance_types if k in by_type), None)
 
 
 def _balance_decimal(balance: Optional[dict]) -> Decimal:
@@ -192,10 +199,7 @@ class EnableBankingProvider(BankProvider):
 
     @property
     def redirect_uri(self) -> str:
-        return (
-            get_settings().enable_banking_oauth_redirect_uri
-            or default_oauth_redirect_uri()
-        )
+        return get_settings().enable_banking_oauth_redirect_uri or default_oauth_redirect_uri()
 
     # ----- credentials -----
 
@@ -270,16 +274,12 @@ class EnableBankingProvider(BankProvider):
         async with self._client() as client:
             resp = await client.request(method, path, params=params, json=json_body)
         if resp.status_code in (401, 410):
-            raise SessionExpiredError(
-                f"Enable Banking returned {resp.status_code} for {path}"
-            )
+            raise SessionExpiredError(f"Enable Banking returned {resp.status_code} for {path}")
         if resp.status_code == 429:
             # The bank (ASPSP) is throttling us — transient, not a broken
             # connection. Surface a distinct type so sync can skip-and-retry
             # instead of erroring the connection.
-            raise ProviderRateLimited(
-                f"Enable Banking {method} {path} → 429: {resp.text[:200]}"
-            )
+            raise ProviderRateLimited(f"Enable Banking {method} {path} → 429: {resp.text[:200]}")
         if resp.status_code >= 400:
             raise httpx.HTTPStatusError(
                 f"Enable Banking {method} {path} → {resp.status_code}: {resp.text[:300]}",
@@ -290,9 +290,7 @@ class EnableBankingProvider(BankProvider):
 
     # ----- institution listing -----
 
-    async def list_institutions(
-        self, country: Optional[str] = None
-    ) -> InstitutionListData:
+    async def list_institutions(self, country: Optional[str] = None) -> InstitutionListData:
         params: dict[str, Any] = {}
         if country:
             params["country"] = country.upper()
@@ -339,9 +337,7 @@ class EnableBankingProvider(BankProvider):
         valid_until_days = min(valid_until_days, MAX_VALID_UNTIL_DAYS)
         valid_until_dt = datetime.now(timezone.utc) + timedelta(days=valid_until_days)
         # EB wants RFC3339 with a trailing 'Z' for UTC.
-        valid_until = valid_until_dt.replace(microsecond=0).isoformat().replace(
-            "+00:00", "Z"
-        )
+        valid_until = valid_until_dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
         return {
             "access": {"valid_until": valid_until},
             "aspsp": {"name": institution_name, "country": country.upper()},
@@ -364,9 +360,7 @@ class EnableBankingProvider(BankProvider):
                 "Enable Banking requires flow_params with 'country' and 'institution_name'"
             )
         psu_type = (flow_params.get("psu_type") or DEFAULT_PSU_TYPE).strip()
-        valid_until_days = int(
-            flow_params.get("valid_until_days") or DEFAULT_VALID_UNTIL_DAYS
-        )
+        valid_until_days = int(flow_params.get("valid_until_days") or DEFAULT_VALID_UNTIL_DAYS)
         payload = self._build_auth_payload(
             country=country,
             institution_name=institution_name,
@@ -390,9 +384,7 @@ class EnableBankingProvider(BankProvider):
     ) -> str:
         stored = (settings or {}).get("flow_params") or {}
         if not stored.get("country") or not stored.get("institution_name"):
-            raise RuntimeError(
-                "Cannot reauth Enable Banking connection without stored flow_params"
-            )
+            raise RuntimeError("Cannot reauth Enable Banking connection without stored flow_params")
         return await self.get_oauth_url(redirect_uri, state, flow_params=stored)
 
     # ----- session exchange -----
@@ -457,29 +449,43 @@ class EnableBankingProvider(BankProvider):
     async def _build_account(self, raw: dict) -> AccountData:
         uid = raw.get("uid") or raw.get("account_uid") or ""
         currency = raw.get("currency") or "EUR"
+        account_type = _map_cash_account_type(raw.get("cash_account_type"))
         # EB doesn't include balances in the session payload; fetch separately.
         balance = Decimal("0")
+        expected_balance: Optional[Decimal] = None
+        available_credit: Optional[Decimal] = None
         try:
             bal_resp = await self._request("GET", f"/accounts/{uid}/balances")
-            picked = _pick_balance(bal_resp.get("balances") or [])
-            balance = _balance_decimal(picked)
-            currency = _balance_currency(picked, currency)
+            balances = bal_resp.get("balances") or []
+            if account_type == "credit_card":
+                # EB card balances use the cash-account sign: positive means
+                # the bank owes the customer, negative means debt. Normalize
+                # booked/expected snapshots once at the provider boundary.
+                booked = _balance_of_type(balances, "CLBD", "OPBD")
+                expected = _balance_of_type(balances, "XPCD")
+                available = _balance_of_type(balances, "ITAV", "CLAV", "OPAV")
+                fallback = booked or expected or _pick_balance(balances)
+                balance = -_balance_decimal(fallback)
+                if expected is not None:
+                    expected_balance = -_balance_decimal(expected)
+                if available is not None:
+                    available_credit = _balance_decimal(available)
+                currency = _balance_currency(booked or expected or available or fallback, currency)
+            else:
+                picked = _pick_balance(balances)
+                balance = _balance_decimal(picked)
+                currency = _balance_currency(picked, currency)
         except (httpx.HTTPError, SessionExpiredError) as exc:
-            logger.warning(
-                "Failed to fetch balances for account %s: %s", uid, exc
-            )
-        name = (
-            raw.get("display_name")
-            or raw.get("product")
-            or raw.get("name")
-            or "Account"
-        )
+            logger.warning("Failed to fetch balances for account %s: %s", uid, exc)
+        name = raw.get("display_name") or raw.get("product") or raw.get("name") or "Account"
         return AccountData(
             external_id=uid,
             name=name,
-            type=_map_cash_account_type(raw.get("cash_account_type")),
+            type=account_type,
             balance=balance,
             currency=currency,
+            expected_balance=expected_balance,
+            available_credit=available_credit,
             masked_number=mask_last4(_account_identifier(raw)),
         )
 
@@ -559,9 +565,7 @@ class EnableBankingProvider(BankProvider):
                 params=params,
             )
             for raw_txn, status in self._iter_transactions(page):
-                parsed = self._build_transaction(
-                    account_external_id, raw_txn, status, payee_source
-                )
+                parsed = self._build_transaction(account_external_id, raw_txn, status, payee_source)
                 # A broken pagination cursor can make Enable Banking return a
                 # page we have already consumed. Keep the result idempotent
                 # even before the repeated cursor is detected below.

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -58,6 +58,7 @@ class AccountRead(AccountBase):
     current_balance: float = 0.0
     previous_balance: Optional[float] = None
     balance_primary: Optional[float] = None
+    expected_balance: Optional[float] = None
     credit_limit: Optional[float] = None
     available_credit: Optional[float] = None
     statement_close_day: Optional[int] = None

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -19,7 +19,11 @@ from app.services._query_filters import (
     is_inside_provider_snapshot,
     is_not_future,
 )
-from app.services.credit_card_service import apply_effective_date, compute_available_credit, get_cycle_dates
+from app.services.credit_card_service import (
+    apply_effective_date,
+    compute_available_credit,
+    get_cycle_dates,
+)
 from app.models.category import Category
 
 
@@ -48,7 +52,9 @@ def _opening_balance_values(account_type: str, balance: Decimal) -> tuple[Decima
     return amount, "credit" if is_credit else "debit"
 
 
-async def get_accounts(session: AsyncSession, workspace_id: uuid.UUID, include_closed: bool = False) -> list[dict]:
+async def get_accounts(
+    session: AsyncSession, workspace_id: uuid.UUID, include_closed: bool = False
+) -> list[dict]:
     today = _Date.today()
     # Subquery: compute current_balance per account from transactions in one pass
     # Use amount_primary only when tx currency differs from account currency
@@ -128,9 +134,9 @@ async def get_accounts(session: AsyncSession, workspace_id: uuid.UUID, include_c
     query = query.order_by(Account.name)
     result = await session.execute(query)
     return [
-            serialize_account(acc, current_balance, previous_balance, connection)
-            for acc, connection, current_balance, previous_balance in result.all()
-        ]
+        serialize_account(acc, current_balance, previous_balance, connection)
+        for acc, connection, current_balance, previous_balance in result.all()
+    ]
 
 
 def _institution(
@@ -182,6 +188,11 @@ def serialize_account(
         "currency": acc.currency,
         "current_balance": resolved_balance,
         "previous_balance": float(previous_balance or 0),
+        "expected_balance": (
+            -float(acc.expected_balance)
+            if acc.type == "credit_card" and acc.expected_balance is not None
+            else None
+        ),
         "is_closed": acc.is_closed,
         "closed_at": acc.closed_at,
         "credit_limit": float(acc.credit_limit) if acc.credit_limit is not None else None,
@@ -198,7 +209,9 @@ def serialize_account(
     }
 
     if acc.type == "credit_card":
-        available = compute_available_credit(acc.credit_limit, Decimal(str(resolved_balance)))
+        available = acc.available_credit
+        if available is None:
+            available = compute_available_credit(acc.credit_limit, acc.balance)
         payload["available_credit"] = float(available) if available is not None else None
         cycle = get_cycle_dates(acc.statement_close_day, acc.payment_due_day)
         payload["next_close_date"] = cycle["next_close_date"]
@@ -235,7 +248,9 @@ async def get_credit_card_bills(
     return list(result.scalars().all())
 
 
-async def get_account(session: AsyncSession, account_id: uuid.UUID, workspace_id: uuid.UUID) -> Optional[Account]:
+async def get_account(
+    session: AsyncSession, account_id: uuid.UUID, workspace_id: uuid.UUID
+) -> Optional[Account]:
     result = await session.execute(
         select(Account)
         .outerjoin(BankConnection)
@@ -309,9 +324,7 @@ async def update_account(
     # Track whether we need to recompute effective_date for all transactions.
     # Changes to the CC cycle days shift which bill each historical purchase
     # belongs to, so stored effective_dates need to be rebuilt.
-    cycle_fields_changed = any(
-        k in update_data for k in ("statement_close_day", "payment_due_day")
-    )
+    cycle_fields_changed = any(k in update_data for k in ("statement_close_day", "payment_due_day"))
 
     # Bank-connected accounts are managed by the sync pipeline. Beyond display
     # name and credit card metadata (limit + cycle days, which providers often
@@ -361,6 +374,8 @@ async def update_account(
         # If the override moves the account away from credit_card, drop any
         # stale card metadata so it isn't left half credit-card.
         if new_type != "credit_card":
+            account.expected_balance = None
+            account.available_credit = None
             account.credit_limit = None
             account.statement_close_day = None
             account.payment_due_day = None
@@ -445,9 +460,7 @@ async def _recompute_effective_dates(session: AsyncSession, account: Account) ->
     Called when an account's CC cycle metadata (statement_close_day,
     payment_due_day) changes, so historical transactions get rebucketed into
     the correct bill. Cheap: a few hundred rows per account at most."""
-    result = await session.execute(
-        select(Transaction).where(Transaction.account_id == account.id)
-    )
+    result = await session.execute(select(Transaction).where(Transaction.account_id == account.id))
     for tx in result.scalars():
         apply_effective_date(tx, account)
 
@@ -496,6 +509,7 @@ async def sync_opening_balance_for_connected_account(
         select(func.coalesce(func.sum(signed_amount), 0)).where(
             Transaction.account_id == account.id,
             Transaction.source != "opening_balance",
+            *([Transaction.status == "posted"] if is_cc else []),
             Transaction.date <= balance_cutoff,
             Transaction.is_ignored == False,
             or_(
@@ -528,6 +542,7 @@ async def sync_opening_balance_for_connected_account(
         select(func.min(Transaction.date)).where(
             Transaction.account_id == account.id,
             Transaction.source != "opening_balance",
+            *([Transaction.status == "posted"] if is_cc else []),
             Transaction.date <= balance_cutoff,
             Transaction.is_ignored == False,
             or_(
@@ -570,7 +585,9 @@ async def sync_opening_balance_for_connected_account(
     await session.flush()
 
 
-async def delete_account(session: AsyncSession, account_id: uuid.UUID, workspace_id: uuid.UUID) -> bool:
+async def delete_account(
+    session: AsyncSession, account_id: uuid.UUID, workspace_id: uuid.UUID
+) -> bool:
     account = await get_account(session, account_id, workspace_id)
     if not account:
         return False
@@ -584,6 +601,7 @@ async def delete_account(session: AsyncSession, account_id: uuid.UUID, workspace
     from app.models.import_log import ImportLog
     from app.models.recurring_transaction import RecurringTransaction
     from app.models.goal import Goal
+
     tx_result = await session.execute(
         select(Transaction.id).where(Transaction.account_id == account_id)
     )
@@ -601,23 +619,13 @@ async def delete_account(session: AsyncSession, account_id: uuid.UUID, workspace
     # The transaction rows themselves cascade-delete via Account.transactions
     # when session.delete(account) flushes below.
     await session.execute(
-        update(Transaction)
-        .where(Transaction.account_id == account_id)
-        .values(import_id=None)
+        update(Transaction).where(Transaction.account_id == account_id).values(import_id=None)
     )
+    await session.execute(delete(ImportLog).where(ImportLog.account_id == account_id))
     await session.execute(
-        delete(ImportLog).where(ImportLog.account_id == account_id)
+        delete(RecurringTransaction).where(RecurringTransaction.account_id == account_id)
     )
-    await session.execute(
-        delete(RecurringTransaction).where(
-            RecurringTransaction.account_id == account_id
-        )
-    )
-    await session.execute(
-        update(Goal)
-        .where(Goal.account_id == account_id)
-        .values(account_id=None)
-    )
+    await session.execute(update(Goal).where(Goal.account_id == account_id).values(account_id=None))
 
     await session.delete(account)
     await session.commit()
@@ -666,8 +674,11 @@ async def reopen_account(
 
 
 async def get_account_summary(
-    session: AsyncSession, account_id: uuid.UUID, workspace_id: uuid.UUID,
-    date_from: Optional[_Date] = None, date_to: Optional[_Date] = None,
+    session: AsyncSession,
+    account_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+    date_from: Optional[_Date] = None,
+    date_to: Optional[_Date] = None,
     bill_id: Optional[uuid.UUID] = None,
     unbilled_only: bool = False,
 ) -> Optional[dict]:
@@ -738,13 +749,14 @@ async def get_account_summary(
     #       we'd drop user-added compensations for missing provider txs.
     # Without bill_id (cycle-math or non-CC), apply the date window straight.
     from sqlalchemy import and_ as _and, not_ as _not  # local: only for scope
+
     # Resolve the active bill's due_date once so the pending-exclusion can
     # trust our cycle-math pre-classification (see get_transactions).
     active_due_subq = (
-        select(CreditCardBill.due_date)
-        .where(CreditCardBill.id == bill_id)
-        .scalar_subquery()
-    ) if bill_id is not None else None
+        (select(CreditCardBill.due_date).where(CreditCardBill.id == bill_id).scalar_subquery())
+        if bill_id is not None
+        else None
+    )
 
     def _scope(query):
         if bill_id is not None:
@@ -762,12 +774,14 @@ async def get_account_summary(
                 # the override doesn't snap to a real bill due_date and
                 # bill_id stays null (issue #162). Mirrors the same
                 # carve-out in get_transactions.
-                _not(_and(
-                    Transaction.source == "sync",
-                    Transaction.status == "pending",
-                    Transaction.effective_bill_date.is_(None),
-                    Transaction.effective_date != active_due_subq,
-                )),
+                _not(
+                    _and(
+                        Transaction.source == "sync",
+                        Transaction.status == "pending",
+                        Transaction.effective_bill_date.is_(None),
+                        Transaction.effective_date != active_due_subq,
+                    )
+                ),
                 bucket_date >= date_from,
                 bucket_date <= date_to,
             )
@@ -798,14 +812,16 @@ async def get_account_summary(
     # Income = SUM of credit transactions in window (excluding opening_balance,
     # paired transfers, and transfer-like categories).
     income_result = await session.execute(
-        _scope(select(func.coalesce(func.sum(effective_amount), 0)).where(
-            Transaction.account_id == account_id,
-            Transaction.type == "credit",
-            Transaction.source != "opening_balance",
-            bucket_date <= today,
-            Transaction.status == "posted",
-            counts_as_pnl(),
-        ))
+        _scope(
+            select(func.coalesce(func.sum(effective_amount), 0)).where(
+                Transaction.account_id == account_id,
+                Transaction.type == "credit",
+                Transaction.source != "opening_balance",
+                bucket_date <= today,
+                Transaction.status == "posted",
+                counts_as_pnl(),
+            )
+        )
     )
     monthly_income = float(income_result.scalar())
 
@@ -820,23 +836,27 @@ async def get_account_summary(
             else_=func.abs(effective_amount),
         )
         expenses_result = await session.execute(
-            _scope(select(func.coalesce(func.sum(signed_for_bill), 0)).where(
-                Transaction.account_id == account_id,
-                Transaction.source != "opening_balance",
-                bucket_date <= today,
-                Transaction.status == "posted",
-                counts_as_pnl(),
-            ))
+            _scope(
+                select(func.coalesce(func.sum(signed_for_bill), 0)).where(
+                    Transaction.account_id == account_id,
+                    Transaction.source != "opening_balance",
+                    bucket_date <= today,
+                    Transaction.status == "posted",
+                    counts_as_pnl(),
+                )
+            )
         )
     else:
         expenses_result = await session.execute(
-            _scope(select(func.coalesce(func.sum(func.abs(effective_amount)), 0)).where(
-                Transaction.account_id == account_id,
-                Transaction.type == "debit",
-                bucket_date <= today,
-                Transaction.status == "posted",
-                counts_as_pnl(),
-            ))
+            _scope(
+                select(func.coalesce(func.sum(func.abs(effective_amount)), 0)).where(
+                    Transaction.account_id == account_id,
+                    Transaction.type == "debit",
+                    bucket_date <= today,
+                    Transaction.status == "posted",
+                    counts_as_pnl(),
+                )
+            )
         )
     monthly_expenses = float(expenses_result.scalar())
 
@@ -850,33 +870,39 @@ async def get_account_summary(
         bucket_date > today,
     )
     forecast_income_result = await session.execute(
-        _scope(select(func.coalesce(func.sum(effective_amount), 0)).where(
-            Transaction.account_id == account_id,
-            Transaction.type == "credit",
-            Transaction.source != "opening_balance",
-            forecast_condition,
-            counts_as_pnl(),
-        ))
+        _scope(
+            select(func.coalesce(func.sum(effective_amount), 0)).where(
+                Transaction.account_id == account_id,
+                Transaction.type == "credit",
+                Transaction.source != "opening_balance",
+                forecast_condition,
+                counts_as_pnl(),
+            )
+        )
     )
     forecast_income = float(forecast_income_result.scalar() or 0)
 
     if account.type == "credit_card":
         forecast_expense_result = await session.execute(
-            _scope(select(func.coalesce(func.sum(signed_for_bill), 0)).where(
-                Transaction.account_id == account_id,
-                Transaction.source != "opening_balance",
-                forecast_condition,
-                counts_as_pnl(),
-            ))
+            _scope(
+                select(func.coalesce(func.sum(signed_for_bill), 0)).where(
+                    Transaction.account_id == account_id,
+                    Transaction.source != "opening_balance",
+                    forecast_condition,
+                    counts_as_pnl(),
+                )
+            )
         )
     else:
         forecast_expense_result = await session.execute(
-            _scope(select(func.coalesce(func.sum(func.abs(effective_amount)), 0)).where(
-                Transaction.account_id == account_id,
-                Transaction.type == "debit",
-                forecast_condition,
-                counts_as_pnl(),
-            ))
+            _scope(
+                select(func.coalesce(func.sum(func.abs(effective_amount)), 0)).where(
+                    Transaction.account_id == account_id,
+                    Transaction.type == "debit",
+                    forecast_condition,
+                    counts_as_pnl(),
+                )
+            )
         )
     forecast_expenses = float(forecast_expense_result.scalar() or 0)
 
@@ -910,20 +936,30 @@ async def get_account_summary(
                 Transaction.date <= today,
             ]
             posted_result = await session.execute(
-                select(func.coalesce(func.sum(
-                    case(
-                        (Transaction.type == "credit", effective_amount),
-                        else_=-effective_amount,
+                select(
+                    func.coalesce(
+                        func.sum(
+                            case(
+                                (Transaction.type == "credit", effective_amount),
+                                else_=-effective_amount,
+                            )
+                        ),
+                        0,
                     )
-                ), 0)).where(*period_filters, Transaction.status == "posted")
+                ).where(*period_filters, Transaction.status == "posted")
             )
             pending_result = await session.execute(
-                select(func.coalesce(func.sum(
-                    case(
-                        (Transaction.type == "credit", effective_amount),
-                        else_=-effective_amount,
+                select(
+                    func.coalesce(
+                        func.sum(
+                            case(
+                                (Transaction.type == "credit", effective_amount),
+                                else_=-effective_amount,
+                            )
+                        ),
+                        0,
                     )
-                ), 0)).where(
+                ).where(
                     *period_filters,
                     Transaction.status == "pending",
                     is_inside_provider_snapshot(),
@@ -934,12 +970,17 @@ async def get_account_summary(
 
             if date_from > today:
                 before_window_result = await session.execute(
-                    select(func.coalesce(func.sum(
-                        case(
-                            (Transaction.type == "credit", effective_amount),
-                            else_=-effective_amount,
+                    select(
+                        func.coalesce(
+                            func.sum(
+                                case(
+                                    (Transaction.type == "credit", effective_amount),
+                                    else_=-effective_amount,
+                                )
+                            ),
+                            0,
                         )
-                    ), 0)).where(
+                    ).where(
                         *ob_base_filters,
                         Transaction.date > today,
                         Transaction.date < date_from,
@@ -949,12 +990,17 @@ async def get_account_summary(
                 opening_balance += float(before_window_result.scalar() or 0)
         else:
             manual_result = await session.execute(
-                select(func.coalesce(func.sum(
-                    case(
-                        (Transaction.type == "credit", effective_amount),
-                        else_=-effective_amount,
+                select(
+                    func.coalesce(
+                        func.sum(
+                            case(
+                                (Transaction.type == "credit", effective_amount),
+                                else_=-effective_amount,
+                            )
+                        ),
+                        0,
                     )
-                ), 0)).where(
+                ).where(
                     *ob_base_filters,
                     Transaction.date < date_from,
                     Transaction.status.in_(("posted", "pending")),
@@ -989,7 +1035,9 @@ def _signed_amount_expr(account_currency: str):
 
 
 async def _account_balance_at(
-    session: AsyncSession, account_id: uuid.UUID, cutoff: _Date,
+    session: AsyncSession,
+    account_id: uuid.UUID,
+    cutoff: _Date,
     account_currency: str = "",
 ) -> float:
     """Get balance for a single account at a specific date.
@@ -1012,14 +1060,18 @@ async def _account_balance_at(
 
 
 async def _account_daily_balance_series(
-    session: AsyncSession, account_id: uuid.UUID,
-    date_from: _Date, date_to: _Date,
+    session: AsyncSession,
+    account_id: uuid.UUID,
+    date_from: _Date,
+    date_to: _Date,
     account_currency: str = "",
 ) -> list[dict]:
     """Build daily balance series for [date_from, date_to] inclusive.
     Excludes ignored transactions from balance calculations."""
     # Get balance at end of day before range start
-    start_balance = await _account_balance_at(session, account_id, date_from - timedelta(days=1), account_currency)
+    start_balance = await _account_balance_at(
+        session, account_id, date_from - timedelta(days=1), account_currency
+    )
 
     # Get daily deltas within range: group by actual date
     # Exclude ignored transactions from daily deltas
@@ -1058,8 +1110,11 @@ async def _account_daily_balance_series(
 
 
 async def get_account_balance_history(
-    session: AsyncSession, account_id: uuid.UUID, workspace_id: uuid.UUID,
-    date_from: Optional[_Date] = None, date_to: Optional[_Date] = None,
+    session: AsyncSession,
+    account_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+    date_from: Optional[_Date] = None,
+    date_to: Optional[_Date] = None,
 ) -> Optional[list[dict]]:
     account = await get_account(session, account_id, workspace_id)
     if not account:
@@ -1073,7 +1128,9 @@ async def get_account_balance_history(
 
     sign = -1.0 if (account.type == "credit_card" and account.connection_id) else 1.0
 
-    series = await _account_daily_balance_series(session, account_id, date_from, date_to, account.currency)
+    series = await _account_daily_balance_series(
+        session, account_id, date_from, date_to, account.currency
+    )
 
     if sign != 1.0:
         for point in series:

--- a/backend/app/services/connection_service.py
+++ b/backend/app/services/connection_service.py
@@ -185,9 +185,7 @@ async def _resolve_institution(
                     select(Institution)
                     .where(
                         Institution.connection_id == connection_id,
-                        Institution.external_id == ext
-                        if ext
-                        else Institution.name == name,
+                        Institution.external_id == ext if ext else Institution.name == name,
                     )
                     .limit(1)
                 )
@@ -203,6 +201,7 @@ async def _resolve_institution(
             inst.logo_url = new_logo
     cache[key] = inst
     return inst
+
 
 PLUGGY_CATEGORY_MAP = {
     "Eating out": "Alimentação",
@@ -268,9 +267,7 @@ async def _sync_holdings(
         provider = get_provider(connection.provider)
         holdings = await provider.get_holdings(credentials)
     except Exception:  # noqa: BLE001
-        logger.exception(
-            "Failed to fetch holdings for connection %s", connection.id
-        )
+        logger.exception("Failed to fetch holdings for connection %s", connection.id)
         return
 
     source = connection.provider
@@ -354,8 +351,7 @@ async def _sync_holdings(
             )
             wallet_key = _wallet_external_id(connection.external_id, key)
             default_name = (
-                _clean_institution_name(holding.account_name)
-                or connection.institution_name
+                _clean_institution_name(holding.account_name) or connection.institution_name
             )
             # The first claim on a wallet key adopts the wallet these
             # holdings lived in before — the legacy connection-keyed one, or
@@ -389,9 +385,7 @@ async def _sync_holdings(
                 if key:
                     key_shape = or_(
                         key_shape,
-                        AssetGroup.external_id.endswith(
-                            f"::{key}", autoescape=True
-                        ),
+                        AssetGroup.external_id.endswith(f"::{key}", autoescape=True),
                     )
                 candidates = [
                     g
@@ -415,7 +409,9 @@ async def _sync_holdings(
                                 key_shape,
                             )
                         )
-                    ).scalars().all()
+                    )
+                    .scalars()
+                    .all()
                     if g.id not in claimed
                 ]
                 # A stale key parses as exactly "{old prefix}::{key}"; a
@@ -431,27 +427,17 @@ async def _sync_holdings(
                     and g.external_id[: -len(tail)]
                     and "::" not in g.external_id[: -len(tail)]
                 ]
-                plain = [
-                    g
-                    for g in candidates
-                    if g.external_id and "::" not in g.external_id
-                ]
+                plain = [g for g in candidates if g.external_id and "::" not in g.external_id]
                 pool = suffixed or (
-                    []
-                    if (has_any_split_wallets if key else has_split_wallets)
-                    else plain
+                    [] if (has_any_split_wallets if key else has_split_wallets) else plain
                 )
-                exact = [
-                    g for g in pool if g.external_id == connection.external_id
-                ]
+                exact = [g for g in pool if g.external_id == connection.external_id]
                 if exact:
                     legacy = exact[0]
                 else:
                     ours = [g for g in pool if g.connection_id == connection.id]
                     if not ours:
-                        ours = [
-                            g for g in pool if await _holds_synced_asset(g.id)
-                        ]
+                        ours = [g for g in pool if await _holds_synced_asset(g.id)]
                     if len(ours) == 1:
                         legacy = ours[0]
             if legacy is not None:
@@ -462,9 +448,7 @@ async def _sync_holdings(
                     async with session.begin_nested():
                         legacy.external_id = wallet_key
                         legacy.connection_id = connection.id
-                        if _is_auto_wallet_name(
-                            legacy.name, connection.institution_name
-                        ):
+                        if _is_auto_wallet_name(legacy.name, connection.institution_name):
                             legacy.name = await _unique_default_name(
                                 session,
                                 user_id,
@@ -588,7 +572,12 @@ async def _sync_holdings(
             existing.sell_date = None
 
         asset = await _upsert_asset_from_holding(
-            session, existing, holding, user_id, connection.id, source,
+            session,
+            existing,
+            holding,
+            user_id,
+            connection.id,
+            source,
             workspace_id=connection.workspace_id,
         )
         if asset.group_id is not None:
@@ -613,10 +602,7 @@ async def _sync_holdings(
         # user made themselves ("US Stocks", source "manual") is never
         # touched.
         group = await _wallet_for(holding)
-        hint_lost = (
-            holding.account_external_id is None
-            and asset.group_id in split_group_ids
-        )
+        hint_lost = holding.account_external_id is None and asset.group_id in split_group_ids
         if (
             not hint_lost
             and (asset.group_id is None or asset.group_id in sync_owned_group_ids)
@@ -911,9 +897,7 @@ async def get_reauth_url(
     )
 
 
-async def list_provider_institutions(
-    provider_name: str, country: Optional[str] = None
-) -> dict:
+async def list_provider_institutions(provider_name: str, country: Optional[str] = None) -> dict:
     provider = get_provider(provider_name)
     data = await provider.list_institutions(country)
     return {
@@ -1014,7 +998,9 @@ async def handle_oauth_callback(
         existing_reconnect.institution_name = (
             connection_data.institution_name or existing_reconnect.institution_name
         )
-        existing_reconnect.logo_url = _clean_logo_url(connection_data.logo_url) or existing_reconnect.logo_url
+        existing_reconnect.logo_url = (
+            _clean_logo_url(connection_data.logo_url) or existing_reconnect.logo_url
+        )
         existing_reconnect.credentials = connection_data.credentials
         existing_reconnect.status = "active"
         # Re-sync from current data on next sync cycle.
@@ -1066,6 +1052,8 @@ async def handle_oauth_callback(
             masked_number=acc_data.masked_number,
             type=acc_data.type,
             balance=acc_data.balance,
+            expected_balance=acc_data.expected_balance if is_cc else None,
+            available_credit=acc_data.available_credit if is_cc else None,
             currency=acc_data.currency,
             credit_limit=acc_data.credit_limit if is_cc else None,
             statement_close_day=acc_data.statement_close_day if is_cc else None,
@@ -1108,16 +1096,11 @@ async def handle_oauth_callback(
                     synced_dup.status = "posted"
                     synced_dup.external_id = txn_data.external_id
                     synced_dup.raw_data = txn_data.raw_data
-                    if (
-                        txn_data.bill_external_id
-                        and synced_dup.effective_bill_date is None
-                    ):
+                    if txn_data.bill_external_id and synced_dup.effective_bill_date is None:
                         bill = bills_by_external_id.get(txn_data.bill_external_id)
                         if bill is not None and synced_dup.bill_id != bill.id:
                             synced_dup.bill_id = bill.id
-                            apply_effective_date(
-                                synced_dup, account, bill_due_date=bill.due_date
-                            )
+                            apply_effective_date(synced_dup, account, bill_due_date=bill.due_date)
                 continue
 
             category_id = await _match_pluggy_category(
@@ -1322,10 +1305,13 @@ async def _find_synced_duplicate(
     for candidate in result.scalars():
         if candidate.external_id and candidate.external_id.startswith("bill_charge:"):
             continue
-        if _description_similarity(
-            candidate.original_description or candidate.description,
-            txn_data.description,
-        ) >= 0.7:
+        if (
+            _description_similarity(
+                candidate.original_description or candidate.description,
+                txn_data.description,
+            )
+            >= 0.7
+        ):
             return candidate
 
     return None
@@ -1381,10 +1367,13 @@ async def _cleanup_phantom_duplicates(
             )
         )
         for sibling in sibling_result.scalars():
-            if _description_similarity(
-                sibling.original_description or sibling.description,
-                tx.original_description or tx.description,
-            ) >= 0.9:
+            if (
+                _description_similarity(
+                    sibling.original_description or sibling.description,
+                    tx.original_description or tx.description,
+                )
+                >= 0.9
+            ):
                 await session.delete(tx)
                 deleted += 1
                 break
@@ -1418,6 +1407,7 @@ def _compute_bill_close_date(due_date: date, close_day: Optional[int]) -> date:
     after the payment in the tx list, which doesn't match real bank semantics.
     """
     import calendar  # local — not used elsewhere in this file
+
     if not close_day:
         return due_date
     last = calendar.monthrange(due_date.year, due_date.month)[1]
@@ -1495,12 +1485,14 @@ async def _sync_bill_finance_charges(
         external_id = f"bill_charge:{bill.external_id}:{charge_id}"
         desired_external_ids.add(external_id)
 
-        existing = (await session.execute(
-            select(Transaction).where(
-                Transaction.account_id == account.id,
-                Transaction.external_id == external_id,
+        existing = (
+            await session.execute(
+                select(Transaction).where(
+                    Transaction.account_id == account.id,
+                    Transaction.external_id == external_id,
+                )
             )
-        )).scalar_one_or_none()
+        ).scalar_one_or_none()
 
         description = _describe_finance_charge(
             str(raw.get("type") or ""), raw.get("additionalInfo")
@@ -1535,13 +1527,19 @@ async def _sync_bill_finance_charges(
     # Drop synthetic charges Pluggy no longer reports for this bill (e.g.
     # the bank reversed an erroneous fee on a re-sync). Real transactions
     # don't share the bill_charge: prefix so they're untouched.
-    orphans = (await session.execute(
-        select(Transaction).where(
-            Transaction.account_id == account.id,
-            Transaction.bill_id == bill.id,
-            Transaction.external_id.like(f"bill_charge:{bill.external_id}:%"),
+    orphans = (
+        (
+            await session.execute(
+                select(Transaction).where(
+                    Transaction.account_id == account.id,
+                    Transaction.bill_id == bill.id,
+                    Transaction.external_id.like(f"bill_charge:{bill.external_id}:%"),
+                )
+            )
         )
-    )).scalars().all()
+        .scalars()
+        .all()
+    )
     for tx in orphans:
         if tx.external_id not in desired_external_ids:
             await session.delete(tx)
@@ -1571,19 +1569,21 @@ async def _sync_credit_card_bills(
     try:
         bills_data = await provider.get_bills(credentials, account.external_id)
     except Exception as e:  # noqa: BLE001 — provider failures must not fail sync
-        logger.info(
-            "Skipping credit-card bills sync for account %s: %s", account.id, e
-        )
+        logger.info("Skipping credit-card bills sync for account %s: %s", account.id, e)
         return {}
 
     if not bills_data:
         return {}
 
     existing = (
-        await session.execute(
-            select(CreditCardBill).where(CreditCardBill.account_id == account.id)
+        (
+            await session.execute(
+                select(CreditCardBill).where(CreditCardBill.account_id == account.id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     by_external_id: dict[str, CreditCardBill] = {b.external_id: b for b in existing}
 
     for bd in bills_data:
@@ -1619,7 +1619,11 @@ async def _sync_credit_card_bills(
         raw_charges = (bd.raw_data or {}).get("financeCharges")
         if isinstance(raw_charges, list) and raw_charges:
             await _sync_bill_finance_charges(
-                session, user_id, account, bill, raw_charges,
+                session,
+                user_id,
+                account,
+                bill,
+                raw_charges,
             )
 
     return by_external_id
@@ -1684,7 +1688,8 @@ async def sync_connection(
                     connection.logo_url = logo
             except Exception:
                 logger.warning(
-                    "Failed to backfill logo for connection %s", connection.id,
+                    "Failed to backfill logo for connection %s",
+                    connection.id,
                     exc_info=True,
                 )
 
@@ -1766,6 +1771,11 @@ async def sync_connection(
                 account.balance = _simplefin_to_internal_balance(
                     connection.provider, account.type, acc_data.balance
                 )
+                if account.type == "credit_card":
+                    # Snapshot fields are provider-owned. Clear stale values
+                    # when a later response no longer supplies them.
+                    account.expected_balance = acc_data.expected_balance
+                    account.available_credit = acc_data.available_credit
                 account.name = acc_data.name
                 # Backfills existing accounts on their next sync. Only written
                 # when the provider actually returns an identifier, so a payload
@@ -1805,6 +1815,8 @@ async def sync_connection(
                     masked_number=acc_data.masked_number,
                     type=acc_data.type,
                     balance=acc_data.balance,
+                    expected_balance=acc_data.expected_balance if is_cc else None,
+                    available_credit=acc_data.available_credit if is_cc else None,
                     currency=acc_data.currency,
                     credit_limit=acc_data.credit_limit if is_cc else None,
                     statement_close_day=acc_data.statement_close_day if is_cc else None,
@@ -1877,16 +1889,11 @@ async def sync_connection(
                     # User's manual override wins: if effective_bill_date is
                     # set, we don't touch bill_id or effective_date — the
                     # user has explicitly overridden the auto bucketing.
-                    if (
-                        txn_data.bill_external_id
-                        and existing_tx.effective_bill_date is None
-                    ):
+                    if txn_data.bill_external_id and existing_tx.effective_bill_date is None:
                         bill = bills_by_external_id.get(txn_data.bill_external_id)
                         if bill is not None and existing_tx.bill_id != bill.id:
                             existing_tx.bill_id = bill.id
-                            apply_effective_date(
-                                existing_tx, account, bill_due_date=bill.due_date
-                            )
+                            apply_effective_date(existing_tx, account, bill_due_date=bill.due_date)
                     continue
 
                 # Pass 2: Fuzzy match against manual transactions
@@ -1909,9 +1916,7 @@ async def sync_connection(
                 # comes back under a new external id with a different
                 # status, fingerprint match collapses it instead of letting
                 # both rows land.
-                synced_dup = await _find_synced_duplicate(
-                    session, account.id, txn_data
-                )
+                synced_dup = await _find_synced_duplicate(session, account.id, txn_data)
                 if synced_dup:
                     if synced_dup.original_description is None:
                         synced_dup.original_description = txn_data.description
@@ -1921,10 +1926,7 @@ async def sync_connection(
                         synced_dup.status = "posted"
                         synced_dup.external_id = txn_data.external_id
                         synced_dup.raw_data = txn_data.raw_data
-                        if (
-                            txn_data.bill_external_id
-                            and synced_dup.effective_bill_date is None
-                        ):
+                        if txn_data.bill_external_id and synced_dup.effective_bill_date is None:
                             bill = bills_by_external_id.get(txn_data.bill_external_id)
                             if bill is not None and synced_dup.bill_id != bill.id:
                                 synced_dup.bill_id = bill.id
@@ -1933,9 +1935,7 @@ async def sync_connection(
                                 )
                     continue
 
-                incoming_currency = (
-                    txn_data.currency or acc_data.currency or user_currency
-                )
+                incoming_currency = txn_data.currency or acc_data.currency or user_currency
                 category_id = await _match_pluggy_category(
                     session,
                     workspace_id,
@@ -1986,24 +1986,20 @@ async def sync_connection(
                     account,
                     bill_due_date=bill.due_date if bill else None,
                 )
-                preview = await preview_rules_for_transaction(
-                    session, user_id, transaction
-                )
+                preview = await preview_rules_for_transaction(session, user_id, transaction)
 
                 # Normalize before recurring reconciliation. A generated
                 # placeholder is upgraded in place; otherwise the normalized
                 # candidate may fulfill an active definition, which advances so
                 # later generation cannot duplicate the occurrence.
-                placeholder = (
-                    await recurring_match_service.find_placeholder_for_incoming(
-                        session,
-                        account.id,
-                        txn_data.amount,
-                        incoming_currency,
-                        txn_data.type,
-                        txn_data.date,
-                        preview.description,
-                    )
+                placeholder = await recurring_match_service.find_placeholder_for_incoming(
+                    session,
+                    account.id,
+                    txn_data.amount,
+                    incoming_currency,
+                    txn_data.type,
+                    txn_data.date,
+                    preview.description,
                 )
                 if placeholder:
                     if placeholder.is_ignored:
@@ -2025,35 +2021,27 @@ async def sync_connection(
                         placeholder.payee = txn_data.payee
                     if placeholder.payee_id is None:
                         placeholder.payee_id = preview.payee_id
-                    placeholder.notes = merge_notes(
-                        placeholder.notes, preview.notes
-                    )
+                    placeholder.notes = merge_notes(placeholder.notes, preview.notes)
                     if preview.is_ignored:
                         placeholder.is_ignored = True
                     merged_count += 1
                     continue
 
-                recurring_link = (
-                    await recurring_match_service.find_bill_for_incoming(
-                        session,
-                        user_id,
-                        account.id,
-                        txn_data.amount,
-                        incoming_currency,
-                        txn_data.type,
-                        txn_data.date,
-                        preview.description,
-                    )
+                recurring_link = await recurring_match_service.find_bill_for_incoming(
+                    session,
+                    user_id,
+                    account.id,
+                    txn_data.amount,
+                    incoming_currency,
+                    txn_data.type,
+                    txn_data.date,
+                    preview.description,
                 )
-                transaction.recurring_transaction_id = (
-                    recurring_link.id if recurring_link else None
-                )
+                transaction.recurring_transaction_id = recurring_link.id if recurring_link else None
                 session.add(transaction)
                 await session.flush()
                 if recurring_link is not None:
-                    recurring_match_service.advance_past(
-                        recurring_link, txn_data.date
-                    )
+                    recurring_match_service.advance_past(recurring_link, txn_data.date)
                 new_tx_ids.append(transaction.id)
                 await apply_rules_to_transaction(session, user_id, transaction)
 
@@ -2172,32 +2160,32 @@ async def delete_connection(
     # (user_id, source, external_id). The FK's ON DELETE SET NULL will
     # then clear connection_id when the row is removed below.
     await session.execute(
-        update(Asset)
-        .where(Asset.connection_id == connection.id)
-        .values(is_archived=True)
+        update(Asset).where(Asset.connection_id == connection.id).values(is_archived=True)
     )
 
     # Track payees referenced by this connection's transactions so we can
     # remove only newly-orphaned records after deleting the connection.
     affected_payee_ids = (
-        await session.execute(
-            select(Transaction.payee_id)
-            .join(Account, Account.id == Transaction.account_id)
-            .where(
-                Account.connection_id == connection.id,
-                Transaction.payee_id.isnot(None),
+        (
+            await session.execute(
+                select(Transaction.payee_id)
+                .join(Account, Account.id == Transaction.account_id)
+                .where(
+                    Account.connection_id == connection.id,
+                    Transaction.payee_id.isnot(None),
+                )
+                .distinct()
             )
-            .distinct()
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     await session.delete(connection)
     await session.flush()
 
     if affected_payee_ids:
-        has_transactions = exists(
-            select(Transaction.id).where(Transaction.payee_id == Payee.id)
-        )
+        has_transactions = exists(select(Transaction.id).where(Transaction.payee_id == Payee.id))
         has_external_mappings = exists(
             select(PayeeMapping.id).where(
                 PayeeMapping.target_id == Payee.id,

--- a/backend/app/services/credit_card_service.py
+++ b/backend/app/services/credit_card_service.py
@@ -57,13 +57,17 @@ def get_cycle_dates(
 
 def compute_available_credit(
     credit_limit: Optional[Decimal],
-    current_balance: Decimal,
+    booked_balance: Decimal,
 ) -> Optional[Decimal]:
-    """available = limit − utilized. current_balance for a credit card is negative when debt."""
+    """Return fallback credit from a normalized booked card balance.
+
+    ``booked_balance`` uses the stored Securo invariant: positive is debt and
+    negative is credit/guthaben. Provider-reported available credit should be
+    preferred by callers because it may already include pending transactions.
+    """
     if credit_limit is None:
         return None
-    utilized = -current_balance if current_balance < 0 else Decimal("0")
-    return credit_limit - utilized
+    return credit_limit - booked_balance
 
 
 def apply_effective_date(transaction, account, *, bill_due_date: Optional[date] = None) -> None:

--- a/backend/tests/test_account_service.py
+++ b/backend/tests/test_account_service.py
@@ -9,11 +9,13 @@ Directly exercises the service functions to ensure full coverage of:
 - get_account_balance_history
 - _account_balance_at / _account_daily_balance_series
 """
+
 import uuid
 from datetime import date, timedelta
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
@@ -36,16 +38,21 @@ from app.services.account_service import (
     sync_opening_balance_for_connected_account,
     update_account,
 )
+from app.services.credit_card_service import compute_available_credit
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 async def _make_account(
-    session: AsyncSession, user_id: uuid.UUID,
-    name: str = "Test Account", acc_type: str = "checking",
-    balance: str = "0.00", currency: str = "BRL",
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    name: str = "Test Account",
+    acc_type: str = "checking",
+    balance: str = "0.00",
+    currency: str = "BRL",
     connection_id: uuid.UUID | None = None,
     external_id: str | None = None,
 ) -> Account:
@@ -66,12 +73,18 @@ async def _make_account(
 
 
 async def _add_txn(
-    session: AsyncSession, user_id: uuid.UUID, account_id: uuid.UUID,
-    amount: float, txn_type: str, txn_date: date,
-    source: str = "manual", transfer_pair_id: uuid.UUID | None = None,
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    account_id: uuid.UUID,
+    amount: float,
+    txn_type: str,
+    txn_date: date,
+    source: str = "manual",
+    transfer_pair_id: uuid.UUID | None = None,
     status: str = "posted",
 ) -> Transaction:
     from datetime import datetime, timezone
+
     txn = Transaction(
         id=uuid.uuid4(),
         user_id=user_id,
@@ -100,7 +113,9 @@ async def _add_txn(
 @pytest.mark.asyncio
 async def test_create_account_with_balance(session: AsyncSession, test_user, test_workspace):
     """Creating an account with balance > 0 creates an opening_balance transaction."""
-    data = AccountCreate(name="Checking", type="checking", balance=Decimal("1000.00"), currency="BRL")
+    data = AccountCreate(
+        name="Checking", type="checking", balance=Decimal("1000.00"), currency="BRL"
+    )
     account = await create_account(session, test_workspace.id, test_user.id, data)
 
     assert account.name == "Checking"
@@ -108,6 +123,7 @@ async def test_create_account_with_balance(session: AsyncSession, test_user, tes
 
     # Verify opening_balance transaction was created
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -121,12 +137,17 @@ async def test_create_account_with_balance(session: AsyncSession, test_user, tes
 
 
 @pytest.mark.asyncio
-async def test_create_account_with_negative_balance(session: AsyncSession, test_user, test_workspace):
+async def test_create_account_with_negative_balance(
+    session: AsyncSession, test_user, test_workspace
+):
     """Negative manual opening balance is recorded as a debit."""
-    data = AccountCreate(name="Overdrawn", type="checking", balance=Decimal("-250.00"), currency="BRL")
+    data = AccountCreate(
+        name="Overdrawn", type="checking", balance=Decimal("-250.00"), currency="BRL"
+    )
     account = await create_account(session, test_workspace.id, test_user.id, data)
 
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -142,12 +163,17 @@ async def test_create_account_with_negative_balance(session: AsyncSession, test_
 
 
 @pytest.mark.asyncio
-async def test_create_credit_card_account_opening_is_debit(session: AsyncSession, test_user, test_workspace):
+async def test_create_credit_card_account_opening_is_debit(
+    session: AsyncSession, test_user, test_workspace
+):
     """Credit card opening balance is recorded as debit (represents debt)."""
-    data = AccountCreate(name="Nubank", type="credit_card", balance=Decimal("500.00"), currency="BRL")
+    data = AccountCreate(
+        name="Nubank", type="credit_card", balance=Decimal("500.00"), currency="BRL"
+    )
     account = await create_account(session, test_workspace.id, test_user.id, data)
 
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -160,12 +186,15 @@ async def test_create_credit_card_account_opening_is_debit(session: AsyncSession
 
 
 @pytest.mark.asyncio
-async def test_create_account_zero_balance_no_opening(session: AsyncSession, test_user, test_workspace):
+async def test_create_account_zero_balance_no_opening(
+    session: AsyncSession, test_user, test_workspace
+):
     """Creating an account with zero balance creates no opening transaction."""
     data = AccountCreate(name="Empty", type="checking", balance=Decimal("0.00"), currency="BRL")
     account = await create_account(session, test_workspace.id, test_user.id, data)
 
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -180,12 +209,16 @@ async def test_create_account_with_balance_date(session: AsyncSession, test_user
     """Opening transaction uses the provided balance_date."""
     custom_date = date(2025, 1, 15)
     data = AccountCreate(
-        name="Dated", type="checking", balance=Decimal("2000.00"),
-        currency="BRL", balance_date=custom_date,
+        name="Dated",
+        type="checking",
+        balance=Decimal("2000.00"),
+        currency="BRL",
+        balance_date=custom_date,
     )
     account = await create_account(session, test_workspace.id, test_user.id, data)
 
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -213,7 +246,9 @@ async def test_update_account_name(session: AsyncSession, test_user, test_worksp
 
 
 @pytest.mark.asyncio
-async def test_update_account_balance_creates_opening(session: AsyncSession, test_user, test_workspace):
+async def test_update_account_balance_creates_opening(
+    session: AsyncSession, test_user, test_workspace
+):
     """Updating balance on an account with no opening_balance creates one."""
     account = await _make_account(session, test_user.id, "No Balance", balance="0.00")
     data = AccountUpdate(balance=Decimal("500.00"))
@@ -221,6 +256,7 @@ async def test_update_account_balance_creates_opening(session: AsyncSession, tes
 
     assert updated is not None
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -233,7 +269,9 @@ async def test_update_account_balance_creates_opening(session: AsyncSession, tes
 
 
 @pytest.mark.asyncio
-async def test_update_account_balance_creates_negative_opening(session: AsyncSession, test_user, test_workspace):
+async def test_update_account_balance_creates_negative_opening(
+    session: AsyncSession, test_user, test_workspace
+):
     """Updating a manual account to a negative balance creates a debit opening."""
     account = await _make_account(session, test_user.id, "No Balance", balance="0.00")
     data = AccountUpdate(balance=Decimal("-500.00"))
@@ -241,6 +279,7 @@ async def test_update_account_balance_creates_negative_opening(session: AsyncSes
 
     assert updated is not None
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -253,15 +292,20 @@ async def test_update_account_balance_creates_negative_opening(session: AsyncSes
 
 
 @pytest.mark.asyncio
-async def test_update_account_balance_updates_existing_opening(session: AsyncSession, test_user, test_workspace):
+async def test_update_account_balance_updates_existing_opening(
+    session: AsyncSession, test_user, test_workspace
+):
     """Updating balance when opening_balance exists updates it."""
-    data = AccountCreate(name="Update Test", type="checking", balance=Decimal("1000.00"), currency="BRL")
+    data = AccountCreate(
+        name="Update Test", type="checking", balance=Decimal("1000.00"), currency="BRL"
+    )
     account = await create_account(session, test_workspace.id, test_user.id, data)
 
     update_data = AccountUpdate(balance=Decimal("2000.00"))
     await update_account(session, account.id, test_workspace.id, update_data)
 
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -273,15 +317,20 @@ async def test_update_account_balance_updates_existing_opening(session: AsyncSes
 
 
 @pytest.mark.asyncio
-async def test_update_account_balance_to_zero_removes_opening(session: AsyncSession, test_user, test_workspace):
+async def test_update_account_balance_to_zero_removes_opening(
+    session: AsyncSession, test_user, test_workspace
+):
     """Setting balance to 0 removes the opening_balance transaction."""
-    data = AccountCreate(name="Zero Test", type="checking", balance=Decimal("500.00"), currency="BRL")
+    data = AccountCreate(
+        name="Zero Test", type="checking", balance=Decimal("500.00"), currency="BRL"
+    )
     account = await create_account(session, test_workspace.id, test_user.id, data)
 
     update_data = AccountUpdate(balance=Decimal("0.00"))
     await update_account(session, account.id, test_workspace.id, update_data)
 
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -294,7 +343,9 @@ async def test_update_account_balance_to_zero_removes_opening(session: AsyncSess
 @pytest.mark.asyncio
 async def test_update_account_balance_with_date(session: AsyncSession, test_user, test_workspace):
     """Updating balance with balance_date updates the opening tx date."""
-    data = AccountCreate(name="Date Test", type="checking", balance=Decimal("1000.00"), currency="BRL")
+    data = AccountCreate(
+        name="Date Test", type="checking", balance=Decimal("1000.00"), currency="BRL"
+    )
     account = await create_account(session, test_workspace.id, test_user.id, data)
 
     new_date = date(2025, 6, 15)
@@ -302,6 +353,7 @@ async def test_update_account_balance_with_date(session: AsyncSession, test_user
     await update_account(session, account.id, test_workspace.id, update_data)
 
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -314,9 +366,13 @@ async def test_update_account_balance_with_date(session: AsyncSession, test_user
 
 
 @pytest.mark.asyncio
-async def test_update_account_balance_date_only_updates_opening(session: AsyncSession, test_user, test_workspace):
+async def test_update_account_balance_date_only_updates_opening(
+    session: AsyncSession, test_user, test_workspace
+):
     """Updating only balance_date moves the existing opening transaction."""
-    data = AccountCreate(name="Date Only Test", type="checking", balance=Decimal("1000.00"), currency="BRL")
+    data = AccountCreate(
+        name="Date Only Test", type="checking", balance=Decimal("1000.00"), currency="BRL"
+    )
     account = await create_account(session, test_workspace.id, test_user.id, data)
 
     new_date = date(2025, 7, 20)
@@ -324,6 +380,7 @@ async def test_update_account_balance_date_only_updates_opening(session: AsyncSe
     await update_account(session, account.id, test_workspace.id, update_data)
 
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -336,11 +393,16 @@ async def test_update_account_balance_date_only_updates_opening(session: AsyncSe
 
 
 @pytest.mark.asyncio
-async def test_update_bank_connected_raises(session: AsyncSession, test_user, test_workspace, test_connection):
+async def test_update_bank_connected_raises(
+    session: AsyncSession, test_user, test_workspace, test_connection
+):
     """Updating a bank-connected account raises ValueError."""
     account = await _make_account(
-        session, test_user.id, "Connected",
-        connection_id=test_connection.id, external_id="ext-1",
+        session,
+        test_user.id,
+        "Connected",
+        connection_id=test_connection.id,
+        external_id="ext-1",
     )
     data = AccountUpdate(name="Hacked")
     with pytest.raises(ValueError, match="bank-connected"):
@@ -353,8 +415,12 @@ async def test_update_bank_connected_type_override(
 ):
     """The account type can be overridden on a bank-connected account (issue #271)."""
     account = await _make_account(
-        session, test_user.id, "mBank Savings", acc_type="checking",
-        connection_id=test_connection.id, external_id="ext-type",
+        session,
+        test_user.id,
+        "mBank Savings",
+        acc_type="checking",
+        connection_id=test_connection.id,
+        external_id="ext-type",
     )
     updated = await update_account(
         session, account.id, test_workspace.id, AccountUpdate(type="savings")
@@ -369,8 +435,12 @@ async def test_update_bank_connected_type_override_clears_card_metadata(
 ):
     """Overriding a connected card to a non-card type drops stale card metadata."""
     account = await _make_account(
-        session, test_user.id, "Was a card", acc_type="credit_card",
-        connection_id=test_connection.id, external_id="ext-card",
+        session,
+        test_user.id,
+        "Was a card",
+        acc_type="credit_card",
+        connection_id=test_connection.id,
+        external_id="ext-card",
     )
     account.credit_limit = Decimal("5000.00")
     account.statement_close_day = 10
@@ -410,11 +480,16 @@ async def test_delete_manual_account(session: AsyncSession, test_user, test_work
 
 
 @pytest.mark.asyncio
-async def test_delete_bank_connected_raises(session: AsyncSession, test_user, test_workspace, test_connection):
+async def test_delete_bank_connected_raises(
+    session: AsyncSession, test_user, test_workspace, test_connection
+):
     """Deleting a bank-connected account raises ValueError."""
     account = await _make_account(
-        session, test_user.id, "Connected",
-        connection_id=test_connection.id, external_id="ext-del",
+        session,
+        test_user.id,
+        "Connected",
+        connection_id=test_connection.id,
+        external_id="ext-del",
     )
     with pytest.raises(ValueError, match="bank-connected"):
         await delete_account(session, account.id, test_workspace.id)
@@ -435,8 +510,12 @@ async def test_delete_account_with_import_logs(session: AsyncSession, test_user,
 
     account = await _make_account(session, test_user.id, "With Imports")
     log = ImportLog(
-        id=uuid.uuid4(), user_id=test_user.id, account_id=account.id,
-        filename="stmt.ofx", format="ofx", transaction_count=3,
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        account_id=account.id,
+        filename="stmt.ofx",
+        format="ofx",
+        transaction_count=3,
     )
     session.add(log)
     await session.commit()
@@ -446,14 +525,14 @@ async def test_delete_account_with_import_logs(session: AsyncSession, test_user,
     assert result is True
 
     assert await get_account(session, account.id, test_workspace.id) is None
-    orphan = await session.execute(
-        select(ImportLog).where(ImportLog.id == log_id)
-    )
+    orphan = await session.execute(select(ImportLog).where(ImportLog.id == log_id))
     assert orphan.scalar_one_or_none() is None
 
 
 @pytest.mark.asyncio
-async def test_delete_account_with_recurring_transactions(session: AsyncSession, test_user, test_workspace):
+async def test_delete_account_with_recurring_transactions(
+    session: AsyncSession, test_user, test_workspace
+):
     """Regression (#110, @stanleyndachi): deleting an account with a recurring
     transaction must succeed; the recurring rows cascade away since a schedule
     without an account can't post."""
@@ -461,10 +540,16 @@ async def test_delete_account_with_recurring_transactions(session: AsyncSession,
 
     account = await _make_account(session, test_user.id, "With Recurring")
     rec = RecurringTransaction(
-        id=uuid.uuid4(), user_id=test_user.id, account_id=account.id,
-        description="Rent", amount=Decimal("1000.00"), currency="BRL",
-        type="debit", frequency="monthly",
-        start_date=date.today(), next_occurrence=date.today(),
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        account_id=account.id,
+        description="Rent",
+        amount=Decimal("1000.00"),
+        currency="BRL",
+        type="debit",
+        frequency="monthly",
+        start_date=date.today(),
+        next_occurrence=date.today(),
     )
     session.add(rec)
     await session.commit()
@@ -480,7 +565,9 @@ async def test_delete_account_with_recurring_transactions(session: AsyncSession,
 
 
 @pytest.mark.asyncio
-async def test_delete_account_with_imported_transactions(session: AsyncSession, test_user, test_workspace):
+async def test_delete_account_with_imported_transactions(
+    session: AsyncSession, test_user, test_workspace
+):
     """Regression (#110 v2, @ivancarlosti): deleting an account whose transactions
     were imported from a file must succeed. The imported rows reference the
     import_log via transactions.import_id — deleting import_logs first would
@@ -489,15 +576,23 @@ async def test_delete_account_with_imported_transactions(session: AsyncSession, 
 
     account = await _make_account(session, test_user.id, "Imported Txns")
     log = ImportLog(
-        id=uuid.uuid4(), user_id=test_user.id, account_id=account.id,
-        filename="stmt.ofx", format="ofx", transaction_count=1,
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        account_id=account.id,
+        filename="stmt.ofx",
+        format="ofx",
+        transaction_count=1,
     )
     session.add(log)
     await session.flush()
 
     tx = await _add_txn(
-        session, test_user.id, account.id,
-        amount=42.0, txn_type="debit", txn_date=date.today(),
+        session,
+        test_user.id,
+        account.id,
+        amount=42.0,
+        txn_type="debit",
+        txn_date=date.today(),
         source="import",
     )
     tx.import_id = log.id
@@ -511,13 +606,9 @@ async def test_delete_account_with_imported_transactions(session: AsyncSession, 
     assert await get_account(session, account.id, test_workspace.id) is None
 
     session.expire_all()
-    orphan_log = await session.execute(
-        select(ImportLog).where(ImportLog.id == log_id)
-    )
+    orphan_log = await session.execute(select(ImportLog).where(ImportLog.id == log_id))
     assert orphan_log.scalar_one_or_none() is None
-    orphan_tx = await session.execute(
-        select(Transaction).where(Transaction.id == tx_id)
-    )
+    orphan_tx = await session.execute(select(Transaction).where(Transaction.id == tx_id))
     assert orphan_tx.scalar_one_or_none() is None
 
 
@@ -529,9 +620,14 @@ async def test_delete_account_with_linked_goal(session: AsyncSession, test_user,
 
     account = await _make_account(session, test_user.id, "Goal Tracked")
     goal = Goal(
-        id=uuid.uuid4(), user_id=test_user.id, name="Emergency fund",
-        target_amount=Decimal("10000.00"), current_amount=Decimal("2500.00"),
-        currency="BRL", tracking_type="account", account_id=account.id,
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        name="Emergency fund",
+        target_amount=Decimal("10000.00"),
+        current_amount=Decimal("2500.00"),
+        currency="BRL",
+        tracking_type="account",
+        account_id=account.id,
     )
     session.add(goal)
     await session.commit()
@@ -541,9 +637,7 @@ async def test_delete_account_with_linked_goal(session: AsyncSession, test_user,
     assert result is True
 
     session.expire_all()
-    surviving = await session.execute(
-        select(Goal).where(Goal.id == goal_id)
-    )
+    surviving = await session.execute(select(Goal).where(Goal.id == goal_id))
     kept = surviving.scalar_one()
     assert kept.account_id is None
     assert kept.current_amount == Decimal("2500.00")
@@ -566,7 +660,9 @@ async def test_close_account(session: AsyncSession, test_user, test_workspace):
 
 
 @pytest.mark.asyncio
-async def test_close_bank_connected_keeps_link(session: AsyncSession, test_user, test_workspace, test_connection):
+async def test_close_bank_connected_keeps_link(
+    session: AsyncSession, test_user, test_workspace, test_connection
+):
     """Closing a bank-connected account keeps its connection link.
 
     Sync uses (connection_id, external_id) to find the row; unlinking on close
@@ -574,8 +670,11 @@ async def test_close_bank_connected_keeps_link(session: AsyncSession, test_user,
     flag alone is enough to keep sync from touching it.
     """
     account = await _make_account(
-        session, test_user.id, "Connected Close",
-        connection_id=test_connection.id, external_id="ext-close",
+        session,
+        test_user.id,
+        "Connected Close",
+        connection_id=test_connection.id,
+        external_id="ext-close",
     )
     closed = await close_account(session, account.id, test_workspace.id)
 
@@ -637,7 +736,9 @@ async def test_reopen_not_found(session: AsyncSession, test_user, test_workspace
 async def test_get_accounts_returns_list(session: AsyncSession, test_user, test_workspace):
     """get_accounts returns list with current_balance and previous_balance."""
     account = await _make_account(session, test_user.id, "List Test", balance="1000.00")
-    await _add_txn(session, test_user.id, account.id, 1000, "credit", date.today(), source="opening_balance")
+    await _add_txn(
+        session, test_user.id, account.id, 1000, "credit", date.today(), source="opening_balance"
+    )
 
     accounts = await get_accounts(session, test_workspace.id)
     assert len(accounts) >= 1
@@ -656,12 +757,8 @@ async def test_get_accounts_previous_balance_uses_each_account_currency(
     brl_account = await _make_account(session, test_user.id, "BRL Account", currency="BRL")
     usd_account = await _make_account(session, test_user.id, "USD Account", currency="USD")
 
-    brl_txn = await _add_txn(
-        session, test_user.id, brl_account.id, 100, "credit", previous_month
-    )
-    usd_txn = await _add_txn(
-        session, test_user.id, usd_account.id, 20, "credit", previous_month
-    )
+    brl_txn = await _add_txn(session, test_user.id, brl_account.id, 100, "credit", previous_month)
+    usd_txn = await _add_txn(session, test_user.id, usd_account.id, 20, "credit", previous_month)
     usd_txn.currency = "USD"
     brl_txn.amount_primary = Decimal("500.00")
     usd_txn.amount_primary = Decimal("100.00")
@@ -686,7 +783,9 @@ async def test_get_accounts_excludes_closed(session: AsyncSession, test_user, te
 
 
 @pytest.mark.asyncio
-async def test_get_accounts_includes_closed_when_requested(session: AsyncSession, test_user, test_workspace):
+async def test_get_accounts_includes_closed_when_requested(
+    session: AsyncSession, test_user, test_workspace
+):
     """get_accounts includes closed accounts when include_closed=True."""
     account = await _make_account(session, test_user.id, "Closed Visible")
     await close_account(session, account.id, test_workspace.id)
@@ -697,12 +796,18 @@ async def test_get_accounts_includes_closed_when_requested(session: AsyncSession
 
 
 @pytest.mark.asyncio
-async def test_get_accounts_credit_card_negated_balance(session: AsyncSession, test_user, test_workspace, test_connection):
+async def test_get_accounts_credit_card_negated_balance(
+    session: AsyncSession, test_user, test_workspace, test_connection
+):
     """Bank-connected credit_card current_balance is negated."""
     account = await _make_account(
-        session, test_user.id, "CC Connected",
-        acc_type="credit_card", balance="3000.00",
-        connection_id=test_connection.id, external_id="ext-cc",
+        session,
+        test_user.id,
+        "CC Connected",
+        acc_type="credit_card",
+        balance="3000.00",
+        connection_id=test_connection.id,
+        external_id="ext-cc",
     )
     accounts = await get_accounts(session, test_workspace.id)
     cc = next(a for a in accounts if a["id"] == account.id)
@@ -722,7 +827,9 @@ async def test_get_account_summary_manual(session: AsyncSession, test_user, test
     today = date.today()
 
     # Add opening balance and some transactions
-    await _add_txn(session, test_user.id, account.id, 5000, "credit", today, source="opening_balance")
+    await _add_txn(
+        session, test_user.id, account.id, 5000, "credit", today, source="opening_balance"
+    )
     await _add_txn(session, test_user.id, account.id, 200, "debit", today)
     await _add_txn(session, test_user.id, account.id, 100, "credit", today)
 
@@ -734,12 +841,17 @@ async def test_get_account_summary_manual(session: AsyncSession, test_user, test
 
 
 @pytest.mark.asyncio
-async def test_get_account_summary_bank_connected(session: AsyncSession, test_user, test_workspace, test_connection):
+async def test_get_account_summary_bank_connected(
+    session: AsyncSession, test_user, test_workspace, test_connection
+):
     """Summary for bank-connected account uses stored balance."""
     account = await _make_account(
-        session, test_user.id, "Connected Summary",
+        session,
+        test_user.id,
+        "Connected Summary",
         balance="7500.00",
-        connection_id=test_connection.id, external_id="ext-sum",
+        connection_id=test_connection.id,
+        external_id="ext-sum",
     )
     summary = await get_account_summary(session, account.id, test_workspace.id)
     assert summary is not None
@@ -747,12 +859,18 @@ async def test_get_account_summary_bank_connected(session: AsyncSession, test_us
 
 
 @pytest.mark.asyncio
-async def test_get_account_summary_credit_card_bank(session: AsyncSession, test_user, test_workspace, test_connection):
+async def test_get_account_summary_credit_card_bank(
+    session: AsyncSession, test_user, test_workspace, test_connection
+):
     """Bank-connected credit_card summary negates balance."""
     account = await _make_account(
-        session, test_user.id, "CC Bank",
-        acc_type="credit_card", balance="2000.00",
-        connection_id=test_connection.id, external_id="ext-cc-sum",
+        session,
+        test_user.id,
+        "CC Bank",
+        acc_type="credit_card",
+        balance="2000.00",
+        connection_id=test_connection.id,
+        external_id="ext-cc-sum",
     )
     summary = await get_account_summary(session, account.id, test_workspace.id)
     assert summary is not None
@@ -760,7 +878,9 @@ async def test_get_account_summary_credit_card_bank(session: AsyncSession, test_
 
 
 @pytest.mark.asyncio
-async def test_get_account_summary_with_date_range(session: AsyncSession, test_user, test_workspace):
+async def test_get_account_summary_with_date_range(
+    session: AsyncSession, test_user, test_workspace
+):
     """Summary filters income/expenses by date range."""
     account = await _make_account(session, test_user.id, "Date Range Test")
     today = date.today()
@@ -771,15 +891,20 @@ async def test_get_account_summary_with_date_range(session: AsyncSession, test_u
 
     # Query only this month
     summary = await get_account_summary(
-        session, account.id, test_workspace.id,
-        date_from=today.replace(day=1), date_to=today,
+        session,
+        account.id,
+        test_workspace.id,
+        date_from=today.replace(day=1),
+        date_to=today,
     )
     assert summary is not None
     assert summary["monthly_income"] == pytest.approx(500.0)
 
 
 @pytest.mark.asyncio
-async def test_get_account_summary_excludes_transfers(session: AsyncSession, test_user, test_workspace):
+async def test_get_account_summary_excludes_transfers(
+    session: AsyncSession, test_user, test_workspace
+):
     """Summary excludes transfer pair transactions from income/expenses."""
     account = await _make_account(session, test_user.id, "Transfer Exclude")
     today = date.today()
@@ -802,7 +927,9 @@ async def test_get_account_summary_not_found(session: AsyncSession, test_user, t
 
 
 @pytest.mark.asyncio
-async def test_get_account_summary_excludes_pending_non_cc(session: AsyncSession, test_user, test_workspace):
+async def test_get_account_summary_excludes_pending_non_cc(
+    session: AsyncSession, test_user, test_workspace
+):
     """Non-CC manual accounts exclude pending from current_balance.
 
     Mirrors the get_accounts behavior: credit 100 posted + debit 20 pending →
@@ -821,14 +948,21 @@ async def test_get_account_summary_excludes_pending_non_cc(session: AsyncSession
 
 
 @pytest.mark.asyncio
-async def test_get_account_summary_keeps_pending_for_credit_card(session: AsyncSession, test_user, test_workspace):
+async def test_get_account_summary_keeps_pending_for_credit_card(
+    session: AsyncSession, test_user, test_workspace
+):
     """A card's balance is the debt owed, and an authorized purchase is
     already owed. Keeping pending out would make the balance disagree with
     the card's own bill total, which includes it."""
     account = await _make_account(session, test_user.id, "Summary CC", acc_type="credit_card")
     today = date.today()
     await _add_txn(
-        session, test_user.id, account.id, 100, "credit", today,
+        session,
+        test_user.id,
+        account.id,
+        100,
+        "credit",
+        today,
         source="opening_balance",
     )
     await _add_txn(session, test_user.id, account.id, 20, "debit", today, status="pending")
@@ -854,7 +988,10 @@ async def test_get_account_summary_opening_balance_connected_excludes_period_pen
     480 (= 780 − posted-in-period, which would leave pending counted twice).
     """
     account = await _make_account(
-        session, test_user.id, "Conn Opening", balance="780.00",
+        session,
+        test_user.id,
+        "Conn Opening",
+        balance="780.00",
         connection_id=test_connection.id,
     )
     today = date.today()
@@ -862,18 +999,25 @@ async def test_get_account_summary_opening_balance_connected_excludes_period_pen
     prev_month = (month_start - timedelta(days=1)).replace(day=1)
     await _add_txn(session, test_user.id, account.id, 500, "credit", prev_month + timedelta(days=5))
     await _add_txn(
+<<<<<<< HEAD
         session, test_user.id, account.id, 300, "credit",
         # Clamped like the pending row below: on the 1st of the month this
         # would otherwise land in the future, fall outside the period the
         # summary backs out, and leave the provider snapshot counting it.
         min(month_start + timedelta(days=2), today),
+=======
+        session, test_user.id, account.id, 300, "credit", month_start + timedelta(days=2)
+>>>>>>> 39b0973 (Refactor application functionality and configuration)
     )
     pending_day = min(month_start + timedelta(days=4), today)
     await _add_txn(session, test_user.id, account.id, 20, "debit", pending_day, status="pending")
 
     summary = await get_account_summary(
-        session, account.id, test_workspace.id,
-        date_from=month_start, date_to=today,
+        session,
+        account.id,
+        test_workspace.id,
+        date_from=month_start,
+        date_to=today,
     )
     assert summary is not None
     assert summary["current_balance"] == pytest.approx(780.0)
@@ -893,13 +1037,17 @@ async def test_get_account_summary_connected_keeps_recurring_pending_in_the_walk
     projected balance ignored it.
     """
     account = await _make_account(
-        session, test_user.id, "Conn Recurring", balance="780.00",
+        session,
+        test_user.id,
+        "Conn Recurring",
+        balance="780.00",
         connection_id=test_connection.id,
     )
     today = date.today()
     month_start = today.replace(day=1)
     prev_month = (month_start - timedelta(days=1)).replace(day=1)
     await _add_txn(session, test_user.id, account.id, 500, "credit", prev_month + timedelta(days=5))
+<<<<<<< HEAD
     await _add_txn(
         session, test_user.id, account.id, 300, "credit",
         # Clamped like the pending row below: on the 1st of the month this
@@ -907,15 +1055,28 @@ async def test_get_account_summary_connected_keeps_recurring_pending_in_the_walk
         # summary backs out, and leave the provider snapshot counting it.
         min(month_start + timedelta(days=2), today),
     )
+=======
+>>>>>>> 39b0973 (Refactor application functionality and configuration)
     await _add_txn(
-        session, test_user.id, account.id, 20, "debit",
+        session, test_user.id, account.id, 300, "credit", month_start + timedelta(days=2)
+    )
+    await _add_txn(
+        session,
+        test_user.id,
+        account.id,
+        20,
+        "debit",
         min(month_start + timedelta(days=4), today),
-        source="recurring", status="pending",
+        source="recurring",
+        status="pending",
     )
 
     summary = await get_account_summary(
-        session, account.id, test_workspace.id,
-        date_from=month_start, date_to=today,
+        session,
+        account.id,
+        test_workspace.id,
+        date_from=month_start,
+        date_to=today,
     )
     assert summary is not None
     # The provider snapshot is untouched.
@@ -933,13 +1094,17 @@ async def test_get_account_summary_connected_excludes_future_rows_from_opening_b
 ):
     """Future-dated rows remain projections and do not shift today's opening."""
     account = await _make_account(
-        session, test_user.id, "Conn Future Rows", balance="780.00",
+        session,
+        test_user.id,
+        "Conn Future Rows",
+        balance="780.00",
         connection_id=test_connection.id,
     )
     today = date.today()
     month_start = today.replace(day=1)
     prev_month = (month_start - timedelta(days=1)).replace(day=1)
     await _add_txn(session, test_user.id, account.id, 500, "credit", prev_month + timedelta(days=5))
+<<<<<<< HEAD
     await _add_txn(
         session, test_user.id, account.id, 300, "credit",
         # Clamped like the pending row below: on the 1st of the month this
@@ -947,18 +1112,35 @@ async def test_get_account_summary_connected_excludes_future_rows_from_opening_b
         # summary backs out, and leave the provider snapshot counting it.
         min(month_start + timedelta(days=2), today),
     )
+=======
+>>>>>>> 39b0973 (Refactor application functionality and configuration)
     await _add_txn(
-        session, test_user.id, account.id, 20, "debit",
-        min(month_start + timedelta(days=4), today), status="pending",
+        session, test_user.id, account.id, 300, "credit", month_start + timedelta(days=2)
     )
     await _add_txn(
-        session, test_user.id, account.id, 1000, "credit",
+        session,
+        test_user.id,
+        account.id,
+        20,
+        "debit",
+        min(month_start + timedelta(days=4), today),
+        status="pending",
+    )
+    await _add_txn(
+        session,
+        test_user.id,
+        account.id,
+        1000,
+        "credit",
         today + timedelta(days=10),
     )
 
     summary = await get_account_summary(
-        session, account.id, test_workspace.id,
-        date_from=month_start, date_to=today,
+        session,
+        account.id,
+        test_workspace.id,
+        date_from=month_start,
+        date_to=today,
     )
 
     assert summary is not None
@@ -971,18 +1153,24 @@ async def test_sync_opening_balance_ignores_future_and_ignored_rows(
 ):
     """Provider reconciliation uses only active rows dated through today."""
     account = await _make_account(
-        session, test_user.id, "Sync Future Rows", balance="600.00",
+        session,
+        test_user.id,
+        "Sync Future Rows",
+        balance="600.00",
         connection_id=test_connection.id,
     )
     today = date.today()
     await _add_txn(session, test_user.id, account.id, 500, "credit", today - timedelta(days=5))
     await _add_txn(session, test_user.id, account.id, 1000, "credit", today + timedelta(days=10))
-    ignored = await _add_txn(session, test_user.id, account.id, 75, "debit", today - timedelta(days=2))
+    ignored = await _add_txn(
+        session, test_user.id, account.id, 75, "debit", today - timedelta(days=2)
+    )
     ignored.is_ignored = True
     await session.commit()
 
     await sync_opening_balance_for_connected_account(session, account)
     from sqlalchemy import select
+
     result = await session.execute(
         select(Transaction).where(
             Transaction.account_id == account.id,
@@ -993,6 +1181,97 @@ async def test_sync_opening_balance_ignores_future_and_ignored_rows(
 
     assert opening.type == "credit"
     assert opening.amount == Decimal("100.00")
+
+
+@pytest.mark.asyncio
+async def test_credit_card_booked_credit_reconciles_without_opening_balance(
+    session, test_user, test_workspace, test_connection
+):
+    account = await _make_account(
+        session,
+        test_user.id,
+        "Card credit",
+        acc_type="credit_card",
+        balance="-2.23",
+        connection_id=test_connection.id,
+    )
+    today = date.today()
+    await _add_txn(session, test_user.id, account.id, 15, "credit", today)
+    await _add_txn(session, test_user.id, account.id, 6, "debit", today)
+    await _add_txn(session, test_user.id, account.id, 4.27, "debit", today)
+    await _add_txn(session, test_user.id, account.id, 2.50, "debit", today)
+    await _add_txn(session, test_user.id, account.id, 10, "debit", today, status="pending")
+    await _add_txn(session, test_user.id, account.id, 4.27, "debit", today, status="pending")
+
+    await sync_opening_balance_for_connected_account(session, account)
+
+    result = await session.execute(
+        select(Transaction).where(
+            Transaction.account_id == account.id,
+            Transaction.source == "opening_balance",
+        )
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_credit_card_incomplete_history_reconciles_to_booked_debt(
+    session, test_user, test_workspace, test_connection
+):
+    account = await _make_account(
+        session,
+        test_user.id,
+        "Card debt",
+        acc_type="credit_card",
+        balance="100.00",
+        connection_id=test_connection.id,
+    )
+    await _add_txn(session, test_user.id, account.id, 60, "debit", date.today())
+
+    await sync_opening_balance_for_connected_account(session, account)
+
+    result = await session.execute(
+        select(Transaction).where(
+            Transaction.account_id == account.id,
+            Transaction.source == "opening_balance",
+        )
+    )
+    opening = result.scalar_one()
+    assert opening.type == "debit"
+    assert opening.amount == Decimal("40.00")
+
+
+@pytest.mark.parametrize(
+    ("booked_balance", "expected"),
+    [
+        (Decimal("100.00"), Decimal("1900.00")),
+        (Decimal("0.00"), Decimal("2000.00")),
+        (Decimal("-2.23"), Decimal("2002.23")),
+    ],
+)
+def test_available_credit_fallback_uses_positive_debt_invariant(booked_balance, expected):
+    assert compute_available_credit(Decimal("2000.00"), booked_balance) == expected
+
+
+def test_serialize_account_prefers_provider_available_credit(test_user):
+    account = Account(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        connection_id=uuid.uuid4(),
+        name="Card",
+        type="credit_card",
+        balance=Decimal("-2.23"),
+        expected_balance=Decimal("12.04"),
+        available_credit=Decimal("1987.96"),
+        credit_limit=Decimal("2000.00"),
+        currency="EUR",
+    )
+
+    payload = serialize_account(account, None, None)
+
+    assert payload["current_balance"] == pytest.approx(2.23)
+    assert payload["expected_balance"] == pytest.approx(-12.04)
+    assert payload["available_credit"] == pytest.approx(1987.96)
 
 
 # ---------------------------------------------------------------------------
@@ -1006,12 +1285,25 @@ async def test_get_account_balance_history(session: AsyncSession, test_user, tes
     account = await _make_account(session, test_user.id, "History Test")
     today = date.today()
 
-    await _add_txn(session, test_user.id, account.id, 1000, "credit", today.replace(day=1), source="opening_balance")
-    await _add_txn(session, test_user.id, account.id, 200, "debit", today.replace(day=min(5, today.day)))
+    await _add_txn(
+        session,
+        test_user.id,
+        account.id,
+        1000,
+        "credit",
+        today.replace(day=1),
+        source="opening_balance",
+    )
+    await _add_txn(
+        session, test_user.id, account.id, 200, "debit", today.replace(day=min(5, today.day))
+    )
 
     history = await get_account_balance_history(
-        session, account.id, test_workspace.id,
-        date_from=today.replace(day=1), date_to=today,
+        session,
+        account.id,
+        test_workspace.id,
+        date_from=today.replace(day=1),
+        date_to=today,
     )
     assert history is not None
     assert len(history) > 0
@@ -1021,17 +1313,23 @@ async def test_get_account_balance_history(session: AsyncSession, test_user, tes
 
 
 @pytest.mark.asyncio
-async def test_get_account_balance_history_not_found(session: AsyncSession, test_user, test_workspace):
+async def test_get_account_balance_history_not_found(
+    session: AsyncSession, test_user, test_workspace
+):
     """Balance history for nonexistent account returns None."""
     result = await get_account_balance_history(session, uuid.uuid4(), test_workspace.id)
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_get_account_balance_history_default_dates(session: AsyncSession, test_user, test_workspace):
+async def test_get_account_balance_history_default_dates(
+    session: AsyncSession, test_user, test_workspace
+):
     """Balance history uses current month if no dates provided."""
     account = await _make_account(session, test_user.id, "Default Dates")
-    await _add_txn(session, test_user.id, account.id, 1000, "credit", date.today(), source="opening_balance")
+    await _add_txn(
+        session, test_user.id, account.id, 1000, "credit", date.today(), source="opening_balance"
+    )
 
     history = await get_account_balance_history(session, account.id, test_workspace.id)
     assert history is not None
@@ -1040,20 +1338,30 @@ async def test_get_account_balance_history_default_dates(session: AsyncSession, 
 
 @pytest.mark.asyncio
 async def test_get_account_balance_history_credit_card_negated(
-    session: AsyncSession, test_user, test_workspace, test_connection,
+    session: AsyncSession,
+    test_user,
+    test_workspace,
+    test_connection,
 ):
     """Balance history for bank-connected credit_card applies sign negation."""
     account = await _make_account(
-        session, test_user.id, "CC History",
-        acc_type="credit_card", balance="1000.00",
-        connection_id=test_connection.id, external_id="ext-cc-hist",
+        session,
+        test_user.id,
+        "CC History",
+        acc_type="credit_card",
+        balance="1000.00",
+        connection_id=test_connection.id,
+        external_id="ext-cc-hist",
     )
     today = date.today()
     await _add_txn(session, test_user.id, account.id, 500, "debit", today)
 
     history = await get_account_balance_history(
-        session, account.id, test_workspace.id,
-        date_from=today, date_to=today,
+        session,
+        account.id,
+        test_workspace.id,
+        date_from=today,
+        date_to=today,
     )
     assert history is not None
     assert len(history) == 1
@@ -1068,15 +1376,22 @@ async def test_get_account_balance_history_credit_card_negated(
 
 
 async def _make_provider_connection(
-    session: AsyncSession, user_id: uuid.UUID, provider: str,
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    provider: str,
 ) -> "uuid.UUID":
     from datetime import datetime, timezone
     from app.models.bank_connection import BankConnection
+
     conn = BankConnection(
-        id=uuid.uuid4(), user_id=user_id, provider=provider,
+        id=uuid.uuid4(),
+        user_id=user_id,
+        provider=provider,
         external_id=f"ext-{provider}-{uuid.uuid4().hex[:8]}",
-        institution_name=f"{provider} bank", credentials={"token": "fake"},
-        status="active", last_sync_at=datetime.now(timezone.utc),
+        institution_name=f"{provider} bank",
+        credentials={"token": "fake"},
+        status="active",
+        last_sync_at=datetime.now(timezone.utc),
         created_at=datetime.now(timezone.utc),
     )
     session.add(conn)
@@ -1094,16 +1409,16 @@ def test_simplefin_to_internal_balance_flips_card():
 
 def test_simplefin_to_internal_balance_checking_unchanged():
     """A SimpleFIN non-card balance is already in the right convention."""
-    assert _simplefin_to_internal_balance(
-        "simplefin", "checking", Decimal("1500.00")
-    ) == Decimal("1500.00")
+    assert _simplefin_to_internal_balance("simplefin", "checking", Decimal("1500.00")) == Decimal(
+        "1500.00"
+    )
 
 
 def test_simplefin_to_internal_balance_other_provider_unchanged():
     """Pluggy/Enable already use positive-for-debt — never flip their cards."""
-    assert _simplefin_to_internal_balance(
-        "pluggy", "credit_card", Decimal("500.00")
-    ) == Decimal("500.00")
+    assert _simplefin_to_internal_balance("pluggy", "credit_card", Decimal("500.00")) == Decimal(
+        "500.00"
+    )
     assert _simplefin_to_internal_balance(
         "enable_banking", "credit_card", Decimal("500.00")
     ) == Decimal("500.00")
@@ -1111,7 +1426,9 @@ def test_simplefin_to_internal_balance_other_provider_unchanged():
 
 @pytest.mark.asyncio
 async def test_update_simplefin_account_to_credit_card_flips_balance(
-    session: AsyncSession, test_user, test_workspace,
+    session: AsyncSession,
+    test_user,
+    test_workspace,
 ):
     """Decisive case: a SimpleFIN account stores debt as a negative balance under
     type="checking". When the user overrides the type to credit_card, the stored
@@ -1120,8 +1437,13 @@ async def test_update_simplefin_account_to_credit_card_flips_balance(
     the flip the card double-counts in net worth (≈2x the debt)."""
     conn_id = await _make_provider_connection(session, test_user.id, "simplefin")
     account = await _make_account(
-        session, test_user.id, "SimpleFIN Card", acc_type="checking",
-        balance="-500.00", connection_id=conn_id, external_id="sf-card-1",
+        session,
+        test_user.id,
+        "SimpleFIN Card",
+        acc_type="checking",
+        balance="-500.00",
+        connection_id=conn_id,
+        external_id="sf-card-1",
     )
 
     updated = await update_account(
@@ -1138,15 +1460,22 @@ async def test_update_simplefin_account_to_credit_card_flips_balance(
 
 @pytest.mark.asyncio
 async def test_update_simplefin_account_away_from_credit_card_flips_back(
-    session: AsyncSession, test_user, test_workspace,
+    session: AsyncSession,
+    test_user,
+    test_workspace,
 ):
     """Reverse direction: moving a SimpleFIN card back to a non-card type must
     flip the stored balance back to the raw provider sign so it stays
     consistent with a fresh sync (which writes the raw negative value)."""
     conn_id = await _make_provider_connection(session, test_user.id, "simplefin")
     account = await _make_account(
-        session, test_user.id, "SimpleFIN WasCard", acc_type="credit_card",
-        balance="500.00", connection_id=conn_id, external_id="sf-card-2",
+        session,
+        test_user.id,
+        "SimpleFIN WasCard",
+        acc_type="credit_card",
+        balance="500.00",
+        connection_id=conn_id,
+        external_id="sf-card-2",
     )
 
     updated = await update_account(
@@ -1159,14 +1488,21 @@ async def test_update_simplefin_account_away_from_credit_card_flips_back(
 
 @pytest.mark.asyncio
 async def test_update_pluggy_account_to_credit_card_does_not_flip(
-    session: AsyncSession, test_user, test_workspace,
+    session: AsyncSession,
+    test_user,
+    test_workspace,
 ):
     """No double-count for non-SimpleFIN providers: a Pluggy account already
     uses positive-for-debt, so a type edit must NOT touch the stored balance."""
     conn_id = await _make_provider_connection(session, test_user.id, "pluggy")
     account = await _make_account(
-        session, test_user.id, "Pluggy Card", acc_type="checking",
-        balance="500.00", connection_id=conn_id, external_id="pl-card-1",
+        session,
+        test_user.id,
+        "Pluggy Card",
+        acc_type="checking",
+        balance="500.00",
+        connection_id=conn_id,
+        external_id="pl-card-1",
     )
 
     updated = await update_account(
@@ -1182,14 +1518,21 @@ async def test_update_pluggy_account_to_credit_card_does_not_flip(
 
 @pytest.mark.asyncio
 async def test_update_simplefin_type_change_not_crossing_card_keeps_balance(
-    session: AsyncSession, test_user, test_workspace,
+    session: AsyncSession,
+    test_user,
+    test_workspace,
 ):
     """A SimpleFIN type edit that doesn't cross the credit_card boundary (e.g.
     checking → savings) must leave the stored balance alone."""
     conn_id = await _make_provider_connection(session, test_user.id, "simplefin")
     account = await _make_account(
-        session, test_user.id, "SimpleFIN Savings", acc_type="checking",
-        balance="1500.00", connection_id=conn_id, external_id="sf-sav-1",
+        session,
+        test_user.id,
+        "SimpleFIN Savings",
+        acc_type="checking",
+        balance="1500.00",
+        connection_id=conn_id,
+        external_id="sf-sav-1",
     )
 
     updated = await update_account(
@@ -1307,15 +1650,21 @@ def _hint(name, logo=None, ext=None):
     from app.providers.base import AccountData
 
     return AccountData(
-        external_id="x", name="A", type="checking",
-        balance=Decimal("0"), currency="USD",
-        institution_external_id=ext, institution_name=name, institution_logo_url=logo,
+        external_id="x",
+        name="A",
+        type="checking",
+        balance=Decimal("0"),
+        currency="USD",
+        institution_external_id=ext,
+        institution_name=name,
+        institution_logo_url=logo,
     )
 
 
 @pytest.mark.asyncio
 async def test_resolve_institution_matches_by_org_id_across_renames(
-    session: AsyncSession, test_user,
+    session: AsyncSession,
+    test_user,
 ):
     """A bank renamed on the provider side updates its row in place — same id,
     new name — instead of minting a new row (review on #654)."""
@@ -1340,7 +1689,8 @@ async def test_resolve_institution_matches_by_org_id_across_renames(
 
 @pytest.mark.asyncio
 async def test_resolve_institution_adopts_legacy_name_row(
-    session: AsyncSession, test_user,
+    session: AsyncSession,
+    test_user,
 ):
     """A row created before the server sent org ids is adopted by the first
     id-carrying hint with the same name, keeping its accounts attached."""
@@ -1358,7 +1708,8 @@ async def test_resolve_institution_adopts_legacy_name_row(
 
 @pytest.mark.asyncio
 async def test_resolve_institution_same_name_different_orgs_stay_distinct(
-    session: AsyncSession, test_user,
+    session: AsyncSession,
+    test_user,
 ):
     """Two logins at the same bank (same display name, different org ids)
     must not collapse into one row."""

--- a/backend/tests/test_account_service.py
+++ b/backend/tests/test_account_service.py
@@ -999,15 +999,11 @@ async def test_get_account_summary_opening_balance_connected_excludes_period_pen
     prev_month = (month_start - timedelta(days=1)).replace(day=1)
     await _add_txn(session, test_user.id, account.id, 500, "credit", prev_month + timedelta(days=5))
     await _add_txn(
-<<<<<<< HEAD
         session, test_user.id, account.id, 300, "credit",
         # Clamped like the pending row below: on the 1st of the month this
         # would otherwise land in the future, fall outside the period the
         # summary backs out, and leave the provider snapshot counting it.
         min(month_start + timedelta(days=2), today),
-=======
-        session, test_user.id, account.id, 300, "credit", month_start + timedelta(days=2)
->>>>>>> 39b0973 (Refactor application functionality and configuration)
     )
     pending_day = min(month_start + timedelta(days=4), today)
     await _add_txn(session, test_user.id, account.id, 20, "debit", pending_day, status="pending")
@@ -1047,7 +1043,6 @@ async def test_get_account_summary_connected_keeps_recurring_pending_in_the_walk
     month_start = today.replace(day=1)
     prev_month = (month_start - timedelta(days=1)).replace(day=1)
     await _add_txn(session, test_user.id, account.id, 500, "credit", prev_month + timedelta(days=5))
-<<<<<<< HEAD
     await _add_txn(
         session, test_user.id, account.id, 300, "credit",
         # Clamped like the pending row below: on the 1st of the month this
@@ -1055,8 +1050,6 @@ async def test_get_account_summary_connected_keeps_recurring_pending_in_the_walk
         # summary backs out, and leave the provider snapshot counting it.
         min(month_start + timedelta(days=2), today),
     )
-=======
->>>>>>> 39b0973 (Refactor application functionality and configuration)
     await _add_txn(
         session, test_user.id, account.id, 300, "credit", month_start + timedelta(days=2)
     )
@@ -1104,7 +1097,6 @@ async def test_get_account_summary_connected_excludes_future_rows_from_opening_b
     month_start = today.replace(day=1)
     prev_month = (month_start - timedelta(days=1)).replace(day=1)
     await _add_txn(session, test_user.id, account.id, 500, "credit", prev_month + timedelta(days=5))
-<<<<<<< HEAD
     await _add_txn(
         session, test_user.id, account.id, 300, "credit",
         # Clamped like the pending row below: on the 1st of the month this
@@ -1112,8 +1104,6 @@ async def test_get_account_summary_connected_excludes_future_rows_from_opening_b
         # summary backs out, and leave the provider snapshot counting it.
         min(month_start + timedelta(days=2), today),
     )
-=======
->>>>>>> 39b0973 (Refactor application functionality and configuration)
     await _add_txn(
         session, test_user.id, account.id, 300, "credit", month_start + timedelta(days=2)
     )

--- a/backend/tests/test_providers_enable_banking.py
+++ b/backend/tests/test_providers_enable_banking.py
@@ -4,11 +4,12 @@ Covers: JWT signing/claims, transaction fingerprint stability, account-type
 mapping, nested vs flat transaction page shapes, restricted-mode handling.
 HTTP is mocked end-to-end via httpx.MockTransport.
 """
+
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -37,10 +38,14 @@ def _rsa_pem() -> tuple[str, str]:
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     ).decode("utf-8")
-    public_pem = key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode("utf-8")
+    public_pem = (
+        key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
     return private_pem, public_pem
 
 
@@ -75,9 +80,7 @@ def test_jwt_token_has_expected_claims_and_kid(eb_keys):
     assert header["kid"] == "test-app-id-123"
     assert header["typ"] == "JWT"
 
-    claims = jwt.decode(
-        token, public_pem, algorithms=["RS256"], audience="api.enablebanking.com"
-    )
+    claims = jwt.decode(token, public_pem, algorithms=["RS256"], audience="api.enablebanking.com")
     assert claims["iss"] == "enablebanking.com"
     assert claims["aud"] == "api.enablebanking.com"
     assert isinstance(claims["iat"], int)
@@ -225,9 +228,7 @@ async def test_get_oauth_url_returns_consent_url(eb_keys):
 async def test_get_oauth_url_rejects_missing_flow_params(eb_keys):
     provider = EnableBankingProvider()
     with pytest.raises(ValueError):
-        await provider.get_oauth_url(
-            "https://x/cb", "s", flow_params={"country": "DE"}
-        )
+        await provider.get_oauth_url("https://x/cb", "s", flow_params={"country": "DE"})
 
 
 @pytest.mark.asyncio
@@ -305,6 +306,70 @@ async def test_handle_oauth_callback_builds_connection_data(eb_keys):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("closing_booked", "expected_internal"),
+    [
+        ("-100.00", Decimal("100.00")),
+        ("0.00", Decimal("0.00")),
+        ("2.23", Decimal("-2.23")),
+    ],
+)
+async def test_credit_card_booked_balance_is_normalized(closing_booked, expected_internal):
+    provider = EnableBankingProvider()
+    provider._request = AsyncMock(
+        return_value={
+            "balances": [
+                {
+                    "balance_type": "CLBD",
+                    "balance_amount": {
+                        "amount": closing_booked,
+                        "currency": "EUR",
+                    },
+                }
+            ]
+        }
+    )
+
+    account = await provider._build_account(
+        {"uid": "card-1", "cash_account_type": "CARD", "currency": "EUR"}
+    )
+
+    assert account.balance == expected_internal
+
+
+@pytest.mark.asyncio
+async def test_credit_card_balance_types_remain_distinct():
+    """Sanitized regression payload: booked credit plus pending card spend."""
+    provider = EnableBankingProvider()
+    provider._request = AsyncMock(
+        return_value={
+            "balances": [
+                {
+                    "balance_type": "CLBD",
+                    "balance_amount": {"amount": "2.23", "currency": "EUR"},
+                },
+                {
+                    "balance_type": "XPCD",
+                    "balance_amount": {"amount": "-12.04", "currency": "EUR"},
+                },
+                {
+                    "balance_type": "ITAV",
+                    "balance_amount": {"amount": "1987.96", "currency": "EUR"},
+                },
+            ]
+        }
+    )
+
+    account = await provider._build_account(
+        {"uid": "card-1", "cash_account_type": "CARD", "currency": "EUR"}
+    )
+
+    assert account.balance == Decimal("-2.23")
+    assert account.expected_balance == Decimal("12.04")
+    assert account.available_credit == Decimal("1987.96")
+
+
+@pytest.mark.asyncio
 async def test_get_transactions_parses_nested_and_flat_shapes(eb_keys):
     """Both `transactions:{booked,pending}` and flat list must produce the
     same internal TransactionData list."""
@@ -337,7 +402,11 @@ async def test_get_transactions_parses_nested_and_flat_shapes(eb_keys):
         assert request.url.path == "/accounts/acc-1/transactions"
         return httpx.Response(200, json=nested_page)
 
-    credentials = {"session_id_enc": None, "session_id": "sess-x", "valid_until": "2099-01-01T00:00:00Z"}
+    credentials = {
+        "session_id_enc": None,
+        "session_id": "sess-x",
+        "valid_until": "2099-01-01T00:00:00Z",
+    }
     with _patch_client(provider, handler):
         nested = await provider.get_transactions(credentials, "acc-1", date(2026, 5, 1))
 
@@ -407,9 +476,7 @@ async def test_get_transactions_stops_on_repeated_continuation_key(eb_keys, capl
         "valid_until": "2099-01-01T00:00:00Z",
     }
     with _patch_client(provider, handler), caplog.at_level("WARNING"):
-        transactions = await provider.get_transactions(
-            credentials, "acc-1", date(2026, 5, 1)
-        )
+        transactions = await provider.get_transactions(credentials, "acc-1", date(2026, 5, 1))
 
     assert len(requests) == 2
     assert requests[0].url.params.get("continuation_key") is None
@@ -421,9 +488,7 @@ async def test_get_transactions_stops_on_repeated_continuation_key(eb_keys, capl
 @pytest.mark.asyncio
 async def test_refresh_credentials_expired_raises(eb_keys):
     provider = EnableBankingProvider()
-    expired = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat().replace(
-        "+00:00", "Z"
-    )
+    expired = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
     with pytest.raises(SessionExpiredError):
         await provider.refresh_credentials({"valid_until": expired})
 
@@ -431,9 +496,7 @@ async def test_refresh_credentials_expired_raises(eb_keys):
 @pytest.mark.asyncio
 async def test_refresh_credentials_valid_passes(eb_keys):
     provider = EnableBankingProvider()
-    future = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat().replace(
-        "+00:00", "Z"
-    )
+    future = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat().replace("+00:00", "Z")
     creds = {"valid_until": future, "session_id_enc": "enc"}
     out = await provider.refresh_credentials(creds)
     assert out is creds

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -164,6 +164,7 @@ export interface Account {
   current_balance: number
   previous_balance: number | null
   balance_primary: number | null
+  expected_balance: number | null
   currency: string
   credit_limit: number | null
   available_credit: number | null


### PR DESCRIPTION
## What
Fix Enable Banking credit-card balance handling by preserving the different ISO 20022 balance semantics instead of collapsing them into a single generic value.
- Treat `CLBD`/`OPBD` as the booked card balance.
- Preserve `XPCD` separately as the expected balance, which may include pending transactions.
- Preserve `ITAV`/`CLAV`/`OPAV` separately as provider-reported available credit.
- Normalize Enable Banking card balances at the provider boundary to Securo's internal convention: positive values represent debt and negative values represent card credit or overpayment.
- Persist `expected_balance` and `available_credit` on connected credit-card accounts and expose the expected balance through the account API.
- Prefer provider-reported available credit and only fall back to `credit_limit - booked_balance` when the provider does not supply it.
- Reconcile connected credit-card opening balances against booked transactions only, excluding pending transactions from a booked-balance target.
- Add migration `085` to create the snapshot columns and normalize existing Enable Banking credit-card balances once.
- Keep the existing generic balance selection for non-credit-card accounts and avoid changing Pluggy and SimpleFIN balance behavior.
## Why
Enable Banking may return booked, expected, and available balances for the same credit-card account, but these values have different meanings. Previously Securo discarded that distinction and applied credit-card sign conversion in multiple downstream locations.
This could invert the displayed balance incorrectly, generate a synthetic opening-balance transaction even when the imported booked transactions already reconciled, and calculate available credit from the wrong balance. Keeping the snapshots separate and normalizing the sign once gives account summaries, utilization, available credit, and opening reconciliation a consistent source of truth.
## How to Test
1. Start from a database at migration `084` and run `alembic upgrade head`; verify that `expected_balance` and `available_credit` are added to `accounts` and Alembic reports `085` as the single head.
2. Connect or mock an Enable Banking credit card that returns `CLBD`, `XPCD`, and `ITAV` balances.
3. Verify that a provider booked balance of `-150.00` is stored as `150.00` debt, `0.00` remains zero, and `25.00` provider credit is stored as `-25.00` card credit.
4. Verify that `XPCD` is stored separately as the expected balance and that `ITAV`/`CLAV` is preserved as an absolute available-credit value without sign inversion.
5. Verify that the account API displays the normalized credit-card balance and expected balance using the existing connected-card display convention.
6. Set a credit limit and confirm that provider-reported available credit takes precedence over the calculated fallback.
7. Remove the provider-reported available-credit snapshot and verify the fallback for debt, zero balance, and card credit using `credit_limit - booked_balance`.
8. Import booked transactions whose signed total exactly matches `CLBD`; verify that no synthetic opening-balance transaction is created.
9. Add pending transactions alongside the booked transactions and verify that they do not affect reconciliation against `CLBD`, while `XPCD` can still represent the expected balance including those pending entries.
10. Verify that incomplete booked history creates only the required opening-balance adjustment.
11. Sync checking and savings accounts through Enable Banking and verify that their existing balance-selection behavior is unchanged.
12. Run the targeted backend tests:
    ```bash
    cd backend
    pytest -q tests/test_migration_chain.py tests/test_providers_enable_banking.py tests/test_account_service.py
    ```
13. Run the frontend checks:
    ```bash
    cd frontend
    npm run lint
    npm run build
    ```
## Related Issue
Closes #800 ([Enable Banking credit-card balances, available credit, and opening reconciliation use inconsistent semantics](https://github.com/securo-finance/securo/issues/800)).
## Checklist
- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
- [ ] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))