### PR TITLE
fix(payees): serialize legacy payee types as null

### DIFF
--- a/backend/app/schemas/payee.py
+++ b/backend/app/schemas/payee.py
@@ -3,7 +3,7 @@ from datetime import date as _Date, datetime
 from decimal import Decimal
 from typing import Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.fiscal.registry import TaxIdKind
 from app.schemas.category import CategoryRead
@@ -71,6 +71,14 @@ class PayeeRead(BaseModel):
     user_id: uuid.UUID
     name: str
     type: Optional[PayeeType] = None
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def coerce_legacy_type(cls, value: Optional[str]) -> Optional[str]:
+        if value is not None and value not in ("person", "company"):
+            return None
+        return value
+
     # Read-only. Exposed so a client picker can tell the handful of
     # counterparties somebody entered on purpose from the hundreds sync
     # created from card descriptors.

--- a/backend/tests/test_payees_api.py
+++ b/backend/tests/test_payees_api.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
+from app.models.payee import Payee
 from app.models.transaction import Transaction
 from app.models.user import User
 
@@ -76,6 +77,37 @@ async def test_list_payees(client: AsyncClient, auth_headers):
     assert len(data) == 2
     names = {p["name"] for p in data}
     assert names == {"Alpha", "Beta"}
+
+
+@pytest.mark.asyncio
+async def test_list_payees_coerces_legacy_types_to_null(
+    client: AsyncClient,
+    auth_headers,
+    session: AsyncSession,
+    test_user: User,
+    test_workspace,
+):
+    legacy_types = ("transfer", "employer", "merchant")
+    session.add_all(
+        [
+            Payee(
+                id=uuid.uuid4(),
+                user_id=test_user.id,
+                workspace_id=test_workspace.id,
+                name=f"Legacy {legacy_type}",
+                type=legacy_type,
+            )
+            for legacy_type in legacy_types
+        ]
+    )
+    await session.commit()
+
+    resp = await client.get("/api/payees", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert {payee["name"]: payee["type"] for payee in resp.json()} == {
+        f"Legacy {legacy_type}": None for legacy_type in legacy_types
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #830.

Payees created by older data imports can retain `transfer`, `employer`, or `merchant` as their type. The payees list endpoint serialized those rows through a response schema that accepted only `person` and `company`, so the endpoint returned 500.

The read-side response validator now maps unknown persisted type values to `null`. Create and update validation remain strict, so new writes still accept only `person` and `company`.

### How this was tested

- Payee API tests: 20 passed.
- Focused payee type and source tests: 13 passed.
- `ruff check` and `ty check` reported no findings.
- The exact reproducer passed with `transfer`, `employer`, and `merchant` serializing as `null`.

The broad backend suite remains environment-limited by existing setup and temporary-database failures. The target repository's CI should provide the full-project check.

### Alternative considered

Accepting every persisted string in the response schema would avoid the 500 but weaken the API contract. Mapping only unknown read values to `null` preserves known values and keeps write validation strict.

### AI disclosure

This change was drafted and reviewed with AI assistance through Codex (`gpt-5.6-luna`) under Mailman. The verification results above were recorded by Mailman's test harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

`GET /api/payees` now returns legacy payees without a 500 error. Unknown types map to `null`, while new payee types remain limited to `person` and `company`.

- Legacy `transfer`, `employer`, and `merchant` types appear as `null`.
- `person` and `company` remain valid payee types.
- New payees cannot use unknown types.

Risk: none of these.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->