### PR TITLE
fix(transaction-drill-down): keep projections inside the total shown

### DIFF
--- a/frontend/src/components/transaction-drill-down.tsx
+++ b/frontend/src/components/transaction-drill-down.tsx
@@ -180,7 +180,11 @@ export function TransactionDrillDown({
   const { absTotal, postedTotal, pendingTotal, projectedTotal } =
     sumDrillDownTotals(displayItems, userCurrency)
 
-  const hasPendingTransactions = displayItems.some((item) => item.isPending)
+  // Break the total down whenever some of it is money that has not settled,
+  // whether it is pending or still only projected. Gating on pending alone
+  // hid the projected line from a panel that happened to have no pending row,
+  // even though the total it sits under already counted the projection.
+  const hasUnsettledTotal = pendingTotal > 0 || projectedTotal > 0
 
   return (
     <>
@@ -302,7 +306,7 @@ export function TransactionDrillDown({
         {/* Footer */}
         {displayItems.length > 0 && (
           <div className="px-5 py-3 border-t border-border bg-muted/50 shrink-0">
-            {hasPendingTransactions ? (
+            {hasUnsettledTotal ? (
               <div className="space-y-1">
                 <div className="flex items-center justify-between gap-4 text-xs text-muted-foreground">
                   <span>{t('dashboard.drillDownSettledTotal')}</span>

--- a/frontend/src/components/transaction-drill-down.tsx
+++ b/frontend/src/components/transaction-drill-down.tsx
@@ -6,6 +6,7 @@ import { transactions as transactionsApi, dashboard, admin } from '@/lib/api'
 import { AlertTriangle, Clock, Info, Paperclip, X } from 'lucide-react'
 import { CategoryIcon } from '@/components/category-icon'
 import { ProjectedTransactionBadge } from '@/components/projected-transaction-badge'
+import { sumDrillDownTotals } from '@/lib/drill-down-totals'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useAuth } from '@/contexts/auth-context'
 import { usePrivacyMode } from '@/hooks/use-privacy-mode'
@@ -176,23 +177,8 @@ export function TransactionDrillDown({
   // amount_primary; if it's missing we can't convert, so skip the row
   // instead of adding a raw foreign amount as if it were primary. This
   // matches how get_summary computes monthly_*_primary on the backend.
-  const { absTotal, postedTotal, pendingTotal } = displayItems.reduce(
-    (totals, item) => {
-      // For foreign-currency rows, skip missing conversions rather than
-      // treating the raw amount as the user's primary currency.
-      const amount = item.currency === userCurrency
-        ? Math.abs(item.amount)
-        : item.amountPrimary != null
-          ? Math.abs(item.amountPrimary)
-          : 0
-
-      totals.absTotal += amount
-      if (item.isPending) totals.pendingTotal += amount
-      if (item.transaction?.status === 'posted') totals.postedTotal += amount
-      return totals
-    },
-    { absTotal: 0, postedTotal: 0, pendingTotal: 0 },
-  )
+  const { absTotal, postedTotal, pendingTotal, projectedTotal } =
+    sumDrillDownTotals(displayItems, userCurrency)
 
   const hasPendingTransactions = displayItems.some((item) => item.isPending)
 
@@ -326,9 +312,15 @@ export function TransactionDrillDown({
                   <span>{t('dashboard.drillDownPendingTotal')}</span>
                   <span className="tabular-nums text-foreground">{mask(formatCurrency(pendingTotal, userCurrency, locale))}</span>
                 </div>
+                {projectedTotal > 0 && (
+                  <div className="flex items-center justify-between gap-4 text-xs text-muted-foreground">
+                    <span>{t('transactions.projected')}</span>
+                    <span className="tabular-nums text-foreground">{mask(formatCurrency(projectedTotal, userCurrency, locale))}</span>
+                  </div>
+                )}
                 <div className="flex items-center justify-between gap-4 border-t border-border pt-2 mt-2">
                   <span className="text-xs font-medium text-muted-foreground">{t('dashboard.drillDownShownTotal')}</span>
-                  <span className="text-sm font-bold tabular-nums text-foreground">{mask(formatCurrency(postedTotal + pendingTotal, userCurrency, locale))}</span>
+                  <span className="text-sm font-bold tabular-nums text-foreground">{mask(formatCurrency(absTotal, userCurrency, locale))}</span>
                 </div>
               </div>
             ) : (

--- a/frontend/src/lib/drill-down-totals.test.ts
+++ b/frontend/src/lib/drill-down-totals.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import { sumDrillDownTotals } from '@/lib/drill-down-totals'
+import type { DrillDownTotalsItem } from '@/lib/drill-down-totals'
+
+const row = (overrides: Partial<DrillDownTotalsItem> = {}): DrillDownTotalsItem => ({
+  amount: 100,
+  amountPrimary: null,
+  currency: 'USD',
+  isPending: false,
+  isProjected: false,
+  ...overrides,
+})
+
+describe('sumDrillDownTotals', () => {
+  it('splits rows into posted, pending and projected', () => {
+    const totals = sumDrillDownTotals([
+      row({ amount: 200 }),
+      row({ amount: 100, isPending: true }),
+      row({ amount: 487.68, isProjected: true }),
+    ], 'USD')
+
+    expect(totals.postedTotal).toBeCloseTo(200)
+    expect(totals.pendingTotal).toBeCloseTo(100)
+    expect(totals.projectedTotal).toBeCloseTo(487.68)
+    expect(totals.absTotal).toBeCloseTo(787.68)
+  })
+
+  it('keeps a projected row inside the total when the panel also has a pending one', () => {
+    // The regression: a projected row is neither posted nor pending, so
+    // bucketing it by transaction status dropped it from the footer while
+    // the list above still showed it.
+    const totals = sumDrillDownTotals([
+      row({ amount: 100, isPending: true }),
+      row({ amount: 487.68, isProjected: true }),
+    ], 'USD')
+
+    expect(totals.postedTotal + totals.pendingTotal + totals.projectedTotal)
+      .toBeCloseTo(totals.absTotal)
+    expect(totals.absTotal).toBeCloseTo(587.68)
+  })
+
+  it('never loses a row: the three buckets always rebuild the total', () => {
+    const totals = sumDrillDownTotals([
+      row({ amount: 10 }),
+      row({ amount: 20, isPending: true }),
+      row({ amount: 30, isProjected: true }),
+      row({ amount: 40, isPending: true, isProjected: true }),
+    ], 'USD')
+
+    expect(totals.postedTotal + totals.pendingTotal + totals.projectedTotal)
+      .toBeCloseTo(totals.absTotal)
+  })
+
+  it('counts a foreign row through its primary amount', () => {
+    expect(sumDrillDownTotals([
+      row({ amount: 2500, amountPrimary: 487.68, currency: 'BRL' }),
+    ], 'USD')).toMatchObject({ absTotal: 487.68, postedTotal: 487.68 })
+  })
+
+  it('skips a foreign row with no conversion rather than counting it raw', () => {
+    expect(sumDrillDownTotals([
+      row({ amount: 2500, amountPrimary: null, currency: 'BRL' }),
+    ], 'USD')).toEqual({
+      absTotal: 0,
+      postedTotal: 0,
+      pendingTotal: 0,
+      projectedTotal: 0,
+    })
+  })
+
+  it('reads amounts as magnitudes, whatever sign they arrive with', () => {
+    expect(sumDrillDownTotals([
+      row({ amount: -100 }),
+      row({ amount: 100 }),
+    ], 'USD')).toMatchObject({ absTotal: 200, postedTotal: 200 })
+  })
+
+  it('returns zeroes for an empty panel', () => {
+    expect(sumDrillDownTotals([], 'USD')).toEqual({
+      absTotal: 0,
+      postedTotal: 0,
+      pendingTotal: 0,
+      projectedTotal: 0,
+    })
+  })
+})

--- a/frontend/src/lib/drill-down-totals.ts
+++ b/frontend/src/lib/drill-down-totals.ts
@@ -1,0 +1,57 @@
+/**
+ * A drill-down row, reduced to what the footer totals need. Kept structural
+ * rather than importing the panel's DisplayItem so the arithmetic can be
+ * tested without standing up the panel.
+ */
+export type DrillDownTotalsItem = {
+  amount: number
+  amountPrimary: number | null
+  currency: string
+  isPending: boolean
+  isProjected: boolean
+}
+
+export type DrillDownTotals = {
+  absTotal: number
+  postedTotal: number
+  pendingTotal: number
+  projectedTotal: number
+}
+
+/**
+ * Split the rows the panel is showing into the buckets the footer reports.
+ *
+ * Every row lands in exactly one of posted, pending or projected, so the
+ * three always add back up to `absTotal`. That invariant is the point: the
+ * footer labels its bottom line "total shown", and a row the user can see in
+ * the list has to be inside it. Bucketing on the row's own `isPending` and
+ * `isProjected` flags, rather than on a persisted status, is what keeps
+ * projections from falling through the gaps: they have no transaction behind
+ * them, so a status test can never place them.
+ *
+ * Foreign-currency rows are converted through `amountPrimary`; when that is
+ * missing the row is skipped rather than added as if its raw amount were
+ * already in the user's currency. This matches how `get_summary` computes
+ * `monthly_*_primary` on the backend.
+ */
+export function sumDrillDownTotals(
+  items: DrillDownTotalsItem[],
+  userCurrency: string,
+): DrillDownTotals {
+  return items.reduce<DrillDownTotals>(
+    (totals, item) => {
+      const amount = item.currency === userCurrency
+        ? Math.abs(item.amount)
+        : item.amountPrimary != null
+          ? Math.abs(item.amountPrimary)
+          : 0
+
+      totals.absTotal += amount
+      if (item.isProjected) totals.projectedTotal += amount
+      else if (item.isPending) totals.pendingTotal += amount
+      else totals.postedTotal += amount
+      return totals
+    },
+    { absTotal: 0, postedTotal: 0, pendingTotal: 0, projectedTotal: 0 },
+  )
+}


### PR DESCRIPTION
The split footer added in #716 reports "total shown" as posted plus pending. A projected row is neither: it has no transaction behind it, so `transaction?.status === 'posted'` can never place it and `isPending` is false by construction. It falls into no bucket, and the bottom line drops it while the row stays visible in the list right above.

Only panels with at least one pending row are affected. Without one, the old single-total branch still totals everything.

### Moradia, September, before and after

Same panel both times: a pending charge of $19.51 and a projected rent of $487.68, both rendered in the list. The dashboard card reads **$507.19**.

| | before | after |
|---|---|---|
| Liquidado · valor da categoria | $0.00 | $0.00 |
| Pendente de liquidação | $19.51 | $19.51 |
| Prevista | not shown | $487.68 |
| **Total exibido** | **$19.51** | **$507.19** |

### What changed

The arithmetic moves to `lib/drill-down-totals.ts`, where it can be tested without standing up the panel, following `payee-sorting.ts` and `asset-profit.ts`. It buckets on the row's own flags with a final `else` rather than on a persisted status, so every row lands in exactly one bucket and the three always rebuild the total. The footer totals `absTotal` instead of a sum of parts that may not be all of them.

Projections get their own line when there are any, reusing `transactions.projected` so the label matches the `PREVISTA` badge in the list. No locale needs a new string.

7 unit tests, including the invariant that the buckets always add back up to the total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Projected transactions now count toward the transaction drill-down total. The footer separates posted, pending, and projected amounts.

- Shows projected transactions in the footer.
- Includes projected amounts in “total shown.”
- Uses amount magnitude for totals.

Risk: money math.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->