### PR TITLE
chore: release v0.15.1

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "securo-backend"
-version = "0.15.0"
+version = "0.15.1"
 description = "Securo API - Personal Finance Manager"
 requires-python = ">=3.11"
 # These ranges express intent; the resolved versions live in uv.lock, which is

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2540,7 +2540,7 @@ wheels = [
 
 [[package]]
 name = "securo-backend"
-version = "0.15.0"
+version = "0.15.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/charts/securo/Chart.yaml
+++ b/charts/securo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: securo
 description: A Helm chart for Securo Finance, an open-source personal finance application.
 type: application
-version: 0.15.0
-appVersion: "0.15.0"
+version: 0.15.1
+appVersion: "0.15.1"
 icon: https://raw.githubusercontent.com/securo-finance/securo/main/favicons/android-icon-192x192.png
 home: https://github.com/securo-finance/securo
 sources:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.90.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump for v0.15.1: `backend/pyproject.toml`, `frontend/package.json`, `charts/securo/Chart.yaml`.

After merging, publish the `v0.15.1` GitHub release targeting `main` to build and push the images.
