### PR TITLE
test(agents): replace a sleep-based JWT expiry test with a fake clock

### DIFF
--- a/backend/tests/test_agents_jwt.py
+++ b/backend/tests/test_agents_jwt.py
@@ -9,6 +9,7 @@ Both sides share AGENTS_MCP_JWT_SECRET. We test that:
 
 import time
 import uuid
+from datetime import datetime
 
 import pytest
 from jose import jwt
@@ -94,16 +95,30 @@ def test_expired_token_rejected():
     assert exc.value.status_code == 401
 
 
-def test_short_ttl_respected():
-    """Mint with ttl_seconds=1, sleep 2, verify rejection."""
+def test_short_ttl_respected(monkeypatch):
+    """A one-second token verifies before expiry and is rejected afterward."""
     from fastapi import HTTPException
     from mcp_server.auth import verify_request
 
-    token = mint_token(user_id=uuid.uuid4(), ttl_seconds=1)
-    time.sleep(2.1)
+    user_id = uuid.uuid4()
+    token = mint_token(user_id=user_id, ttl_seconds=1)
+    claims = jwt.get_unverified_claims(token)
+    assert claims["exp"] - claims["iat"] == 1
+    now = claims["iat"]
 
-    with pytest.raises(HTTPException):
+    class Clock(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime.fromtimestamp(now, tz)
+
+    monkeypatch.setattr(jwt, "datetime", Clock)
+    assert verify_request(_req_bearer(token)).user_id == user_id
+
+    now += 2
+    with pytest.raises(HTTPException) as exc:
         _ = verify_request(_req_bearer(token))
+    assert exc.value.status_code == 401
+    assert "expired" in exc.value.detail
 
 
 def test_optional_conv_id_is_truly_optional():


### PR DESCRIPTION
## What

`test_short_ttl_respected` minted a 1-second token, called `time.sleep(2.1)`,
then asserted rejection. Replaced the sleep with a monkeypatched clock on
`jose.jwt`.

The new version also asserts the half the old one never covered: that the token
**verifies** before expiry. Previously a token that was rejected for any reason
at all — wrong secret, malformed, bad audience — would have passed this test.

## Why

2.1 seconds of wall clock in every CI run, and a sleep-based expiry assertion is
inherently timing-flaky under load.

`tests/test_agents_jwt.py`: **2.20s → 0.07s**. The test drops off the
`--durations` board entirely.

## How to Test

```
cd backend
uv run pytest tests/test_agents_jwt.py -ra -W error
```

8 passed, no warnings.

The monkeypatch seam is `jose.jwt`'s module-global `datetime` — `_validate_exp`
computes `now = timegm(datetime.now(UTC).utctimetuple())` off it.

## Related Issue

None — test-only change.

## Checklist

- [x] `uv run ruff check .` passes
- [x] `uv run ty check .` passes
- [x] `uv run pytest tests/test_agents_jwt.py -ra -W error` passes
- [x] `import time` retained — still used by `test_wrong_secret_rejected` and
      `test_expired_token_rejected`
- [x] No production code touched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Replaced the sleep-based JWT expiry test with a fake clock. The test now checks acceptance before expiry and rejection after expiry without waiting.

- JWT expiry checks run without real-time delays.
- Expired tokens must return the expected error details.

Risk: none of database migration, auth, money math, or sync provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->