### PR TITLE
chore(ci): drop the decimal once the download count outgrows it

### DIFF
--- a/.github/workflows/downloads-badge.yml
+++ b/.github/workflows/downloads-badge.yml
@@ -28,11 +28,18 @@ jobs:
           # Both images are required to run Securo, so the smaller count is
           # the closest proxy for real installs.
           min=$(( backend < frontend ? backend : frontend ))
-          if [ "$min" -ge 1000 ]; then
-            pretty=$(awk -v n="$min" 'BEGIN { printf "%.1fk", n / 1000 }')
-          else
-            pretty=$min
-          fi
+          # Keep the decimal only while it still says something: 1.2k reads
+          # better than 1k, and 101k better than 100.8k.
+          pretty=$(awk -v n="$min" 'BEGIN {
+            if (n < 1000) { out = sprintf("%d", n) }
+            else {
+              k = n / 1000
+              out = (k < 10) ? sprintf("%.1f", k) : sprintf("%.0f", k)
+              sub(/\.0$/, "", out)
+              out = out "k"
+            }
+            printf "%s", out
+          }')
           echo "Backend: $backend, Frontend: $frontend, Badge: $pretty"
           echo "count=$pretty" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
The downloads badge formatted every count above a thousand as `%.1fk`, so it now reads `100.8k`. Past ten thousand the tenths place stops carrying information.

New rule: one decimal below 10k, whole thousands above it, trailing `.0` trimmed.

| downloads | before | after |
|---|---|---|
| 743 | `743` | `743` |
| 1,000 | `1.0k` | `1k` |
| 1,240 | `1.2k` | `1.2k` |
| 9,949 | `9.9k` | `9.9k` |
| 10,400 | `10.4k` | `10k` |
| 100,800 | `100.8k` | `101k` |

The badge only refreshes on the daily 05:17 UTC run (or a manual dispatch from `main`) after this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates download badge formatting to use decimals below 10,000 and whole thousands above 10,000. It also removes trailing `.0` values.

- Counts below 1,000 stay as whole numbers.
- Counts from 1,000 to 9,999 use one decimal.
- Counts above 10,000 use whole thousands without trailing `.0`.

Risk: none of database migration, auth, money math, or sync provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->