### PR TITLE
fix(dashboard): improve account balance summary

### DIFF
--- a/frontend/src/components/app-layout.tsx
+++ b/frontend/src/components/app-layout.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useMemo } from 'react'
-import { getAccountName } from '@/lib/account-utils'
+import { getAccountName, sortAccountsByAbsoluteBalance } from '@/lib/account-utils'
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useDisplayLocale } from '@/hooks/use-display-locale'
@@ -440,7 +440,7 @@ export function AppLayout() {
               </button>
               {accountsExpanded && (
                 <div className="mt-1 space-y-0.5">
-                  {[...visibleAccounts].sort((a, b) => Math.abs(Number(b.current_balance)) - Math.abs(Number(a.current_balance))).slice(0, accountsShowAll ? visibleAccounts.length : 3).map((acc) => {
+                  {sortAccountsByAbsoluteBalance(visibleAccounts).slice(0, accountsShowAll ? visibleAccounts.length : 3).map((acc) => {
                     const balance = Number(acc.current_balance) || 0
                     const typeKey = acc.type.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase()).replace(/^./, c => c.toUpperCase())
 

--- a/frontend/src/lib/account-utils.test.ts
+++ b/frontend/src/lib/account-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sortAccountsByDisplayName } from './account-utils'
+import { sortAccountsByAbsoluteBalance, sortAccountsByDisplayName } from './account-utils'
 
 describe('sortAccountsByDisplayName', () => {
   it('orders accounts by display name when present and falls back to name', () => {
@@ -22,5 +22,34 @@ describe('sortAccountsByDisplayName', () => {
     sortAccountsByDisplayName(accounts)
 
     expect(accounts.map((account) => account.name)).toEqual(['Zulu', 'Alpha'])
+  })
+})
+
+describe('sortAccountsByAbsoluteBalance', () => {
+  it('orders positive and negative balances by magnitude', () => {
+    const accounts = [
+      { id: 'small-positive', current_balance: '8.22' },
+      { id: 'largest-positive', current_balance: '6936.72' },
+      { id: 'large-negative', current_balance: '-1200.50' },
+      { id: 'zero', current_balance: '0' },
+    ]
+
+    expect(sortAccountsByAbsoluteBalance(accounts).map((account) => account.id)).toEqual([
+      'largest-positive',
+      'large-negative',
+      'small-positive',
+      'zero',
+    ])
+  })
+
+  it('does not mutate the API account list', () => {
+    const accounts = [
+      { id: 'small', current_balance: 10 },
+      { id: 'large', current_balance: 20 },
+    ]
+
+    sortAccountsByAbsoluteBalance(accounts)
+
+    expect(accounts.map((account) => account.id)).toEqual(['small', 'large'])
   })
 })

--- a/frontend/src/lib/account-utils.ts
+++ b/frontend/src/lib/account-utils.ts
@@ -18,6 +18,21 @@ export function sortAccountsByDisplayName<
 }
 
 /**
+ * Return a presentation-only copy with the largest account balances first.
+ * Debt accounts participate by magnitude, matching the balance list in the
+ * sidebar, while invalid/missing balances sort as zero.
+ */
+export function sortAccountsByAbsoluteBalance<
+  T extends { current_balance?: number | string | null },
+>(accounts: readonly T[]): T[] {
+  return [...accounts].sort((left, right) => {
+    const leftBalance = Number(left.current_balance) || 0
+    const rightBalance = Number(right.current_balance) || 0
+    return Math.abs(rightBalance) - Math.abs(leftBalance)
+  })
+}
+
+/**
  * The bank's identifier for an account, masked to its last 4 chars, e.g. "•••• 1234".
  *
  * Banks commonly report every account under the same label (often the holder's

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
-import { getAccountLabel, getAccountName } from '@/lib/account-utils'
+import { getAccountLabel, getAccountName, sortAccountsByAbsoluteBalance } from '@/lib/account-utils'
 import { currentMonth, shiftMonth, monthLastDay, monthLabel, monthRange } from '@/lib/month-utils'
 import { useTranslation } from 'react-i18next'
 import { useDisplayLocale, useDateLocale } from '@/hooks/use-display-locale'
@@ -405,6 +405,10 @@ export default function DashboardPage() {
   const availableBalance = availableBalanceAccounts.reduce(
     (sum, a) => sum + Number(a.balance_primary ?? a.current_balance), 0,
   )
+  const sortedAvailableBalanceAccounts = useMemo(
+    () => sortAccountsByAbsoluteBalance(availableBalanceAccounts),
+    [availableBalanceAccounts],
+  )
   // While accounts are loading or failed to load, treat their balance
   // components as unavailable rather than silently rendering zero.
   const accountsUnavailable = accountsLoading || accountsError
@@ -670,9 +674,9 @@ export default function DashboardPage() {
               <p className={`text-3xl font-bold tabular-nums leading-tight ${availableBalance < 0 ? 'text-rose-500' : 'text-foreground'}`}>
                 {mask(formatCurrency(availableBalance, primaryCurrency, locale))}
               </p>
-              {availableBalanceAccounts.length > 0 && (
+              {sortedAvailableBalanceAccounts.length > 0 && (
                 <div className="flex flex-wrap gap-1.5 mt-3">
-                  {availableBalanceAccounts.map((acc) => {
+                  {sortedAvailableBalanceAccounts.map((acc) => {
                     const bal = Number(acc.balance_primary ?? acc.current_balance)
                     const balCurrency = acc.balance_primary != null ? primaryCurrency : acc.currency
                     // A link, not a click handler: the chip is a navigation
@@ -832,7 +836,7 @@ export default function DashboardPage() {
             {summaryLoading || accountsUnavailable ? (
               <Skeleton className="h-6 w-24" />
             ) : (
-              <p className={`text-xl font-bold tabular-nums ${totalBalance < 0 ? 'text-rose-500' : 'text-foreground'}`}>
+              <p className={`text-lg sm:text-xl font-bold tabular-nums ${totalBalance < 0 ? 'text-rose-500' : 'text-foreground'}`}>
                 {mask(formatCurrency(totalBalance, primaryCurrency, locale))}
               </p>
             )}


### PR DESCRIPTION
## What

- Order the dashboard's available-balance account chips by absolute balance, matching the sidebar while continuing to show every eligible checking/savings account.
- Share the non-mutating balance-order helper between the dashboard and sidebar.
- Reduce the net-worth value font size on narrow screens so it does not overlap the savings-rate column.
- Add focused coverage for positive/negative balance ordering and input immutability.

## Why

The dashboard chips previously followed API order instead of surfacing the largest balances first. On narrow screens, large net-worth values could also overlap the adjacent savings-rate value.

## How to Test

1. Run `npm run lint` from `frontend`.
2. Run `npm run build` from `frontend`.
3. Run `npx vitest run src/lib/account-utils.test.ts` from `frontend`.
4. Open the dashboard with several checking/savings accounts and verify every chip remains visible, ordered by absolute balance.
5. At a narrow viewport, verify the net-worth value does not overlap the savings-rate column.

## Related Issue

N/A

## Checklist

- [ ] Backend tests pass (`pytest`) — backend unchanged
- [x] Frontend lints clean (`npm run lint`)
- [x] Frontend builds (`npm run build`)
- [x] Translations updated (not needed; no user-facing strings changed)
- [x] For a large or core change, I discussed it first (not applicable; narrow dashboard presentation fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The dashboard now orders account balances by absolute value and shares this ordering with the sidebar. The net worth value uses a smaller font on narrow screens to prevent overlap.

- Shows checking and savings accounts in balance order.
- Keeps accounts with negative balances in the correct position.
- Prevents narrow-screen overlap with the savings-rate column.

Risk: None of database migration, auth, money math, or sync provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->