### PR TITLE
fix(helm): resolve nginx dns failure

### DIFF
--- a/charts/securo/templates/common/httproute.yaml
+++ b/charts/securo/templates/common/httproute.yaml
@@ -14,6 +14,13 @@ spec:
     - matches:
         - path:
             type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: {{ include "securo.fullname" . }}-backend
+          port: {{ .Values.backend.service.port }}
+    - matches:
+        - path:
+            type: PathPrefix
             value: /
       backendRefs:
         - name: {{ include "securo.fullname" . }}-frontend

--- a/charts/securo/templates/common/ingress.yaml
+++ b/charts/securo/templates/common/ingress.yaml
@@ -27,6 +27,13 @@ spec:
     - host: {{ .Values.global.domain | quote }}
       http:
         paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "securo.fullname" $ }}-backend
+                port:
+                  name: http
           - path: /
             pathType: Prefix
             backend:

--- a/charts/securo/templates/frontend/deployment.yaml
+++ b/charts/securo/templates/frontend/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             periodSeconds: 10
           env:
             - name: BACKEND_URL
-              value: "http://{{ include "securo.fullname" . }}-backend:8000"
+              value: {{ default (printf "http://%s-backend.%s.svc.cluster.local:%v" (include "securo.fullname" .) .Release.Namespace .Values.backend.service.port) .Values.frontend.backendUrl | quote }}
             - name: FRONTEND_URL
               value: {{ include "securo.frontendUrl" . | quote }}
           volumeMounts:

--- a/charts/securo/values.yaml
+++ b/charts/securo/values.yaml
@@ -111,6 +111,7 @@ backend:
 
 # Frontend configuration
 frontend:
+  backendUrl: ""
   replicaCount: 1
   image:
     repository: ghcr.io/securo-finance/securo-frontend


