### PR TITLE
feat(currency): add Moldovan Leu (MDL) support

### DIFF
--- a/backend/app/api/currencies.py
+++ b/backend/app/api/currencies.py
@@ -41,6 +41,7 @@ CURRENCY_META = {
     "SGD": {"symbol": "S$", "name": "Singapore Dollar", "flag": "\U0001F1F8\U0001F1EC"},
     "TRY": {"symbol": "₺", "name": "Turkish Lira", "flag": "\U0001F1F9\U0001F1F7"},
     "PKR": {"symbol": "₨", "name": "Pakistani Rupee", "flag": "\U0001F1F5\U0001F1F0"},
+    "MDL": {"symbol": "L", "name": "Moldovan Leu", "flag": "\U0001F1F2\U0001F1E9"},
 }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -66,7 +66,7 @@ class Settings(BaseSettings):
 
     # FX Rates
     openexchangerates_app_id: str = ""
-    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ,PHP,UAH,NZD,VND,SGD,AZN,TRY,PKR"  # comma-separated list
+    supported_currencies: str = "USD,EUR,GBP,BRL,CAD,AUD,CHF,ARS,JPY,MXN,INR,SEK,DKK,NOK,PLN,CZK,HUF,RON,CRC,IDR,COP,CLP,DOP,RUB,GTQ,PHP,UAH,NZD,VND,SGD,AZN,TRY,PKR,MDL"  # comma-separated list
     fx_sync_mode: str = "on_demand"  # "on_demand" or "scheduled"
 
     # Storage

--- a/backend/tests/test_currencies_api.py
+++ b/backend/tests/test_currencies_api.py
@@ -131,3 +131,15 @@ async def test_currencies_include_pkr_with_metadata(client: AsyncClient):
     assert pkr["symbol"] == "₨"
     assert pkr["name"] == "Pakistani Rupee"
     assert pkr["flag"] == "🇵🇰"
+
+
+@pytest.mark.asyncio
+async def test_currencies_include_mdl_with_metadata(client: AsyncClient):
+    response = await client.get("/api/currencies")
+    data = response.json()
+    mdl = next((currency for currency in data if currency["code"] == "MDL"), None)
+
+    assert mdl is not None
+    assert mdl["symbol"] == "L"
+    assert mdl["name"] == "Moldovan Leu"
+    assert mdl["flag"] == "🇲🇩"

--- a/frontend/src/components/currency-select.tsx
+++ b/frontend/src/components/currency-select.tsx
@@ -43,6 +43,7 @@ export const CURRENCIES = [
   { code: 'SGD', flag: '\u{1F1F8}\u{1F1EC}', symbol: 'S$' },
   { code: 'TRY', flag: '\u{1F1F9}\u{1F1F7}', symbol: '₺' },
   { code: 'PKR', flag: '\u{1F1F5}\u{1F1F0}', symbol: '₨' },
+  { code: 'MDL', flag: '\u{1F1F2}\u{1F1E9}', symbol: 'L' },
 ] as const
 
 interface CurrencySelectProps {

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -66,6 +66,7 @@ const CURRENCY_LOCALE: Record<string, string> = {
   AZN: 'az-AZ',
   TRY: 'tr-TR',
   PKR: 'en-PK',
+  MDL: 'ro-MD',
 }
 
 /**


### PR DESCRIPTION
## What

Add Moldovan Leu (MDL) to the default supported currencies, API metadata, and shared currency selector, with symbol L and flag 🇲🇩.

Map MDL to ro-MD, and add an API metadata test. Follows the currency-addition pattern used for PKR in #867.

## Why

MDL is currently missing from the currency selectors. This allows users to choose Moldovan lei for accounts and as their primary currency.

## How to Test

1. Start the app with `docker compose up -d`.
2. Confirm `/api/currencies` includes MDL, Moldovan Leu, L, and 🇲🇩.
3. Confirm MDL appears in the setup/registration and account currency selectors.

## Related Issue

Closes #878

## Checklist

- [ ] Backend tests pass (pytest) - full backend run on Windows identified an unrelated failure in `test_a_line_taller_than_a_page_still_finishes`, which uses Unix-only `signal.SIGALRM`. The same test causes Windows type-check errors.
- [x] Frontend lints clean (npm run lint)
- [x] Frontend builds (npm run build)
- [x] Translations updated - no translation keys added
- [x] For a large or core change, I discussed it first - Small change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds Moldovan Leu (MDL) support to account and currency selectors, API metadata, and automatic formatting. MDL uses the `L` symbol, two decimal places, Moldova flag, and `ro-MD` locale.

- Select MDL for accounts and primary currency.
- View MDL with the `L` symbol and Moldova flag.
- Format MDL values using Moldovan locale rules.

Risk: none of database migration, auth, money math, or sync provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->