### PR TITLE
Feat/manual recurring link

### DIFF
--- a/backend/app/services/recurring_transaction_service.py
+++ b/backend/app/services/recurring_transaction_service.py
@@ -243,7 +243,6 @@ async def generate_pending(
         .where(
             RecurringTransaction.user_id == user_id,
             RecurringTransaction.is_active == True,
-            RecurringTransaction.auto_generate == True,
             or_(
                 and_(
                     RecurringTransaction.weekend_adjustment == "previous_friday",
@@ -288,6 +287,12 @@ async def generate_pending(
             )
             if existing_real is not None:
                 existing_real.recurring_transaction_id = recurring.id
+            elif not recurring.auto_generate:
+                # Generation is off for this bill and nothing covers this
+                # occurrence yet. Stop without materialising a placeholder and
+                # without advancing the pointer, so the occurrence stays due
+                # and is reconciled on a later run once the real charge lands.
+                break
             else:
                 account = await session.get(Account, recurring.account_id)
                 # Only occurrences that already came due reach this point, so

--- a/backend/tests/test_recurring_match.py
+++ b/backend/tests/test_recurring_match.py
@@ -475,3 +475,25 @@ async def test_unlink_recurring_noop_when_not_linked(session, test_user, test_wo
         session, tx.id, test_workspace.id
     )
     assert result is None  # nothing to unlink → 404 at the API layer
+
+@pytest.mark.asyncio
+async def test_generate_pending_links_real_tx_when_auto_generate_off(
+    session, test_user, test_workspace, account
+):
+    """A bill with generation off is still reconciled against a real charge.
+
+    Turning off automatic generation should suppress placeholders, not the
+    matching itself — otherwise the users who opted out precisely to avoid
+    duplicates are the only ones who never get a link.
+    """
+    bill = await _make_bill(
+        session, test_workspace, test_user, account, auto_generate=False
+    )
+    real = await _add_tx(
+        session, test_user, test_workspace, account,
+        date=date(2025, 1, 12), source="manual", external_id=None,
+    )
+    count = await generate_pending(session, test_user.id, up_to=date(2025, 1, 20))
+    assert count == 0  # no placeholder written
+    await session.refresh(real)
+    assert real.recurring_transaction_id == bill.id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-name: securo
+name: securo-dev
 
 # podman-compose groups all services into a single pod by default, which
 # interferes with per-service port mapping and networking. Disabling it makes


### PR DESCRIPTION
## What

Brief description of the changes.

## Why

Why are these changes needed?

## How to Test

Steps to verify the changes work:

1. ...
2. ...

## Related Issue

Closes #___ (or link the issue this addresses).

## Checklist

- [ ] Backend tests pass (`pytest`)
- [ ] Frontend lints clean (`npm run lint`)
- [ ] Frontend builds (`npm run build`)
- [ ] Translations updated (if user-facing strings changed)
- [ ] For a large or core change, I discussed it first (issue or Discord) so we could align before the code (see [CONTRIBUTING](../CONTRIBUTING.md#before-large-or-core-changes))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Recurring bills with automatic generation disabled can now link to matching real charges without creating placeholders. Docker Compose now uses the `securo-dev` project name.

- Manual charges can be linked to recurring bills.
- Disabled automatic generation no longer creates placeholder charges.

Risk: None of database migration, auth, money math, or sync provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->