### PR TITLE
fix(tests): pin the invoice suite to its own clock

### DIFF
--- a/backend/tests/test_invoice_service.py
+++ b/backend/tests/test_invoice_service.py
@@ -204,7 +204,16 @@ async def credit(session: AsyncSession, workspace, test_user) -> Transaction:
 
 
 async def create(session, workspace, user, **data):
-    payload = {"total": Decimal("1000.00"), "due_date": TODAY + timedelta(days=10)}
+    # `issue_date` is pinned to the module's TODAY rather than left to
+    # `create_invoice`'s wall-clock default. Without it the helper builds a
+    # due date from a frozen TODAY while the service stamps the real date, so
+    # every test here starts failing on its own once real time passes
+    # TODAY + 10 days, for no reason to do with the ledger.
+    payload = {
+        "total": Decimal("1000.00"),
+        "issue_date": TODAY,
+        "due_date": TODAY + timedelta(days=10),
+    }
     payload.update(data)
     invoice = await svc.create_invoice(session, workspace.id, user.id, payload)
     await session.commit()


### PR DESCRIPTION
Every test in `test_invoice_service.py` is red on a clean `main` since 2026-09-06, for reasons unrelated to anything they test.

The module freezes `TODAY` at 2026-08-26 and the `create` helper builds `due_date = TODAY + 10 days`, but `create_invoice` stamps `issue_date` from the wall clock when the caller does not pass one. Once the real date overtook that due date, every invoice the helper builds is rejected with `due_before_issue` before the test asserts anything. All 14 failures share that single cause.

Same class as #777 and #799, different mechanism: those drifted out of a window on one day of the month, this one crossed a fixed date and stays broken.

Pinning `issue_date` to `TODAY` alongside the due date removes the last wall-clock dependency in the module. Tests that set their own `issue_date`, such as the aging buckets, still override it.

Verified by moving `TODAY` to 2019 and to 2031: 32 pass in both, where before it only passed while the real date trailed the constant.

```
before: 14 failed, 18 passed
after:  32 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Invoice tests now use the fixed `TODAY` value for `issue_date`, which prevents date-dependent rejection before assertions run. Caller-provided issue dates still override the default.

- Invoice test dates remain stable as the calendar date changes.
- Custom issue dates continue to work.

Risk: none of these areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->