### PR TITLE
feat: add Pakistani rupee (PKR) currency support

### DIFF
--- a/backend/app/api/currencies.py
+++ b/backend/app/api/currencies.py
@@ -40,6 +40,7 @@ CURRENCY_META = {
     "VND": {"symbol": "₫", "name": "Vietnamese Dong", "flag": "\U0001F1FB\U0001F1F3"},
     "SGD": {"symbol": "S$", "name": "Singapore Dollar", "flag": "\U0001F1F8\U0001F1EC"},
     "TRY": {"symbol": "₺", "name": "Turkish Lira", "flag": "\U0001F1F9\U0001F1F7"},
+    "PKR": {"symbol": "₨", "name": "Pakistani Rupee", "flag": "\U0001F1F5\U0001F1F0"},
 }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -66,7 +66,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ,PHP,UAH,NZD,VND,SGD,AZN,TRY"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ,PHP,UAH,NZD,VND,SGD,AZN,TRY,PKR"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/backend/tests/test_currencies_api.py
+++ b/backend/tests/test_currencies_api.py
@@ -119,3 +119,15 @@ async def test_currencies_include_try_with_metadata(client: AsyncClient):
     assert turkish_lira["symbol"] == "₺"
     assert turkish_lira["name"] == "Turkish Lira"
     assert turkish_lira["flag"] == "🇹🇷"
+
+
+@pytest.mark.asyncio
+async def test_currencies_include_pkr_with_metadata(client: AsyncClient):
+    response = await client.get("/api/currencies")
+    data = response.json()
+    pkr = next((currency for currency in data if currency["code"] == "PKR"), None)
+
+    assert pkr is not None
+    assert pkr["symbol"] == "₨"
+    assert pkr["name"] == "Pakistani Rupee"
+    assert pkr["flag"] == "🇵🇰"

--- a/frontend/src/components/currency-select.tsx
+++ b/frontend/src/components/currency-select.tsx
@@ -42,6 +42,7 @@ export const CURRENCIES = [
   { code: 'VND', flag: '\u{1F1FB}\u{1F1F3}', symbol: '₫' },
   { code: 'SGD', flag: '\u{1F1F8}\u{1F1EC}', symbol: 'S$' },
   { code: 'TRY', flag: '\u{1F1F9}\u{1F1F7}', symbol: '₺' },
+  { code: 'PKR', flag: '\u{1F1F5}\u{1F1F0}', symbol: '₨' },
 ] as const
 
 interface CurrencySelectProps {

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -65,6 +65,7 @@ const CURRENCY_LOCALE: Record<string, string> = {
   SGD: 'en-SG',
   AZN: 'az-AZ',
   TRY: 'tr-TR',
+  PKR: 'en-PK',
 }
 
 /**


### PR DESCRIPTION
## What

Add `PKR` (Pakistani Rupee, `₨`, 🇵🇰) to the default `supported_currencies`, the `/api/currencies` metadata, the frontend `CurrencySelect` list, and the auto number-format locale map (`en-PK`). Same five files and shape as the TRY addition in #788.

## Why

PKR was missing from the currency picker, so users in Pakistan could not track accounts or transactions in their local currency. Open Exchange Rates already returns PKR, so FX conversion works once the code is in `supported_currencies`.

## How to Test

1. `cd backend && uv sync --all-extras && uv run pytest tests/test_currencies_api.py` — includes a new `test_currencies_include_pkr_with_metadata`.
2. `cd backend && uv run ruff check . && uv run ty check .`
3. `GET /api/currencies` returns `{"code": "PKR", "symbol": "₨", "name": "Pakistani Rupee", "flag": "🇵🇰"}`.
4. `cd frontend && npm run lint && npx vitest run src/components/currency-select.test.tsx src/lib/format.test.ts && npm run build`
5. Open setup or account creation and confirm PKR is in the currency dropdown; with number format on "auto", PKR amounts render as `Rs 1,234.56`.

## Related Issue

Fixes #866

## Checklist

- [x] Backend tests pass (`pytest`) — 163 passed in `test_currencies_api.py` + `test_fiscal_packs_intl.py`; ruff and ty clean
- [x] Frontend lints clean (`npm run lint`) — 0 errors, no warnings in touched files
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed) — n/a, no new translated UI strings
- [x] For a large or core change, I discussed it first — n/a, small self-contained addition on a triaged issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds Pakistani Rupee (PKR) support to currency lists, API metadata, and amount formatting.

- Select PKR when adding accounts or transactions.
- Search for PKR or Pakistani Rupee in the currency selector.
- View PKR amounts with Pakistan locale formatting.

Risk: None of database migration, auth, money math, or sync provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->