### PR TITLE
fix(2fa): report the real reason a 2FA disable failed

### DIFF
--- a/frontend/src/components/two-factor-setup.test.tsx
+++ b/frontend/src/components/two-factor-setup.test.tsx
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import type { AxiosError } from 'axios'
+
+import { TwoFactorSetup } from '@/components/two-factor-setup'
+import { renderWithProviders, t } from '@/test/utils'
+
+const authContext = vi.hoisted(() => ({
+  user: { is_2fa_enabled: true },
+  updateUser: vi.fn(),
+}))
+vi.mock('@/contexts/auth-context', () => ({ useAuth: () => authContext }))
+
+const api = vi.hoisted(() => ({ auth: { disable2fa: vi.fn() } }))
+vi.mock('@/lib/api', () => ({ auth: api.auth }))
+
+function detailError(detail: string): AxiosError<{ detail: string }> {
+  return {
+    isAxiosError: true,
+    response: { status: 400, data: { detail } },
+  } as AxiosError<{ detail: string }>
+}
+
+async function submitDisable() {
+  const { user } = renderWithProviders(<TwoFactorSetup open onClose={vi.fn()} />)
+  await user.type(screen.getByLabelText(t('auth.password')), 'wrong-password')
+  await user.type(screen.getByLabelText(t('auth.twoFactor')), '123456')
+  await user.click(screen.getByRole('button', { name: t('auth.disable2fa') }))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('TwoFactorSetup disable flow', () => {
+  it('blames the password when the backend rejected the password', async () => {
+    api.auth.disable2fa.mockRejectedValue(detailError('Invalid password'))
+
+    await submitDisable()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(t('auth.currentPasswordWrong'))
+    expect(screen.queryByText(t('auth.invalid2faCode'))).not.toBeInTheDocument()
+  })
+
+  it('blames the connection when the server never answered', async () => {
+    api.auth.disable2fa.mockRejectedValue({ isAxiosError: true } as AxiosError)
+
+    await submitDisable()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(t('auth.serverError'))
+  })
+})

--- a/frontend/src/components/two-factor-setup.tsx
+++ b/frontend/src/components/two-factor-setup.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
+import type { AxiosError } from 'axios'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { QRCodeSVG } from 'qrcode.react'
 import { useAuth } from '@/contexts/auth-context'
 import { auth } from '@/lib/api'
+import { isServerUnreachable } from '@/lib/auth-errors'
 import {
   Dialog,
   DialogContent,
@@ -78,8 +80,12 @@ export function TwoFactorSetup({ open, onClose }: TwoFactorSetupProps) {
       toast.success(t('auth.twoFactorDisabled'))
       if (user) updateUser({ ...user, is_2fa_enabled: false })
       handleClose()
-    } catch {
-      setError(t('auth.invalid2faCode'))
+    } catch (err) {
+      const detail = (err as AxiosError<{ detail?: string }>).response?.data?.detail
+      if (isServerUnreachable(err)) setError(t('auth.serverError'))
+      else if (detail === 'Invalid password') setError(t('auth.currentPasswordWrong'))
+      else if (detail === 'Invalid 2FA code') setError(t('auth.invalid2faCode'))
+      else setError(t('common.error'))
     } finally {
       setDisableLoading(false)
     }
@@ -111,6 +117,7 @@ export function TwoFactorSetup({ open, onClose }: TwoFactorSetupProps) {
               <Input
                 id="disable-password"
                 type="password"
+                autoComplete="current-password"
                 value={disablePassword}
                 onChange={(e) => setDisablePassword(e.target.value)}
                 required
@@ -122,6 +129,7 @@ export function TwoFactorSetup({ open, onClose }: TwoFactorSetupProps) {
                 id="disable-code"
                 type="text"
                 inputMode="numeric"
+                autoComplete="one-time-code"
                 value={disableCode}
                 onChange={(e) => setDisableCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
                 placeholder="000000"
@@ -130,7 +138,11 @@ export function TwoFactorSetup({ open, onClose }: TwoFactorSetupProps) {
                 required
               />
             </div>
-            {error && <p className="text-sm text-destructive">{error}</p>}
+            {error && (
+              <p role="alert" className="text-sm text-destructive">
+                {error}
+              </p>
+            )}
             <DialogFooter>
               <Button type="button" variant="outline" onClick={handleClose}>
                 {t('common.cancel')}


### PR DESCRIPTION
## What

When disabling 2FA fails, the dialog reported "invalid 2FA code" for every
failure — including a wrong password and an unreachable server.

The backend already distinguishes these: `/2fa/disable` returns
`detail: "Invalid password"` and `detail: "Invalid 2FA code"` as separate
cases. The frontend threw that away with a bare `catch`.

Also adds `autoComplete="current-password"` / `"one-time-code"` to the two
inputs, and `role="alert"` on the error so screen readers announce it.

## Why

A user typing their password wrong is told their authenticator is wrong. They
go regenerate a code that was never the problem, fail again, and have no way to
find out what is actually wrong — there are no recovery codes, so "I can't
disable 2FA" is a bad place to get stuck.

## How to Test

1. Enable 2FA on an account.
2. Open the 2FA dialog and click Disable.
3. Enter the **wrong password** with a **valid** code → "current password is
   incorrect" (previously: "invalid 2FA code").
4. Enter the **right password** with a **wrong** code → "invalid 2FA code".
5. Stop the backend and retry → the connection error, not a credential error.

`npm test -- two-factor-setup` covers steps 3 and 5.

## Related Issue

None — small bug fix, no prior discussion per CONTRIBUTING.

## Checklist

- [x] Tests added
- [x] `npm run lint -- --max-warnings=0`, `npm test`, `npm run build` all pass
- [x] No new locale keys — `auth.currentPasswordWrong`, `auth.serverError`,
      `auth.invalid2faCode` and `common.error` already exist in all 15 locales
- [x] Not a large or core change, so no prior discussion needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The 2FA disable flow now shows the actual failure reason instead of always showing an invalid-code error. It also improves autofill and screen reader support.

- Shows separate errors for an incorrect password, invalid 2FA code, unreachable server, and unknown failures.
- Adds autofill hints for the password and one-time-code fields.
- Announces error messages to screen readers.

Risk: auth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->