### PR DESCRIPTION
## What
Fixed `502 Bad Gateway` regression on Kubernetes caused by Nginx DNS resolution failure (introduced by PR #696).
Key changes include:
*   **Fully Qualified Domain Name (FQDN):** Changed the `BACKEND_URL` in the frontend deployment from a short Kubernetes service name (`securo-backend`) to an FQDN (`securo-backend.<namespace>.svc.cluster.local`) and added a `frontend.backendUrl` override in `values.yaml`.
*   **Direct API Routing:** Configured direct `/api` path routing in both `ingress.yaml` and `httproute.yaml` to forward API traffic directly to the `securo-backend` service.

## Why
Following the dynamic backend resolution changes in v0.15.1, Nginx's internal DNS resolver failed to resolve the backend's short name because it ignores the `search` domains in `/etc/resolv.conf`. This caused `502 Bad Gateway` errors for all API endpoints resulting in breaking every Kubernetes deployment using version v0.15.1. Using an FQDN circumvents this by providing the exact domain to query. Additionally, routing `/api` traffic directly to the backend at the Ingress/Gateway layer reduces frontend proxy overhead and unnecessary network hops, leaving the Nginx proxy as a fallback for NodePort or port-forward environments.

## How to Test
You can test the Helm chart locally using a lightweight [Kind](https://kind.sigs.k8s.io/) cluster.

Set up a local Kind Cluster
Create a `kind-config.yaml` file to map local ports 80 and 443 into the cluster:
```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
  extraPortMappings:
  - containerPort: 80
    hostPort: 80
    protocol: TCP
  - containerPort: 443
    hostPort: 443
    protocol: TCP
```
Create the cluster:
```bash
kind create cluster --name securo-test --config kind-config.yaml --image kindest/node:v1.31.0
```

> [!NOTE]
> You may notice the `securo-beat` pod remaining in a `Pending` state with a `persistentvolumeclaim ... not found` event. This is a known, unrelated Helm chart bug tracked in [#855](https://github.com/securo-finance/securo/issues/855) and can be safely ignored while testing the routing fixes in this PR.

### Test Variant A: Port-forwarding (Fallback Nginx Routing)
Install the Helm chart without Ingress or HTTPRoute:
```bash
helm install securo charts/securo \
  --namespace securo --create-namespace
```
Wait for the pods to be ready, then port-forward the frontend service:
```bash
kubectl port-forward -n securo svc/securo-frontend 3000:3000
```
Verify the API resolves successfully (should not return 502 Bad Gateway):
```bash
curl -i http://localhost:3000/api/setup/status
```
You can also open [http://localhost:3000](http://localhost:3000) in your browser to verify the application loads correctly.


### Test Variant B: NGINX Ingress Controller
Deploy the official ingress controller for Kind:
```bash
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
kubectl wait --namespace ingress-nginx \
  --for=condition=ready pod \
  --selector=app.kubernetes.io/component=controller \
  --timeout=300s
```
Install the Helm chart with Ingress enabled:
```bash
helm upgrade --install securo charts/securo \
  --namespace securo --create-namespace \
  --set global.domain=securo.local \
  --set ingress.enabled=true \
  --set ingress.className=nginx
```
Add `127.0.0.1 securo.local` to your local `/etc/hosts` file, then verify the API routes directly to the backend:
```bash
curl -H "Host: securo.local" -i http://localhost/api/setup/status
```
You can also open [http://securo.local](http://securo.local) in your browser to verify the application loads correctly.


### Test Variant C: Gateway API (HTTPRoute)
Deploy Gateway API CRDs and the Envoy Gateway Controller to your cluster:
```bash
kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
kubectl apply --server-side -f https://github.com/envoyproxy/gateway/releases/download/v1.2.0/install.yaml
kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
```
Create a `gateway.yaml` file to define a `Gateway` resource for your cluster (which Envoy Gateway will fulfill):
```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: GatewayClass
metadata:
  name: eg
spec:
  controllerName: gateway.envoyproxy.io/gatewayclass-controller
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: eg
  namespace: securo
spec:
  gatewayClassName: eg
  listeners:
    - name: http
      protocol: HTTP
      port: 80
```
Apply the file to your cluster:
```bash
kubectl apply -f gateway.yaml
```
Install the Helm chart with HTTPRoute enabled, attaching it to the Gateway we just created:
```bash
helm upgrade --install securo charts/securo \
  --namespace securo --create-namespace \
  --set global.domain=securo.local \
  --set httpRoute.enabled=true \
  --set 'httpRoute.parentRefs[0].name=eg' \
  --set 'httpRoute.parentRefs[0].namespace=securo'
```
Verify the API routes properly. Since `kind` does not natively assign `LoadBalancer` IPs, we'll port-forward the Envoy proxy service that was dynamically created for our Gateway:
```bash
export ENVOY_SVC=$(kubectl get svc -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-name=eg,gateway.envoyproxy.io/owning-gateway-namespace=securo -o jsonpath='{.items[0].metadata.name}')
kubectl port-forward -n envoy-gateway-system svc/$ENVOY_SVC 8888:80
```
In a separate terminal window, verify the route works:
```bash
curl -H "Host: securo.local" -i http://localhost:8888/api/setup/status
```
You can also map `127.0.0.1 securo.local` in your local `/etc/hosts` file and open [http://securo.local:8888](http://securo.local:8888) in your browser to verify the application loads correctly.

### Delete kind cluster
```bash
kind delete cluster --name securo-test
```

## Related Issue
Closes [#857](https://github.com/securo-finance/securo/issues/857).

## Checklist

- [x] Backend tests pass (`pytest`)
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (if user-facing strings changed)
- [x] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The Helm chart now uses a configurable, namespace-qualified backend URL. It also routes `/api` requests directly to the backend service when Ingress or HTTPRoute is used, while keeping Nginx proxying for other deployments.

- Kubernetes API requests no longer fail with `502 Bad Gateway` because of short-name DNS resolution.
- Operators can set `frontend.backendUrl`.
- Ingress and HTTPRoute send `/api` traffic to the backend service.

Risk: none of database migration, auth, money math, or sync provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->