### PR TITLE
fix(login): don't spend a passkey challenge after an aborted ceremony

### DIFF
--- a/frontend/src/pages/login.test.tsx
+++ b/frontend/src/pages/login.test.tsx
@@ -21,7 +21,11 @@ vi.mock('@/contexts/auth-context', () => ({ useAuth: () => authContext }))
 
 const api = vi.hoisted(() => ({
   setup: { status: vi.fn() },
-  auth: { oidcConfig: vi.fn() },
+  auth: {
+    oidcConfig: vi.fn(),
+    passkeyAuthenticationOptions: vi.fn(),
+    verifyPasskeyAuthentication: vi.fn(),
+  },
   admin: { registrationStatus: vi.fn(), defaultColors: vi.fn() },
 }))
 vi.mock('@/lib/api', () => ({
@@ -30,11 +34,14 @@ vi.mock('@/lib/api', () => ({
   admin: api.admin,
 }))
 
-vi.mock('@/lib/webauthn', () => ({
-  isPasskeySupported: () => false,
-  passkeyFailure: () => 'unknown',
+const webauthn = vi.hoisted(() => ({
+  isPasskeySupported: vi.fn(),
+  isConditionalPasskeySupported: vi.fn(),
+  passkeyFailure: vi.fn(),
   startPasskeyAuthentication: vi.fn(),
+  startConditionalPasskeyAuthentication: vi.fn(),
 }))
+vi.mock('@/lib/webauthn', () => webauthn)
 
 vi.mock('next-themes', () => ({ useTheme: () => ({ resolvedTheme: 'dark' }) }))
 
@@ -56,6 +63,9 @@ beforeEach(() => {
   })
   api.admin.registrationStatus.mockResolvedValue({ enabled: true })
   api.admin.defaultColors.mockResolvedValue({ light: null, dark: null })
+  webauthn.isPasskeySupported.mockReturnValue(false)
+  webauthn.isConditionalPasskeySupported.mockResolvedValue(false)
+  webauthn.passkeyFailure.mockReturnValue('unknown')
 })
 
 async function renderLogin() {
@@ -187,6 +197,36 @@ describe('LoginPage', () => {
     expect(
       await screen.findByRole('link', { name: t('auth.register') }),
     ).toBeInTheDocument()
+  })
+
+  it('does not spend the challenge when the conditional ceremony is aborted', async () => {
+    // The challenge is one-shot on the server (Redis `getdel`). Verifying one
+    // the user walked away from burns it, and the next attempt gets nothing.
+    webauthn.isPasskeySupported.mockReturnValue(true)
+    webauthn.isConditionalPasskeySupported.mockResolvedValue(true)
+    api.auth.passkeyAuthenticationOptions.mockResolvedValue({
+      options: {},
+      challenge_id: 'challenge-1',
+    })
+    let handBackCredential: (credential: unknown) => void = () => {}
+    webauthn.startConditionalPasskeyAuthentication.mockReturnValue(
+      new Promise((resolve) => {
+        handBackCredential = resolve
+      }),
+    )
+
+    const { unmount } = renderWithProviders(<LoginPage />, { route: '/login' })
+    await waitFor(() =>
+      expect(webauthn.startConditionalPasskeyAuthentication).toHaveBeenCalled(),
+    )
+
+    // Leaving the page aborts the ceremony, but the pending browser promise
+    // can still settle afterwards.
+    unmount()
+    handBackCredential({ id: 'credential' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(api.auth.verifyPasskeyAuthentication).not.toHaveBeenCalled()
   })
 
   it('survives the optional config calls failing', async () => {

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -49,7 +49,7 @@ export default function LoginPage() {
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [isPasskeyLoading, setIsPasskeyLoading] = useState(false)
-  const [passkeySupported, setPasskeySupported] = useState(false)
+  const [passkeySupported] = useState(isPasskeySupported)
   const [registrationEnabled, setRegistrationEnabled] = useState(true)
   const [oidcConfig, setOidcConfig] = useState<OIDCConfig | null>(null)
   const [oidcConfigFailed, setOidcConfigFailed] = useState(false)
@@ -70,7 +70,6 @@ export default function LoginPage() {
   const showAuthDivider = localAuthEnabled && (showPasskeyLogin || oidcEnabled)
 
   useEffect(() => {
-    setPasskeySupported(isPasskeySupported())
     if (token) {
       navigate('/', { replace: true })
       return
@@ -136,6 +135,10 @@ export default function LoginPage() {
           options.options,
           abortController.signal,
         )
+        // A challenge is one-shot server-side: verifying one the user already
+        // walked away from burns it and answers a ceremony nobody is watching.
+        if (abortController.signal.aborted) return
+
         const result = await authApi.verifyPasskeyAuthentication(options.challenge_id, credential)
         if (abortController.signal.aborted) return
 
@@ -416,7 +419,11 @@ export default function LoginPage() {
           {localAuthEnabled && (
             <CardContent className="space-y-4 px-8 pt-4">
               {error && (
-                <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-lg">
+                <div
+                  id="login-error"
+                  role="alert"
+                  className="p-3 text-sm text-destructive bg-destructive/10 rounded-lg"
+                >
                   {error}
                 </div>
               )}
@@ -426,9 +433,13 @@ export default function LoginPage() {
                   id="email"
                   type="email"
                   value={email}
-                  onChange={(e) => setEmail(e.target.value)}
+                  onChange={(e) => {
+                    setEmail(e.target.value)
+                    setError('')
+                  }}
                   placeholder="you@example.com"
                   autoComplete="username webauthn"
+                  aria-describedby={error ? 'login-error' : undefined}
                   required
                 />
               </div>


### PR DESCRIPTION
## What

Three small fixes to the login page, all independent of each other:

1. **Don't spend a passkey challenge after an aborted ceremony.** The
   conditional-UI effect checks `abortController.signal.aborted` before starting
   the ceremony and again after verification returns, but not in between. If the
   user navigates away while the browser prompt is open, the credential promise
   still settles and we still `POST` it to
   `/auth/passkeys/authenticate/verify`.
2. **No passkey-button flash on first paint.** `passkeySupported` started `false`
   and was set in an effect, so the button was missing for one frame on every
   load. Moved to a lazy `useState` initializer.
3. **Accessibility.** The login error is now `role="alert"` with an `id`, the
   email input points at it via `aria-describedby`, and editing the email clears
   a stale error.

## Why

(1) is the substantive one. Challenges are one-shot server-side — stored in
Redis and consumed with `getdel`. Answering a ceremony the user walked away from
burns the challenge and logs a verification attempt nobody made.

## How to Test

1. On a device with a platform authenticator, load `/login` so conditional UI
   arms.
2. Focus the email field to trigger the passkey prompt.
3. Navigate away while the prompt is still open.
4. No request to `/api/auth/passkeys/authenticate/verify` in the network tab
   (previously: one fired after the prompt resolved).

`npm test -- login` covers this: the test holds the ceremony pending, unmounts,
then resolves the credential and asserts verification was never called. It fails
without the guard.

## Related Issue

None — small bug fix, no prior discussion per CONTRIBUTING.

## Checklist

- [x] Tests added
- [x] `npm run lint -- --max-warnings=0`, `npm test`, `npm run build` all pass
- [x] No new locale keys, no user-facing string changes
- [x] Not a large or core change, so no prior discussion needed

One note on the test setup: the existing `@/lib/webauthn` mock was a static
object with `isPasskeySupported: () => false`, so the conditional-UI effect had
never executed in any test. I converted it to hoisted `vi.fn()`s with the old
defaults restored in `beforeEach`, so all 11 pre-existing tests behave exactly
as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The login flow now avoids verifying passkeys after an aborted ceremony and initializes passkey support before the first paint. Login errors are also easier to identify and clear when the email changes.

- The passkey button no longer flashes after page load.
- Abandoned passkey sign-ins do not consume the server challenge.
- Login errors are announced and linked to the email field.
- Editing the email clears the current login error.

Risk: auth

<!-- end of auto-generated comment: release notes by coderabbit.ai -->